### PR TITLE
🎨 Palette: [Add Tooltip to Close Button in Motion Photo Preview]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2026-04-03 - Added Semantics/Tooltips for IconButtons
 **Learning:** Icon-only buttons often lack accessibility context for screen readers in Flutter. Using `tooltip` in `IconButton` or wrapping `InkWell` containing `Icon` with `Tooltip` provides semantics and mouse hover text automatically.
 **Action:** Always add `tooltip` for `IconButton` or semantic labels for icon-only components.
+## 2025-04-17 - [Add tooltip to motion photo close button]
+**Learning:** In Flutter, icon-only buttons (`IconButton`) require an explicit `tooltip` to provide semantic labels for screen readers. Using `MaterialLocalizations.of(context).closeButtonTooltip` is a localized, zero-maintenance way to add this without modifying `l10n` resource files directly.
+**Action:** When adding close/cancel icon buttons, always check for missing tooltips and use standard `MaterialLocalizations` when applicable.

--- a/lib/widgets/motion_photo_preview_page.dart
+++ b/lib/widgets/motion_photo_preview_page.dart
@@ -246,6 +246,7 @@ class _MotionPhotoPreviewPageState extends State<MotionPhotoPreviewPage> {
             right: 10,
             child: _CircleIconButton(
               icon: Icons.close,
+              tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
               onPressed: () => Navigator.of(context).pop(),
             ),
           ),
@@ -328,10 +329,12 @@ class _CircleIconButton extends StatelessWidget {
   const _CircleIconButton({
     required this.icon,
     required this.onPressed,
+    this.tooltip,
   });
 
   final IconData icon;
   final VoidCallback onPressed;
+  final String? tooltip;
 
   @override
   Widget build(BuildContext context) {
@@ -341,6 +344,7 @@ class _CircleIconButton extends StatelessWidget {
       child: IconButton(
         onPressed: onPressed,
         icon: Icon(icon, color: Colors.white),
+        tooltip: tooltip,
       ),
     );
   }


### PR DESCRIPTION
💡 What: Added a missing `tooltip` property to `_CircleIconButton` and applied `MaterialLocalizations.of(context).closeButtonTooltip` to it in `motion_photo_preview_page.dart`.
🎯 Why: Icon-only buttons lack context for assistive technologies like screen readers, reducing accessibility.
📸 Before/After: Before, screen readers announced "button". Now, they announce the localized word for "Close".
♿ Accessibility: The close button is now properly labeled with a semantic label across all supported languages natively through `MaterialLocalizations`.

---
*PR created automatically by Jules for task [10123425378042121320](https://jules.google.com/task/10123425378042121320) started by @Shangjin-Xiao*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shangjin-xiao/thoughtecho/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 新增无障碍指导文档，说明在仅图标的关闭和取消按钮中添加工具提示的最佳做法，建议使用本地化的默认文本。

* **新功能**
  * 为关闭按钮实现本地化工具提示支持，提升用户体验和应用无障碍性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->