### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2026-05-18 - Tooltips for Dynamic Icons
 **Learning:** For dynamic icon buttons (like play/pause toggles), assigning a dynamic tooltip is crucial. While localized strings are ideal, a hardcoded English fallback (e.g., 'Pause' / 'Play') significantly improves screen reader comprehension over an unlabeled icon that changes. Avoid redundant `Semantics` wrappers around `Icon` and `Text` widgets, as `Text` is already read and `Icon` without a semantic label is ignored.
 **Action:** When working on media controls or toggle buttons, ensure the `tooltip` property updates dynamically alongside the icon state. Do not shuffle structural `Semantics` tags without a proven need.
+## 2026-05-01 - [Tooltip on icon-only buttons]
+**Learning:** Icon-only buttons used throughout the application (such as the app bar action buttons and the input clear fields) may be missing tooltips, making it difficult for screen readers to explain what those buttons do.
+**Action:** When creating or modifying `IconButton` components, always verify that a `tooltip` attribute containing localized strings from `AppLocalizations` is present, especially when it is icon-only.

--- a/lib/pages/category_settings_page.dart
+++ b/lib/pages/category_settings_page.dart
@@ -94,17 +94,17 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                             ),
                             child: _selectedIconName != null
                                 ? (IconUtils.isEmoji(_selectedIconName)
-                                    ? Text(
-                                        IconUtils.getDisplayIcon(
-                                          _selectedIconName!,
-                                        ),
-                                        style: const TextStyle(fontSize: 20),
-                                      )
-                                    : Icon(
-                                        IconUtils.getIconData(
-                                          _selectedIconName,
-                                        ),
-                                      ))
+                                      ? Text(
+                                          IconUtils.getDisplayIcon(
+                                            _selectedIconName!,
+                                          ),
+                                          style: const TextStyle(fontSize: 20),
+                                        )
+                                      : Icon(
+                                          IconUtils.getIconData(
+                                            _selectedIconName,
+                                          ),
+                                        ))
                                 : const Icon(Icons.add_circle_outline),
                           ),
                         ),
