### PR TITLE
🧪 测试改进: 添加 `recordAppOpen` 单元测试

### DIFF
--- a/test/unit/services/smart_push_analytics_test.dart
+++ b/test/unit/services/smart_push_analytics_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/services/mmkv_service.dart';
+import 'package:thoughtecho/services/smart_push_analytics.dart';
+
+import '../../test_setup.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SmartPushAnalytics analytics;
+  late MMKVService mmkvService;
+
+  setUpAll(() async {
+    await TestSetup.setupUnitTest();
+    await MMKVService().init();
+  });
+
+  setUp(() async {
+    mmkvService = MMKVService();
+    await mmkvService.clear();
+    analytics = SmartPushAnalytics(mmkvService: mmkvService);
+  });
+
+  group('SmartPushAnalytics.recordAppOpen', () {
+    test('appends new record representing current time to MMKV storage', () async {
+      await analytics.recordAppOpen();
+
+      final recordsStr = mmkvService.getString('smart_push_app_open_times');
+      expect(recordsStr, isNotNull);
+      expect(recordsStr, isNotEmpty);
+
+      final records = recordsStr!.split(',').where((s) => s.isNotEmpty).toList();
+      expect(records.length, 1);
+
+      // Should be parseable as DateTime
+      final parsedDate = DateTime.tryParse(records.first);
+      expect(parsedDate, isNotNull);
+    });
+
+    test('maintains max limit of records by removing oldest', () async {
+      final maxRecords = SmartPushAnalytics.maxAppOpenRecords;
+
+      // Create max number of fake records
+      final fakeRecords = List.generate(
+          maxRecords, (i) => DateTime(2023, 1, 1).add(Duration(days: i)).toIso8601String());
+      await mmkvService.setString('smart_push_app_open_times', fakeRecords.join(','));
+
+      await analytics.recordAppOpen();
+
+      final updatedRecordsStr = mmkvService.getString('smart_push_app_open_times');
+      final updatedRecords = updatedRecordsStr!.split(',').where((s) => s.isNotEmpty).toList();
+
+      expect(updatedRecords.length, maxRecords);
+      // The oldest one should be removed (the one from index 0 of fakeRecords)
+      expect(updatedRecords.first, fakeRecords[1]);
+
+      // The newest one should be near current time
+      final parsedLastDate = DateTime.tryParse(updatedRecords.last);
+      expect(parsedLastDate, isNotNull);
+      expect(parsedLastDate!.isAfter(DateTime.parse(fakeRecords.last)), isTrue);
+    });
+
+    test('handles corrupted data gracefully by appending anyway', () async {
+      // Set corrupted data
+      await mmkvService.setString('smart_push_app_open_times', 'corrupted_data_without_datetime');
+
+      await analytics.recordAppOpen();
+
+      final updatedRecordsStr = mmkvService.getString('smart_push_app_open_times');
+      final updatedRecords = updatedRecordsStr!.split(',').where((s) => s.isNotEmpty).toList();
+
+      // Currently, _getAppOpenRecords simply returns the split strings, so 'corrupted_data_without_datetime' will still be there.
+      // And the new DateTime string will be added.
+      expect(updatedRecords.length, 2);
+      expect(updatedRecords.first, 'corrupted_data_without_datetime');
+
+      final parsedDate = DateTime.tryParse(updatedRecords.last);
+      expect(parsedDate, isNotNull);
+    });
+  });
+}

--- a/test/unit/services/smart_push_analytics_test.dart
+++ b/test/unit/services/smart_push_analytics_test.dart
@@ -22,14 +22,16 @@ void main() {
   });
 
   group('SmartPushAnalytics.recordAppOpen', () {
-    test('appends new record representing current time to MMKV storage', () async {
+    test('appends new record representing current time to MMKV storage',
+        () async {
       await analytics.recordAppOpen();
 
       final recordsStr = mmkvService.getString('smart_push_app_open_times');
       expect(recordsStr, isNotNull);
       expect(recordsStr, isNotEmpty);
 
-      final records = recordsStr!.split(',').where((s) => s.isNotEmpty).toList();
+      final records =
+          recordsStr!.split(',').where((s) => s.isNotEmpty).toList();
       expect(records.length, 1);
 
       // Should be parseable as DateTime
@@ -41,14 +43,17 @@ void main() {
       final maxRecords = SmartPushAnalytics.maxAppOpenRecords;
 
       // Create max number of fake records
-      final fakeRecords = List.generate(
-          maxRecords, (i) => DateTime(2023, 1, 1).add(Duration(days: i)).toIso8601String());
-      await mmkvService.setString('smart_push_app_open_times', fakeRecords.join(','));
+      final fakeRecords = List.generate(maxRecords,
+          (i) => DateTime(2023, 1, 1).add(Duration(days: i)).toIso8601String());
+      await mmkvService.setString(
+          'smart_push_app_open_times', fakeRecords.join(','));
 
       await analytics.recordAppOpen();
 
-      final updatedRecordsStr = mmkvService.getString('smart_push_app_open_times');
-      final updatedRecords = updatedRecordsStr!.split(',').where((s) => s.isNotEmpty).toList();
+      final updatedRecordsStr =
+          mmkvService.getString('smart_push_app_open_times');
+      final updatedRecords =
+          updatedRecordsStr!.split(',').where((s) => s.isNotEmpty).toList();
 
       expect(updatedRecords.length, maxRecords);
       // The oldest one should be removed (the one from index 0 of fakeRecords)
@@ -62,12 +67,15 @@ void main() {
 
     test('handles corrupted data gracefully by appending anyway', () async {
       // Set corrupted data
-      await mmkvService.setString('smart_push_app_open_times', 'corrupted_data_without_datetime');
+      await mmkvService.setString(
+          'smart_push_app_open_times', 'corrupted_data_without_datetime');
 
       await analytics.recordAppOpen();
 
-      final updatedRecordsStr = mmkvService.getString('smart_push_app_open_times');
-      final updatedRecords = updatedRecordsStr!.split(',').where((s) => s.isNotEmpty).toList();
+      final updatedRecordsStr =
+          mmkvService.getString('smart_push_app_open_times');
+      final updatedRecords =
+          updatedRecordsStr!.split(',').where((s) => s.isNotEmpty).toList();
 
       // Currently, _getAppOpenRecords simply returns the split strings, so 'corrupted_data_without_datetime' will still be there.
       // And the new DateTime string will be added.


### PR DESCRIPTION
🎯 **What:** Added unit tests for the previously untested public method `recordAppOpen` in `SmartPushAnalytics` (`lib/services/smart_push_analytics.dart:55`).
📊 **Coverage:** The tests cover the happy path (appending a new ISO 8601 string), array capacity limit enforcement (maintaining exactly `maxAppOpenRecords` elements), and graceful handling of corrupted pre-existing data in MMKV storage.
✨ **Result:** Improved test coverage for the smart push response heatmap logic, ensuring the time series collection logic operates safely without data loss or memory leaks.

---
*PR created automatically by Jules for task [10489756392717779832](https://jules.google.com/task/10489756392717779832) started by @Shangjin-Xiao*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shangjin-xiao/thoughtecho/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
