### PR TITLE
🧹 [Code Health] Refactor enhanced toolbar builder into separate methods

### DIFF
--- a/lib/widgets/quill_enhanced_toolbar_unified.dart
+++ b/lib/widgets/quill_enhanced_toolbar_unified.dart
@@ -45,154 +45,197 @@ class _UnifiedQuillToolbarState extends State<UnifiedQuillToolbar> {
         padding: const EdgeInsets.symmetric(horizontal: 8),
         child: Row(
           children: [
-            // 第一组：历史操作
-            quill.QuillToolbarHistoryButton(
-              controller: widget.controller,
-              isUndo: true,
-              options: const quill.QuillToolbarHistoryButtonOptions(),
-            ),
-            quill.QuillToolbarHistoryButton(
-              controller: widget.controller,
-              isUndo: false,
-              options: const quill.QuillToolbarHistoryButtonOptions(),
-            ),
+            ..._buildHistoryGroup(),
             _buildDivider(),
-
-            // 第二组：基础格式
-            quill.QuillToolbarToggleStyleButton(
-              controller: widget.controller,
-              attribute: quill.Attribute.bold,
-              options: const quill.QuillToolbarToggleStyleButtonOptions(),
-            ),
-            quill.QuillToolbarToggleStyleButton(
-              controller: widget.controller,
-              attribute: quill.Attribute.italic,
-              options: const quill.QuillToolbarToggleStyleButtonOptions(),
-            ),
-            quill.QuillToolbarToggleStyleButton(
-              controller: widget.controller,
-              attribute: quill.Attribute.underline,
-              options: const quill.QuillToolbarToggleStyleButtonOptions(),
-            ),
-            quill.QuillToolbarToggleStyleButton(
-              controller: widget.controller,
-              attribute: quill.Attribute.strikeThrough,
-              options: const quill.QuillToolbarToggleStyleButtonOptions(),
-            ),
+            ..._buildBasicFormatGroup(),
             _buildDivider(),
-
-            // 第三组：标题
-            quill.QuillToolbarSelectHeaderStyleDropdownButton(
-              controller: widget.controller,
-              options: const quill
-                  .QuillToolbarSelectHeaderStyleDropdownButtonOptions(),
-            ),
+            ..._buildHeaderGroup(),
             _buildDivider(),
-
-            // 第四组：字体和大小
-            quill.QuillToolbarFontSizeButton(
-              controller: widget.controller,
-              options: const quill.QuillToolbarFontSizeButtonOptions(),
-            ),
-            quill.QuillToolbarFontFamilyButton(
-              controller: widget.controller,
-              options: const quill.QuillToolbarFontFamilyButtonOptions(),
-            ),
+            ..._buildFontGroup(),
             _buildDivider(),
-
-            // 第五组：颜色
-            quill.QuillToolbarColorButton(
-              controller: widget.controller,
-              isBackground: false,
-              options: const quill.QuillToolbarColorButtonOptions(),
-            ),
-            quill.QuillToolbarColorButton(
-              controller: widget.controller,
-              isBackground: true,
-              options: const quill.QuillToolbarColorButtonOptions(),
-            ),
+            ..._buildColorGroup(),
             _buildDivider(),
-
-            // 第六组：对齐
-            quill.QuillToolbarSelectAlignmentButton(
-              controller: widget.controller,
-            ),
+            ..._buildAlignmentGroup(),
             _buildDivider(),
-
-            // 第七组：列表
-            quill.QuillToolbarToggleStyleButton(
-              controller: widget.controller,
-              attribute: quill.Attribute.ol,
-              options: const quill.QuillToolbarToggleStyleButtonOptions(),
-            ),
-            quill.QuillToolbarToggleStyleButton(
-              controller: widget.controller,
-              attribute: quill.Attribute.ul,
-              options: const quill.QuillToolbarToggleStyleButtonOptions(),
-            ),
-            quill.QuillToolbarIndentButton(
-              controller: widget.controller,
-              isIncrease: false,
-              options: const quill.QuillToolbarIndentButtonOptions(),
-            ),
-            quill.QuillToolbarIndentButton(
-              controller: widget.controller,
-              isIncrease: true,
-              options: const quill.QuillToolbarIndentButtonOptions(),
-            ),
+            ..._buildListGroup(),
             _buildDivider(),
-
-            // 第八组：引用和代码
-            quill.QuillToolbarToggleStyleButton(
-              controller: widget.controller,
-              attribute: quill.Attribute.blockQuote,
-              options: const quill.QuillToolbarToggleStyleButtonOptions(),
-            ),
-            quill.QuillToolbarToggleStyleButton(
-              controller: widget.controller,
-              attribute: quill.Attribute.codeBlock,
-              options: const quill.QuillToolbarToggleStyleButtonOptions(),
-            ),
+            ..._buildQuoteAndCodeGroup(),
             _buildDivider(),
-
-            // 第九组：链接
-            quill.QuillToolbarLinkStyleButton(
-              controller: widget.controller,
-              options: const quill.QuillToolbarLinkStyleButtonOptions(),
-            ),
+            ..._buildLinkGroup(),
             _buildDivider(),
-
-            // 第十组：媒体插入 - 使用统一的媒体导入
-            _buildMediaButton(
-              icon: Icons.image,
-              tooltip: AppLocalizations.of(context).insertImage,
-              onPressed: () => _showUnifiedMediaDialog('image'),
-            ),
-            _buildMediaButton(
-              icon: Icons.videocam,
-              tooltip: AppLocalizations.of(context).insertVideo,
-              onPressed: () => _showUnifiedMediaDialog('video'),
-            ),
-            _buildMediaButton(
-              icon: Icons.audiotrack,
-              tooltip: AppLocalizations.of(context).insertAudio,
-              onPressed: () => _showUnifiedMediaDialog('audio'),
-            ),
+            ..._buildMediaGroup(context),
             _buildDivider(),
-
-            // 第十一组：其他功能
-            quill.QuillToolbarClearFormatButton(
-              controller: widget.controller,
-              options: const quill.QuillToolbarClearFormatButtonOptions(),
-            ),
-            quill.QuillToolbarSearchButton(
-              controller: widget.controller,
-              options: const quill.QuillToolbarSearchButtonOptions(),
-            ),
+            ..._buildMiscGroup(),
           ],
         ),
       ),
     );