@@ -321,6 +321,7 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                       prefixIcon: const Icon(Icons.search),
                       suffixIcon: emojiSearchController.text.isNotEmpty
                           ? IconButton(
+                              tooltip: l10n.clear,
                               icon: const Icon(Icons.clear),
                               onPressed: () {
                                 emojiSearchController.clear();
@@ -424,13 +425,13 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                                             decoration: BoxDecoration(
                                               color: isSelected
                                                   ? Theme.of(context)
-                                                      .colorScheme
-                                                      .primaryContainer
+                                                        .colorScheme
+                                                        .primaryContainer
                                                   : Colors.transparent,
                                               borderRadius:
                                                   BorderRadius.circular(
-                                                AppTheme.cardRadius,
-                                              ),
+                                                    AppTheme.cardRadius,
+                                                  ),
                                               border: Border.all(
                                                 color: isSelected
                                                     ? Theme.of(
@@ -516,13 +517,13 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                                             decoration: BoxDecoration(
                                               color: isSelected
                                                   ? Theme.of(context)
-                                                      .colorScheme
-                                                      .primaryContainer
+                                                        .colorScheme
+                                                        .primaryContainer
                                                   : Colors.transparent,
                                               borderRadius:
                                                   BorderRadius.circular(
-                                                AppTheme.cardRadius,
-                                              ),
+                                                    AppTheme.cardRadius,
+                                                  ),
                                               border: Border.all(
                                                 color: isSelected
                                                     ? Theme.of(
@@ -720,8 +721,8 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                     isHiddenTag
                         ? l10n.hiddenTagUsageHint
                         : (isDefault
-                            ? l10n.systemDefaultTag
-                            : l10n.tapToEditLongPressToDelete),
+                              ? l10n.systemDefaultTag
+                              : l10n.tapToEditLongPressToDelete),
                     style: TextStyle(
                       fontSize: 11,
                       color: isDefault || isHiddenTag
@@ -759,9 +760,7 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
       context: context,
       builder: (context) => AlertDialog(
         title: Text(l10n.confirmDelete),
-        content: Text(
-          l10n.deleteTagConfirmation(category.localizedName(l10n)),
-        ),
+        content: Text(l10n.deleteTagConfirmation(category.localizedName(l10n))),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -869,6 +868,7 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
                 prefixIcon: const Icon(Icons.search),
                 suffixIcon: _emojiSearchController.text.isNotEmpty
                     ? IconButton(
+                        tooltip: l10n.clear,
                         icon: const Icon(Icons.clear),
                         onPressed: () {
                           _emojiSearchController.clear();

--- a/lib/pages/category_settings_page.dart
+++ b/lib/pages/category_settings_page.dart
@@ -94,17 +94,17 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                             ),
                             child: _selectedIconName != null
                                 ? (IconUtils.isEmoji(_selectedIconName)
-                                      ? Text(
-                                          IconUtils.getDisplayIcon(
-                                            _selectedIconName!,
-                                          ),
-                                          style: const TextStyle(fontSize: 20),
-                                        )
-                                      : Icon(
-                                          IconUtils.getIconData(
-                                            _selectedIconName,
-                                          ),
-                                        ))
+                                    ? Text(
+                                        IconUtils.getDisplayIcon(
+                                          _selectedIconName!,
+                                        ),
+                                        style: const TextStyle(fontSize: 20),
+                                      )
+                                    : Icon(
+                                        IconUtils.getIconData(
+                                          _selectedIconName,
+                                        ),
+                                      ))
                                 : const Icon(Icons.add_circle_outline),
                           ),
                         ),
@@ -425,13 +425,13 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                                             decoration: BoxDecoration(
                                               color: isSelected
                                                   ? Theme.of(context)
-                                                        .colorScheme
-                                                        .primaryContainer
+                                                      .colorScheme
+                                                      .primaryContainer
                                                   : Colors.transparent,
                                               borderRadius:
                                                   BorderRadius.circular(
-                                                    AppTheme.cardRadius,
-                                                  ),
+                                                AppTheme.cardRadius,
+                                              ),
                                               border: Border.all(
                                                 color: isSelected
                                                     ? Theme.of(
@@ -517,13 +517,13 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                                             decoration: BoxDecoration(
                                               color: isSelected
                                                   ? Theme.of(context)
-                                                        .colorScheme
-                                                        .primaryContainer
+                                                      .colorScheme
+                                                      .primaryContainer
                                                   : Colors.transparent,
                                               borderRadius:
                                                   BorderRadius.circular(
-                                                    AppTheme.cardRadius,
-                                                  ),
+                                                AppTheme.cardRadius,
+                                              ),
                                               border: Border.all(
                                                 color: isSelected
                                                     ? Theme.of(
@@ -721,8 +721,8 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                     isHiddenTag
                         ? l10n.hiddenTagUsageHint
                         : (isDefault
-                              ? l10n.systemDefaultTag
-                              : l10n.tapToEditLongPressToDelete),
+                            ? l10n.systemDefaultTag
+                            : l10n.tapToEditLongPressToDelete),
                     style: TextStyle(
                       fontSize: 11,
                       color: isDefault || isHiddenTag

--- a/lib/pages/media_management_page.dart
+++ b/lib/pages/media_management_page.dart
@@ -111,6 +111,7 @@ class _MediaManagementPageState extends State<MediaManagementPage> {
         title: Text(l10n.mediaManagementTitle),
         actions: [
           IconButton(
+            tooltip: l10n.refresh,
             icon: const Icon(Icons.refresh),
             onPressed: _isLoading ? null : _loadMediaStats,
           ),


### PR DESCRIPTION
This PR adds missing tooltips to several icon-only buttons to improve screen reader accessibility and desktop hover functionality.

### 💡 What:
Added `tooltip` properties mapped to localized strings for the "Refresh" button on the Media Management page and the "Clear" buttons inside search inputs on the Category Settings page.

### 🎯 Why:
Icon-only buttons without text labels or semantic tooltips are invisible or unhelpful to users relying on screen readers. Adding tooltips ensures the UI is accessible.

### ♿ Accessibility:
- Added localized screen-reader context to `Icons.refresh` and `Icons.clear` instances.

---
*PR created automatically by Jules for task [2075584260985706971](https://jules.google.com/task/2075584260985706971) started by @Shangjin-Xiao*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为清除和刷新按钮添加了本地化工具提示,在用户悬停或长按时显示上下文信息,改进了应用的无障碍访问体验。

* **文档**
  * 更新了组件指导,强调图标按钮必须包含工具提示以确保屏幕阅读器用户的可发现性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->