### PR TITLE
🎨 Palette: 补充 IconButton 的 Tooltip (提升无障碍体验)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-05-01 - [Tooltip on icon-only buttons]
 **Learning:** Icon-only buttons used throughout the application (such as the app bar action buttons and the input clear fields) may be missing tooltips, making it difficult for screen readers to explain what those buttons do.
 **Action:** When creating or modifying `IconButton` components, always verify that a `tooltip` attribute containing localized strings from `AppLocalizations` is present, especially when it is icon-only.
+## 2024-05-24 - Missing Tooltips on IconButtons
+**Learning:** Found multiple instances where `IconButton` widgets were missing `tooltip` properties. This affects accessibility for screen readers and tooltips on web/desktop.
+**Action:** Added semantic string tooltips or translated string references across the settings and subpages. The Python script was improved to find these, but `IconButton` wrappers can mask these errors from naive regex tools.

--- a/lib/pages/ai_analysis_history_page_clean.dart
+++ b/lib/pages/ai_analysis_history_page_clean.dart
@@ -308,6 +308,8 @@ class _AIAnalysisHistoryPageState extends State<AIAnalysisHistoryPage> {
                   IconButton(
                     onPressed: () => Navigator.pop(context),
                     icon: const Icon(Icons.close_rounded),
+                    tooltip:
+                        MaterialLocalizations.of(context).closeButtonTooltip,
                     style: IconButton.styleFrom(
                       backgroundColor: Theme.of(context)
                           .colorScheme
@@ -1045,6 +1047,7 @@ $positiveQuotesText
                             _loadAnalyses();
                           },
                           icon: const Icon(Icons.clear),
+                          tooltip: AppLocalizations.of(context).clear,
                         )
                       : null,
                   border: OutlineInputBorder(

--- a/lib/pages/ai_settings_page.dart
+++ b/lib/pages/ai_settings_page.dart
@@ -993,6 +993,7 @@ class _AISettingsPageState extends State<AISettingsPage> {
                       ),
                       onPressed: () =>
                           setState(() => _obscureApiKey = !_obscureApiKey),
+                      tooltip: _obscureApiKey ? l10n.show : l10n.hide,
                     ),
                   ),
                   obscureText: _obscureApiKey,

--- a/lib/pages/annual_report_page.dart
+++ b/lib/pages/annual_report_page.dart
@@ -403,6 +403,7 @@ class _AnnualReportPageState extends State<AnnualReportPage>
                     Icons.close,
                     color: isDark ? Colors.white : Colors.black54,
                   ),
+                  tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
                 ),
                 Text(
                   '${_currentPage + 1} / 7',
@@ -418,6 +419,7 @@ class _AnnualReportPageState extends State<AnnualReportPage>
                     Icons.share,
                     color: isDark ? Colors.white : Colors.black54,
                   ),
+                  tooltip: AppLocalizations.of(context).shareBtn,
                 ),
               ],
             ),

--- a/lib/pages/api_ninjas_category_selection_page.dart
+++ b/lib/pages/api_ninjas_category_selection_page.dart
@@ -70,6 +70,7 @@ class _ApiNinjasCategorySelectionPageState
           title: Text(l10n.dailyQuoteApiNinjasCategorySelection),
           leading: IconButton(
             icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            tooltip: MaterialLocalizations.of(context).backButtonTooltip,
             onPressed: _popWithSelection,
           ),
           actions: [
@@ -106,6 +107,7 @@ class _ApiNinjasCategorySelectionPageState
                             });
                           },
                           icon: const Icon(Icons.close_rounded),
+                          tooltip: AppLocalizations.of(context).clear,
                         ),
                 ),
               ),

