### PR TITLE
🧪 标尺: 补充 SearchController 的 clearSearch 方法测试

### DIFF
--- a/.jules/caliper.md
+++ b/.jules/caliper.md
@@ -13,7 +13,5 @@
 ## 2026-04-28 - [补充 MediaOptimizationUtils 的测试]
 **盲点:** `MediaOptimizationUtils` 中的 `getMimeType` 和 `estimateOptimizedSize` 等纯函数负责媒体类型识别与大小估算，但长期缺乏单元测试覆盖。这容易在添加新的文件类型支持或调整大小估算逻辑时引入无法预料的错误。
 **对策:** 为此类明确的输入输出映射纯函数编写了极简的单元测试。覆盖了正常情况（如常见的图片、视频、音频扩展名与大小映射）、边界条件（如未知文件类型、空字符串）及容错情况（大写扩展名）。测试完全隔离并只断言基本逻辑。
-
-## 2024-05-27 - 补充 SearchController 的测试
-**盲点:** `NoteSearchController` 的 `clearSearch` 方法未经过充分测试，且其内部处理未被防抖定时器延迟的空查询清空逻辑时存在未完整重置状态的 bug。
+## 2026-05-03 - 补充 SearchController 的测试
 **对策:** 添加了针对 `clearSearch` 方法的单元测试。利用 `fake_async` 模拟防抖延时并确保方法能正确取消进行中的定时器。同时修复了代码中的 bug，确保当 `_isSearching` 为 true 时（不论 `_searchQuery` 是否为空），清除逻辑也能正确重置搜索状态并触发状态更新。

--- a/.jules/caliper.md
+++ b/.jules/caliper.md
@@ -13,3 +13,7 @@
 ## 2026-04-28 - [补充 MediaOptimizationUtils 的测试]
 **盲点:** `MediaOptimizationUtils` 中的 `getMimeType` 和 `estimateOptimizedSize` 等纯函数负责媒体类型识别与大小估算，但长期缺乏单元测试覆盖。这容易在添加新的文件类型支持或调整大小估算逻辑时引入无法预料的错误。
 **对策:** 为此类明确的输入输出映射纯函数编写了极简的单元测试。覆盖了正常情况（如常见的图片、视频、音频扩展名与大小映射）、边界条件（如未知文件类型、空字符串）及容错情况（大写扩展名）。测试完全隔离并只断言基本逻辑。
+
+## 2024-05-27 - 补充 SearchController 的测试
+**盲点:** `NoteSearchController` 的 `clearSearch` 方法未经过充分测试，且其内部处理未被防抖定时器延迟的空查询清空逻辑时存在未完整重置状态的 bug。
+**对策:** 添加了针对 `clearSearch` 方法的单元测试。利用 `fake_async` 模拟防抖延时并确保方法能正确取消进行中的定时器。同时修复了代码中的 bug，确保当 `_isSearching` 为 true 时（不论 `_searchQuery` 是否为空），清除逻辑也能正确重置搜索状态并触发状态更新。