+  }
+
+  List<Widget> _buildHistoryGroup() {
+    return [
+      quill.QuillToolbarHistoryButton(
+        controller: widget.controller,
+        isUndo: true,
+        options: const quill.QuillToolbarHistoryButtonOptions(),
+      ),
+      quill.QuillToolbarHistoryButton(
+        controller: widget.controller,
+        isUndo: false,
+        options: const quill.QuillToolbarHistoryButtonOptions(),
+      ),
+    ];
+  }
+
+  List<Widget> _buildBasicFormatGroup() {
+    return [
+      quill.QuillToolbarToggleStyleButton(
+        controller: widget.controller,
+        attribute: quill.Attribute.bold,
+        options: const quill.QuillToolbarToggleStyleButtonOptions(),
+      ),
+      quill.QuillToolbarToggleStyleButton(
+        controller: widget.controller,
+        attribute: quill.Attribute.italic,
+        options: const quill.QuillToolbarToggleStyleButtonOptions(),
+      ),
+      quill.QuillToolbarToggleStyleButton(
+        controller: widget.controller,
+        attribute: quill.Attribute.underline,
+        options: const quill.QuillToolbarToggleStyleButtonOptions(),
+      ),
+      quill.QuillToolbarToggleStyleButton(
+        controller: widget.controller,
+        attribute: quill.Attribute.strikeThrough,
+        options: const quill.QuillToolbarToggleStyleButtonOptions(),
+      ),
+    ];
+  }
+
+  List<Widget> _buildHeaderGroup() {
+    return [
+      quill.QuillToolbarSelectHeaderStyleDropdownButton(
+        controller: widget.controller,
+        options:
+            const quill.QuillToolbarSelectHeaderStyleDropdownButtonOptions(),
+      ),
+    ];
+  }
+
+  List<Widget> _buildFontGroup() {
+    return [
+      quill.QuillToolbarFontSizeButton(
+        controller: widget.controller,
+        options: const quill.QuillToolbarFontSizeButtonOptions(),
+      ),
+      quill.QuillToolbarFontFamilyButton(
+        controller: widget.controller,
+        options: const quill.QuillToolbarFontFamilyButtonOptions(),
+      ),
+    ];
+  }
+
+  List<Widget> _buildColorGroup() {
+    return [
+      quill.QuillToolbarColorButton(
+        controller: widget.controller,
+        isBackground: false,
+        options: const quill.QuillToolbarColorButtonOptions(),
+      ),
+      quill.QuillToolbarColorButton(
+        controller: widget.controller,
+        isBackground: true,
+        options: const quill.QuillToolbarColorButtonOptions(),
+      ),
+    ];
+  }
+
+  List<Widget> _buildAlignmentGroup() {
+    return [
+      quill.QuillToolbarSelectAlignmentButton(controller: widget.controller),
+    ];
+  }
+
+  List<Widget> _buildListGroup() {
+    return [
+      quill.QuillToolbarToggleStyleButton(
+        controller: widget.controller,
+        attribute: quill.Attribute.ol,
+        options: const quill.QuillToolbarToggleStyleButtonOptions(),
+      ),
+      quill.QuillToolbarToggleStyleButton(
+        controller: widget.controller,
+        attribute: quill.Attribute.ul,
+        options: const quill.QuillToolbarToggleStyleButtonOptions(),
+      ),
+      quill.QuillToolbarIndentButton(
+        controller: widget.controller,
+        isIncrease: false,
+        options: const quill.QuillToolbarIndentButtonOptions(),
+      ),
+      quill.QuillToolbarIndentButton(
+        controller: widget.controller,
+        isIncrease: true,
+        options: const quill.QuillToolbarIndentButtonOptions(),
+      ),
+    ];
+  }
+
+  List<Widget> _buildQuoteAndCodeGroup() {
+    return [
+      quill.QuillToolbarToggleStyleButton(
+        controller: widget.controller,
+        attribute: quill.Attribute.blockQuote,
+        options: const quill.QuillToolbarToggleStyleButtonOptions(),
+      ),
+      quill.QuillToolbarToggleStyleButton(
+        controller: widget.controller,
+        attribute: quill.Attribute.codeBlock,
+        options: const quill.QuillToolbarToggleStyleButtonOptions(),
+      ),
+    ];
+  }
+
+  List<Widget> _buildLinkGroup() {
+    return [
+      quill.QuillToolbarLinkStyleButton(
+        controller: widget.controller,
+        options: const quill.QuillToolbarLinkStyleButtonOptions(),
+      ),
+    ];
+  }
+
+  List<Widget> _buildMediaGroup(BuildContext context) {
+    return [
+      _buildMediaButton(
+        icon: Icons.image,
+        tooltip: AppLocalizations.of(context).insertImage,
+        onPressed: () => _showUnifiedMediaDialog('image'),
+      ),
+      _buildMediaButton(
+        icon: Icons.videocam,
+        tooltip: AppLocalizations.of(context).insertVideo,
+        onPressed: () => _showUnifiedMediaDialog('video'),
+      ),
+      _buildMediaButton(
+        icon: Icons.audiotrack,
+        tooltip: AppLocalizations.of(context).insertAudio,
+        onPressed: () => _showUnifiedMediaDialog('audio'),
+      ),
+    ];
+  }
+
+  List<Widget> _buildMiscGroup() {
+    return [
+      quill.QuillToolbarClearFormatButton(
+        controller: widget.controller,
+        options: const quill.QuillToolbarClearFormatButtonOptions(),
+      ),
+      quill.QuillToolbarSearchButton(
+        controller: widget.controller,
+        options: const quill.QuillToolbarSearchButtonOptions(),
+      ),
+    ];
   }
 
   Widget _buildDivider() {
@@ -229,8 +272,9 @@ class _UnifiedQuillToolbarState extends State<UnifiedQuillToolbar> {
               child: Container(
                 width: 36,
                 height: 36,
-                decoration:
-                    BoxDecoration(borderRadius: BorderRadius.circular(4)),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(4),
+                ),
                 child: Icon(icon, size: 18, color: theme.colorScheme.onSurface),
               ),
             ),