--- a/lib/pages/category_settings_page.dart
+++ b/lib/pages/category_settings_page.dart
@@ -596,6 +596,7 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                   Text(l10n.iconLabel),
                   IconButton(
                     icon: IconUtils.getCategoryIcon(selectedIcon),
+                    tooltip: l10n.iconLabel,
                     onPressed: () async {
                       final BuildContext currentContext = dialogContext;
                       if (!context.mounted) return;

--- a/lib/pages/hitokoto_settings_page.dart
+++ b/lib/pages/hitokoto_settings_page.dart
@@ -288,6 +288,7 @@ class _HitokotoSettingsPageState extends State<HitokotoSettingsPage>
           scrolledUnderElevation: 0,
           leading: IconButton(
             icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            tooltip: MaterialLocalizations.of(context).backButtonTooltip,
             onPressed: () => Navigator.of(context).pop(),
           ),
         ),

--- a/lib/pages/insights_page.dart
+++ b/lib/pages/insights_page.dart
@@ -618,6 +618,7 @@ class _InsightsPageState extends State<InsightsPage> {
               // 返回按钮
               IconButton(
                 icon: const Icon(Icons.arrow_back),
+                tooltip: MaterialLocalizations.of(context).backButtonTooltip,
                 onPressed: () {
                   setState(() {
                     _showAnalysisSelection = true;

--- a/lib/pages/license_page.dart
+++ b/lib/pages/license_page.dart
@@ -674,6 +674,7 @@ class _SystemLicensesPageState extends State<SystemLicensesPage> {
                     ? null
                     : IconButton(
                         icon: const Icon(Icons.clear),
+                        tooltip: l10n.clear,
                         onPressed: () => _searchController.clear(),
                       ),
                 border: OutlineInputBorder(

--- a/lib/pages/logs_page.dart
+++ b/lib/pages/logs_page.dart
@@ -590,6 +590,7 @@ class _LogsPageState extends State<LogsPage> {
                   suffixIcon: _searchQuery != null && _searchQuery!.isNotEmpty
                       ? IconButton(
                           icon: const Icon(Icons.clear),
+                          tooltip: l10n.clear,
                           onPressed: () {
                             _searchDebounceTimer?.cancel();
                             _searchController.clear();

--- a/lib/pages/preferences_detail_page.dart
+++ b/lib/pages/preferences_detail_page.dart
@@ -56,6 +56,7 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
         scrolledUnderElevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new_rounded),
+          tooltip: MaterialLocalizations.of(context).backButtonTooltip,
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),

--- a/lib/pages/tag_settings_page.dart
+++ b/lib/pages/tag_settings_page.dart
@@ -49,6 +49,7 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
         scrolledUnderElevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new_rounded),
+          tooltip: MaterialLocalizations.of(context).backButtonTooltip,
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
@@ -190,6 +191,7 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                         ),
                         child: IconButton(
                           onPressed: () => _showIconSelector(context, l10n),
+                          tooltip: l10n.iconLabel,
                           icon: _selectedIconName != null
                               ? (IconUtils.isEmoji(_selectedIconName!)
                                   ? Text(
@@ -553,6 +555,7 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                                         Icons.delete_outline_rounded,
                                         color: colorScheme.error,
                                       ),
+                                      tooltip: l10n.delete,
                                       onPressed: () async {
                                         // 在异步操作前获取上下文的参数和服务
                                         final scaffoldMessenger =
@@ -758,6 +761,7 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                       suffixIcon: emojiSearchController.text.isNotEmpty
                           ? IconButton(
                               icon: const Icon(Icons.clear),
+                              tooltip: l10n.clear,
                               onPressed: () {
                                 emojiSearchController.clear();
                                 dialogSetState(() => searchQuery = '');

--- a/lib/pages/tag_settings_page.dart
+++ b/lib/pages/tag_settings_page.dart
@@ -210,7 +210,6 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                                   Icons.add_photo_alternate_outlined,
                                   color: colorScheme.onSurfaceVariant,
                                 ),
-                          tooltip: l10n.selectIcon,
                         ),
                       ),
                       const SizedBox(width: 12),

--- a/lib/pages/user_guide_page.dart
+++ b/lib/pages/user_guide_page.dart
@@ -410,6 +410,7 @@ class _UserGuidePageState extends State<UserGuidePage> {
                               ? [
                                   IconButton(
                                     icon: const Icon(Icons.clear),
+                                    tooltip: l10n.clear,
                                     onPressed: () => _searchController.clear(),
                                   )
                                 ]


### PR DESCRIPTION
💡 What: 在各个页面的 IconButton 控件中补充了缺失的 `tooltip` 属性。
🎯 Why: 提高无障碍功能（Accessibility），为使用屏幕阅读器的用户和需要鼠标悬停提示的用户提供更好的交互体验，同时规范代码库的使用。
♿ Accessibility: 支持屏幕阅读器朗读按钮功能，并在 Web/Desktop 端支持鼠标悬停提示。

受影响页面包括：AI 分析历史页、年度报告、分类设置、API配置、标签设置、偏好设置、系统日志等。

---
*PR created automatically by Jules for task [17866769200341555761](https://jules.google.com/task/17866769200341555761) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为各页面的 IconButton 补充本地化 tooltip，提升无障碍体验与可发现性。覆盖返回、关闭、清除、显示/隐藏、分享、删除、图标选择等操作，影响 AI 分析历史、年度报告、API Ninjas 分类选择、分类/标签设置、Hitokoto 设置、洞察、开源许可、日志、偏好详情、用户指南等页面。

- **Refactors**
  - 统一为仅图标按钮添加 tooltip，使用 `MaterialLocalizations` 与 `AppLocalizations`。
  - 更新 `.jules/palette.md`，补充规范与检测脚本说明（改进 Python 脚本；自定义 `IconButton` 封装仍可能漏检）。

<sup>Written for commit eb7d25121d90e39b5a6bdc4225436b711423ded0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **缺陷修复**
  * 为应用中多个页面的图标按钮添加了本地化工具提示，包括关闭、返回、搜索清除等操作按钮，提升了应用的易用性和无障碍支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->