### PR TITLE
🧹 移除 send_session_state.dart 中冗余的注释导入

### DIFF
--- a/lib/services/localsend/models/send_session_state.dart
+++ b/lib/services/localsend/models/send_session_state.dart
@@ -1,7 +1,6 @@
 import 'device.dart';
 import 'session_status.dart';
 import 'sending_file.dart';
-// import 'receive_session_state.dart'; // Removed - not needed
 
 class SendSessionState {
   final String sessionId;


### PR DESCRIPTION
🎯 **What:** 移除了 `lib/services/localsend/models/send_session_state.dart` 中一行注释掉的导入语句。
💡 **Why:** 该导入语句已被标记为“不再需要”，删除它可以减少代码干扰，提高代码库的可维护性和整洁度。
✅ **Verification:**
- 已通过 `dart format` 验证文件格式。
- 已通过代码评审，确认该更改是安全的，不影响功能逻辑。
- 考虑到该代码本身已被注释掉，删除它没有任何运行时风险。
✨ **Result:** 代码库变得更加整洁，减少了死代码。

---
*PR created automatically by Jules for task [3695301465034846281](https://jules.google.com/task/3695301465034846281) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
移除了 `lib/services/localsend/models/send_session_state.dart` 中已注释且不再需要的导入，清理死代码并让文件更干净。
不影响功能或运行时行为。

<sup>Written for commit 40eb69f0c7ec17f8658910f743aa47f68d6e9fef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

