### PR TITLE
Fix local send file sync issues

### DIFF
--- a/lib/pages/annual_report_page.dart
+++ b/lib/pages/annual_report_page.dart
@@ -520,7 +520,7 @@ class _AnnualReportPageState extends State<AnnualReportPage>
               const SizedBox(height: 20),
               Expanded(
                 child: ListView.builder(
-                  itemCount: _stats!.topTags.length.clamp(0, 5),
+                  itemCount: _stats!.topTags.length > 5 ? 5 : _stats!.topTags.length, 
                   itemBuilder: (context, index) {
                     final tag = _stats!.topTags[index];
                     final percentage = (tag.count / _stats!.totalNotes * 100);

--- a/lib/services/localsend/receive_controller.dart
+++ b/lib/services/localsend/receive_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'constants.dart';
+import 'models/file_dto.dart';
 import 'models/info_register_dto.dart';
 import 'models/prepare_upload_request_dto.dart';
 import 'models/prepare_upload_response_dto.dart';
@@ -262,7 +263,7 @@ class ReceiveController {
 class ReceiveSession {
   final String sessionId;
   final InfoRegisterDto senderInfo;
-  final Map<String, dynamic> files;
+  final Map<String, FileDto> files;
   final SessionStatus status;
   final Map<String, String>? fileTokens;
   
@@ -277,7 +278,7 @@ class ReceiveSession {
   ReceiveSession copyWith({
     String? sessionId,
     InfoRegisterDto? senderInfo,
-    Map<String, dynamic>? files,
+    Map<String, FileDto>? files,
     SessionStatus? status,
     Map<String, String>? fileTokens,
   }) {


### PR DESCRIPTION
Improve LocalSend integration to fix file sending failures and enhance sync reliability.

The previous LocalSend integration led to persistent file sending failures. This PR addresses these by:
- **Enhancing protocol compatibility**: Adding a pre-send `/info` handshake and implementing v1/v2 API fallbacks for `prepare-upload` and `upload` endpoints.
- **Improving server robustness**: `LocalSendServer` now attempts alternative ports on startup failure, enables `autoCompress`, and adds `Content-Length` and `Connection: keep-alive` headers for better HTTP compliance.
- **Boosting client reliability**: Introducing stable device fingerprints and implementing client-side upload retries with exponential backoff.
- **Refining data handling**: Strengthening `ReceiveController`'s multipart parsing and type safety.
- **Cleaning code**: Resolving `flutter analyze` warnings related to `clamp` and `substring` usage across the codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1e15388-5e3e-40d2-b182-40795d41e90c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1e15388-5e3e-40d2-b182-40795d41e90c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

