### PR TITLE
🛡️ Sentinel: [High] Fix insecure CORS configuration in LocalSendServer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,7 @@
 ## 2024-06-03 - [Security Enhancement] Parameterize Database Schema Inspection
 **Learning:** SQLite `PRAGMA` statements are generally not parameterized, increasing the risk of SQL injection if user input ever makes it into the schema queries. Using the equivalent SQLite table-valued function `pragma_table_info(?)` allows for safe parameterization.
 **Action:** Replaced hardcoded PRAGMA table_info calls in `lib/services/database_schema_manager.dart` with safe parameterized queries `SELECT name FROM pragma_table_info(?)`.
+## 2026-05-20 - [High] Insecure CORS Configuration on Local Server Fixed
+**Vulnerability:** The `LocalSendServer` (`lib/services/localsend/localsend_server.dart`), which binds to the local network interface (`InternetAddress.anyIPv4`), explicitly added permissive CORS headers (`Access-Control-Allow-Origin: *`) and handled `OPTIONS` preflight requests. This allowed any external malicious website the user visits to bypass the browser's Same-Origin Policy and make direct HTTP requests to the local server via the browser (e.g., DNS rebinding).
+**Learning:** Local network servers must be extremely strict about cross-origin requests. Adding wildcard CORS headers to a local server completely negates the security boundary provided by the browser's Same-Origin Policy.
+**Prevention:** Do not add `Access-Control-Allow-Origin: *` to local servers. Rely on standard Same-Origin Policy to block unauthorized cross-origin access from web browsers.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,7 +39,7 @@
 ## 2024-06-03 - [Security Enhancement] Parameterize Database Schema Inspection
 **Learning:** SQLite `PRAGMA` statements are generally not parameterized, increasing the risk of SQL injection if user input ever makes it into the schema queries. Using the equivalent SQLite table-valued function `pragma_table_info(?)` allows for safe parameterization.
 **Action:** Replaced hardcoded PRAGMA table_info calls in `lib/services/database_schema_manager.dart` with safe parameterized queries `SELECT name FROM pragma_table_info(?)`.
-## 2026-05-20 - [High] Insecure CORS Configuration on Local Server Fixed
+## 2026-04-24 - [High] Insecure CORS Configuration on Local Server Fixed
 **Vulnerability:** The `LocalSendServer` (`lib/services/localsend/localsend_server.dart`), which binds to the local network interface (`InternetAddress.anyIPv4`), explicitly added permissive CORS headers (`Access-Control-Allow-Origin: *`) and handled `OPTIONS` preflight requests. This allowed any external malicious website the user visits to bypass the browser's Same-Origin Policy and make direct HTTP requests to the local server via the browser (e.g., DNS rebinding).
 **Learning:** Local network servers must be extremely strict about cross-origin requests. Adding wildcard CORS headers to a local server completely negates the security boundary provided by the browser's Same-Origin Policy.
 **Prevention:** Do not add `Access-Control-Allow-Origin: *` to local servers. Rely on standard Same-Origin Policy to block unauthorized cross-origin access from web browsers.

--- a/lib/services/localsend/localsend_server.dart
+++ b/lib/services/localsend/localsend_server.dart
@@ -134,24 +134,7 @@ class LocalSendServer {
         source: 'LocalSend',
       );
 
-      // Keep browser-based clients working with standard CORS preflight.
-      request.response.headers.add('Access-Control-Allow-Origin', '*');
-      request.response.headers.add(
-        'Access-Control-Allow-Methods',
-        'GET, POST, PUT, DELETE, OPTIONS',
-      );
-      request.response.headers.add(
-        'Access-Control-Allow-Headers',
-        'Content-Type, Authorization',
-      );
       request.response.headers.add('Connection', 'keep-alive');
-
-      if (request.method == 'OPTIONS') {
-        request.response.statusCode = HttpStatus.ok;
-        await request.response.close();
-        logDebug('req_options', source: 'LocalSend');
-        return;
-      }
 
       final path = request.uri.path;
       final query = request.uri.queryParameters;


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `LocalSendServer` (running on `InternetAddress.anyIPv4`) explicitly added permissive CORS headers (`Access-Control-Allow-Origin: *`) and handled `OPTIONS` preflight requests.
🎯 **Impact:** This allowed any malicious website the user visits to bypass the browser's Same-Origin Policy and execute unauthorized cross-origin requests (e.g., via DNS rebinding) to the local application server, potentially exposing local network data or facilitating unauthorized actions.
🔧 **Fix:** Removed the permissive CORS headers and the `OPTIONS` request handler, restoring the browser's default strict Same-Origin Policy to block unauthorized external access.
✅ **Verification:** Verified that the headers are removed and local unit tests (`localsend_components_test.dart`) continue to pass.

---
*PR created automatically by Jules for task [12486613991066098071](https://jules.google.com/task/12486613991066098071) started by @Shangjin-Xiao*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shangjin-xiao/thoughtecho/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `LocalSendServer` 的不安全 CORS 配置：移除通配 `Access-Control-Allow-*` 响应头和 `OPTIONS` 预检处理，恢复同源策略，阻止网页对本地服务的跨域访问（含 DNS 重绑定）。更新 `.jules/sentinel.md` 记录与预防指引；现有单测通过。

<sup>Written for commit b81c80b454e7f2bc69673d057df02745cc28bcc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

