### PR TITLE
🧹 [code health] fix unreachable code and potential cast error in retry interceptor

### DIFF
--- a/lib/utils/dio_network_utils.dart
+++ b/lib/utils/dio_network_utils.dart
@@ -734,11 +734,16 @@ class RetryInterceptor extends Interceptor {
         final response = await dio.fetch(err.requestOptions);
         handler.resolve(response);
         return;
+      } on DioException catch (e) {
+        return onError(e, handler);
       } catch (e) {
-        if (e is DioException) {
-          return onError(e, handler);
-        }
-        handler.reject(e as DioException);
+        handler.reject(
+          DioException(
+            requestOptions: err.requestOptions,
+            error: e,
+            message: e.toString(),
+          ),
+        );
         return;
       }
     }


### PR DESCRIPTION
🎯 **What:** Removed the unreachable typecast `e as DioException` inside `lib/utils/dio_network_utils.dart:741` and implemented safe exception wrapping.
💡 **Why:** When `dio.fetch` throws a non-`DioException`, the previous code would attempt to cast it to `DioException` and trigger a `TypeError`, crashing the interceptor. Refactoring to explicitly handle `on DioException` and properly wrapping general errors makes the networking layer robust and prevents hard crashes on retry failures.
✅ **Verification:** Verified by running `dart format`, `flutter analyze` and the full `flutter test test/all_tests.dart` suite successfully.
✨ **Result:** Improved codebase maintainability and eliminated a potential runtime crash vector during request retries.

---
*PR created automatically by Jules for task [11782630263276403123](https://jules.google.com/task/11782630263276403123) started by @Shangjin-Xiao*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shangjin-xiao/thoughtecho/pull/209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了网络请求重试机制中的错误处理逻辑，增强了异常捕获的一致性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->