### PR TITLE
🧪 标尺: 补充 NoteSearchController.setSearchState 的测试

### DIFF
--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -52,6 +52,9 @@ import 'unit/widgets/motion_photo_preview_page_test.dart'
     as motion_photo_preview_page_test;
 
 // Import widget tests
+// Import controller tests
+import 'unit/controllers/search_controller_test.dart' as search_controller_test;
+
 import 'widget/pages/home_page_test.dart' as home_page_test;
 
 void main() {
@@ -92,6 +95,10 @@ void main() {
       anniversary_animation_overlay_test.main();
       anniversary_notebook_icon_test.main();
       motion_photo_preview_page_test.main();
+    });
+
+    group('Controller Tests', () {
+      search_controller_test.main();
     });
 
     group('Widget Tests', () {

--- a/test/unit/controllers/search_controller_test.dart
+++ b/test/unit/controllers/search_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/controllers/search_controller.dart';
-import 'dart:async';
 
 void main() {
   group('NoteSearchController - setSearchState', () {

--- a/test/unit/controllers/search_controller_test.dart
+++ b/test/unit/controllers/search_controller_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/controllers/search_controller.dart';
+import 'dart:async';
+
+void main() {
+  group('NoteSearchController - setSearchState', () {
+    late NoteSearchController controller;
+
+    setUp(() {
+      controller = NoteSearchController();
+    });
+
+    test('should update isSearching flag correctly', () {
+      expect(controller.isSearching, false);
+
+      controller.setSearchState(true);
+      expect(controller.isSearching, true);
+
+      controller.setSearchState(false);
+      expect(controller.isSearching, false);
+    });
+
+    test('should notify listeners when state changes', () {
+      bool notified = false;
+      controller.addListener(() {
+        notified = true;
+      });
+
+      controller.setSearchState(true);
+      expect(notified, true);
+    });
+
+    test('should not notify listeners when state is unchanged', () {
+      controller.setSearchState(true);
+
+      bool notified = false;
+      controller.addListener(() {
+        notified = true;
+      });
+
+      controller.setSearchState(true);
+      expect(notified, false);
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `setSearchState` method inside the `NoteSearchController`.
📊 **Coverage:** The scenarios now tested include: 
1. Verifying that the `isSearching` flag updates correctly.
2. Verifying that listeners are notified when the search state changes.
3. Verifying that listeners are *not* notified when the search state does not change (i.e. remains the same).
✨ **Result:** Test coverage for `NoteSearchController` has been improved, adding safety nets for UI state logic relying on `setSearchState`.

---
*PR created automatically by Jules for task [10536983402762946372](https://jules.google.com/task/10536983402762946372) started by @Shangjin-Xiao*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shangjin-xiao/thoughtecho/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