@@ -297,10 +341,12 @@ class _UnifiedQuillToolbarState extends State<UnifiedQuillToolbar> {
         final l10n = AppLocalizations.of(context);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(l10n.insertMediaFailed(
-              _getMediaTypeName(context, mediaType),
-              e.toString(),
-            )),
+            content: Text(
+              l10n.insertMediaFailed(
+                _getMediaTypeName(context, mediaType),
+                e.toString(),
+              ),
+            ),
             duration: const Duration(seconds: 3),
           ),
         );

--- a/test/performance/database_backup_merge_benchmark_test.dart
+++ b/test/performance/database_backup_merge_benchmark_test.dart
@@ -81,7 +81,8 @@ void main() {
       return {
         'id': 'cat_$i',
         'name': 'Category $i',
-        'last_modified': DateTime.now().add(const Duration(minutes: 1)).toIso8601String(),
+        'last_modified':
+            DateTime.now().add(const Duration(minutes: 1)).toIso8601String(),
       };
     });
 
@@ -90,7 +91,8 @@ void main() {
         'id': 'quote_$i',
         'content': 'Updated Content $i',
         'date': DateTime.now().toIso8601String(),
-        'last_modified': DateTime.now().add(const Duration(minutes: 1)).toIso8601String(),
+        'last_modified':
+            DateTime.now().add(const Duration(minutes: 1)).toIso8601String(),
         'tag_ids': i % 5 == 0 ? 'cat_${i % (categoryCount ~/ 2)}' : '',
       };
     });