--- a/lib/controllers/search_controller.dart
+++ b/lib/controllers/search_controller.dart
@@ -104,7 +104,7 @@ class NoteSearchController extends ChangeNotifier {
   void clearSearch() {
     // 取消可能存在的定时器
     _debounceTimer?.cancel();
-    if (_searchQuery.isNotEmpty) {
+    if (_searchQuery.isNotEmpty || _isSearching || _searchError != null) {
       _searchQuery = '';
       _isSearching = false;
       _searchError = null;

--- a/test/unit/controllers/search_controller_test.dart
+++ b/test/unit/controllers/search_controller_test.dart
@@ -90,7 +90,8 @@ void main() {
         // Trigger a search that will start a 500ms debounce timer
         controller.updateSearch('delayed query');
 
-        expect(controller.searchQuery, ''); // Query hasn't updated yet due to debounce
+        expect(controller.searchQuery,
+            ''); // Query hasn't updated yet due to debounce
 
         // Check that isSearching was set to true immediately by updateSearch
         expect(controller.isSearching, true);

--- a/test/unit/controllers/search_controller_test.dart
+++ b/test/unit/controllers/search_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/controllers/search_controller.dart';
 
@@ -39,6 +40,72 @@ void main() {
 
       controller.setSearchState(true);
       expect(notified, false);
+    });
+  });
+
+  group('NoteSearchController - clearSearch', () {
+    late NoteSearchController controller;
+
+    setUp(() {
+      controller = NoteSearchController();
+    });
+
+    test('should reset state and notify listeners when query is not empty', () {
+      // First set some state
+      controller.updateSearchImmediate('test query');
+      controller.setSearchState(true);
+      // Wait for immediate state change, note error is not directly settable here but clearing should reset it.
+
+      expect(controller.searchQuery, 'test query');
+      expect(controller.isSearching, true);
+
+      bool notified = false;
+      controller.addListener(() {
+        notified = true;
+      });
+
+      controller.clearSearch();
+
+      expect(controller.searchQuery, '');
+      expect(controller.isSearching, false);
+      expect(controller.searchError, null);
+      expect(notified, true);
+    });
+
+    test('should not notify listeners when query is already empty', () {
+      expect(controller.searchQuery, '');
+
+      bool notified = false;
+      controller.addListener(() {
+        notified = true;
+      });
+
+      controller.clearSearch();
+
+      expect(notified, false);
+    });
+
+    test('should cancel pending debounce timer', () {
+      fakeAsync((async) {
+        // Trigger a search that will start a 500ms debounce timer
+        controller.updateSearch('delayed query');
+
+        expect(controller.searchQuery, ''); // Query hasn't updated yet due to debounce
+
+        // Check that isSearching was set to true immediately by updateSearch
+        expect(controller.isSearching, true);
+
+        // Call clearSearch before the debounce timer fires
+        controller.clearSearch();
+
+        // Fast forward time past the debounce period
+        async.elapse(const Duration(milliseconds: 600));
+
+        // The delayed update should have been cancelled, so the query remains empty
+        expect(controller.searchQuery, '');
+        // clearSearch immediately sets isSearching back to false
+        expect(controller.isSearching, false);
+      });
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for `clearSearch` in `NoteSearchController` has been addressed. The method was entirely untested and contained a subtle state reset bug.
📊 **Coverage:**
- Tests verify correct state resets (`searchQuery`, `isSearching`, `searchError`).
- Tests ensure `notifyListeners` is called when state changes but NOT called when the search is already clear.
- Tests utilize `fake_async` to simulate and assert that any pending debounce timers created by `updateSearch` are correctly cancelled upon `clearSearch`.
✨ **Result:** 
- `NoteSearchController.clearSearch` is now fully tested.
- Fixed a bug where clearing a fast-typed, debounced search query could leave `_isSearching` permanently stuck at `true`.
- Improved overall test coverage and controller reliability.

---
*PR created automatically by Jules for task [12852705970191592897](https://jules.google.com/task/12852705970191592897) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `NoteSearchController.clearSearch` 添加全面测试，修复清空搜索时状态卡住的问题；修复 Dart 格式导致的 CI 失败；更新 `.jules/caliper.md` 记录此变更。

- **Bug Fixes**
  - 当查询为空但仍处于搜索中或存在错误时也执行重置：`_searchQuery=''`、`_isSearching=false`、`_searchError=null`。
  - 取消未触发的防抖定时器，避免延迟更新污染空查询。

- **Tests**
  - 覆盖 `clearSearch` 的状态重置与监听通知触发/不触发分支。
  - 使用 `fake_async` 验证防抖计时器被正确取消。

<sup>Written for commit 467fcd2ab7cb091ef6335b6ca761b6e30d5a326d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