@@ -105,7 +107,8 @@ void main() {
     final report = await service.importDataWithLWWMerge(db, mergeData);
     stopwatch.stop();
 
-    print('Time taken to merge $categoryCount categories and $quoteCount quotes: ${stopwatch.elapsedMilliseconds} ms');
+    print(
+        'Time taken to merge $categoryCount categories and $quoteCount quotes: ${stopwatch.elapsedMilliseconds} ms');
     print('Report: ${report.summary}');
 
     expect(report.insertedCategories + report.updatedCategories, categoryCount);

--- a/test/unit/services/database_backup_merge_test.dart
+++ b/test/unit/services/database_backup_merge_test.dart
@@ -106,13 +106,18 @@ void main() {
     expect(report.updatedQuotes, 1);
     expect(report.insertedQuotes, 1);
 
-    final cat1 = (await db.query('categories', where: 'id = ?', whereArgs: ['cat_1'])).first;
+    final cat1 =
+        (await db.query('categories', where: 'id = ?', whereArgs: ['cat_1']))
+            .first;
     expect(cat1['name'], 'New Category Name');
 
-    final quote1 = (await db.query('quotes', where: 'id = ?', whereArgs: ['quote_1'])).first;
+    final quote1 =
+        (await db.query('quotes', where: 'id = ?', whereArgs: ['quote_1']))
+            .first;
     expect(quote1['content'], 'New Content');
 
-    final tags = await db.query('quote_tags', where: 'quote_id = ?', whereArgs: ['quote_1']);
+    final tags = await db
+        .query('quote_tags', where: 'quote_id = ?', whereArgs: ['quote_1']);
     expect(tags.length, 2);
   });
 }


### PR DESCRIPTION
🎯 **What:** Extracted 11 distinct button groups inside the `build` method of `UnifiedQuillToolbar` (`lib/widgets/quill_enhanced_toolbar_unified.dart`) into their own private builder methods (e.g., `_buildHistoryGroup()`, `_buildFormatGroup()`).
💡 **Why:** The original `build` method was nearly 150 lines long, making it hard to navigate. By decomposing it into smaller, logically grouped methods and utilizing the spread operator, the code is much more readable and maintainable. This aligns with good code health practices by isolating concerns.
✅ **Verification:** Ran `dart format`, `flutter analyze`, and the entire `flutter test` suite. All checks passed successfully, ensuring no existing behaviors were broken.
✨ **Result:** A much cleaner `build` method in `quill_enhanced_toolbar_unified.dart` that accurately conveys the toolbar's structure at a glance without cluttering the widget tree with hundreds of lines of implementation detail.

---
*PR created automatically by Jules for task [3538194444502667054](https://jules.google.com/task/3538194444502667054) started by @Shangjin-Xiao*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shangjin-xiao/thoughtecho/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `UnifiedQuillToolbar` 的 11 个按钮组从 `build` 拆分为私有方法，并用扩展运算符组装，显著精简 `build`；同时格式化两处测试/基准文件以修复 CI 行长检查，无逻辑或布局变更。

- **Refactors**
  - 拆分历史、基础格式、标题、字体/大小、颜色、对齐、列表、引用/代码、链接、媒体、其他为私有方法（如 `_buildHistoryGroup()`）
  - 使用扩展运算符组装 `Row.children`，提升可读性

- **Bug Fixes**
  - 运行 `dart format` 修复 `test/performance/database_backup_merge_benchmark_test.dart` 与 `test/unit/services/database_backup_merge_test.dart` 的行长问题，恢复 CI 通过

<sup>Written for commit ffb6e5a14bf5d98e5fbb9df1196fc203fdd35b70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

