### PR TITLE
📏 标尺: 补充 updateSearch 测试

### DIFF
--- a/test/unit/controllers/search_controller_test.dart
+++ b/test/unit/controllers/search_controller_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:thoughtecho/controllers/search_controller.dart';
 
 void main() {
@@ -39,6 +40,152 @@ void main() {
 
       controller.setSearchState(true);
       expect(notified, false);
+    });
+  });
+
+  group('NoteSearchController - updateSearch', () {
+    late NoteSearchController controller;
+
+    setUp(() {
+      controller = NoteSearchController();
+    });
+
+    test('should handle empty string query', () {
+      controller.updateSearchImmediate('test');
+      expect(controller.searchQuery, 'test');
+
+      controller.updateSearch('');
+      expect(controller.searchQuery, '');
+      expect(controller.isSearching, false);
+      expect(controller.searchError, null);
+    });
+
+    test('should handle short string query (< 2 chars)', () {
+      controller.updateSearch('a');
+      expect(controller.searchQuery, 'a');
+      expect(controller.isSearching, false);
+      expect(controller.searchError, null);
+    });
+
+    test('should debounce normal query', () {
+      fakeAsync((async) {
+        bool notified = false;
+        controller.addListener(() {
+          notified = true;
+        });
+
+        controller.updateSearch('test query');
+
+        // Immediately sets isSearching to true
+        expect(controller.isSearching, true);
+        expect(controller.searchQuery, ''); // Query not updated yet
+
+        // Advance time by 400ms (less than 500ms debounce)
+        async.elapse(const Duration(milliseconds: 400));
+        expect(controller.searchQuery, '');
+
+        // Advance time by 100ms (total 500ms)
+        async.elapse(const Duration(milliseconds: 100));
+        expect(controller.searchQuery, 'test query');
+        expect(notified, true);
+      });
+    });
+
+    test('should cancel previous debounce timer if updated quickly', () {
+      fakeAsync((async) {
+        controller.updateSearch('test1');
+
+        async.elapse(const Duration(milliseconds: 300));
+
+        controller.updateSearch('test2');
+
+        // Advance 300ms, first query would have resolved if not cancelled,
+        // but now it's cancelled, so query should remain empty.
+        async.elapse(const Duration(milliseconds: 300));
+        expect(controller.searchQuery, '');
+
+        // Advance another 200ms (total 500ms for test2)
+        async.elapse(const Duration(milliseconds: 200));
+        expect(controller.searchQuery, 'test2');
+      });
+    });
+
+    test('should set timeout error if search takes too long', () {
+      fakeAsync((async) {
+        controller.updateSearch('test timeout');
+
+        // Advance past debounce
+        async.elapse(const Duration(milliseconds: 500));
+        expect(controller.searchQuery, 'test timeout');
+        expect(controller.isSearching, true);
+
+        // Advance past timeout (5 seconds)
+        async.elapse(const Duration(seconds: 5));
+
+        expect(controller.isSearching, false);
+        expect(controller.searchError, '搜索超时，请重试');
+      });
+    });
+
+    test('should ignore delayed results if query changes', () {
+      // Actually, timeout timer checks version.
+      fakeAsync((async) {
+        controller.updateSearch('first');
+
+        // Advance past debounce
+        async.elapse(const Duration(milliseconds: 500));
+
+        // Now it's searching 'first'. We start a new search.
+        controller.updateSearch('second');
+
+        // Advance 5 seconds to trigger first search timeout.
+        // It should NOT affect the current search because version/query changed.
+        async.elapse(const Duration(seconds: 5));
+
+        expect(controller.searchError, null);
+      });
+    });
+  });
+
+  group('NoteSearchController - other methods', () {
+    late NoteSearchController controller;
+
+    setUp(() {
+      controller = NoteSearchController();
+    });
+
+    test('updateSearchImmediate should update immediately without debounce', () {
+      fakeAsync((async) {
+        controller.updateSearchImmediate('immediate test');
+        expect(controller.searchQuery, 'immediate test');
+        expect(controller.isSearching, false);
+        expect(controller.searchError, null);
+      });
+    });
+
+    test('clearSearch should clear query immediately', () {
+      controller.updateSearchImmediate('test');
+      expect(controller.searchQuery, 'test');
+
+      controller.clearSearch();
+      expect(controller.searchQuery, '');
+      expect(controller.isSearching, false);
+      expect(controller.searchError, null);
+    });
+
+    test('resetSearchState should reset state and cancel timers', () {
+      fakeAsync((async) {
+        controller.updateSearch('test search');
+
+        controller.resetSearchState();
+
+        expect(controller.isSearching, false);
+        expect(controller.searchError, null);
+
+        // Advance past debounce to ensure it was cancelled/ignored
+        async.elapse(const Duration(milliseconds: 500));
+        expect(controller.searchQuery, ''); // Query not updated because timer/version changed
+      });
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** 补充了针对 `NoteSearchController` 中 `updateSearch` 方法及其相关辅助方法（如 `updateSearchImmediate`，`clearSearch` 以及 `resetSearchState`）的测试。由于之前的状态更新缺乏测试，且涉及防抖和延迟操作，这部分极易引发回归。

📊 **Coverage:**
新增覆盖场景：
- `updateSearch` 正常防抖处理与计时取消
- `updateSearch` 查询为空或过短的特殊场景（立即触发无延迟）
- `updateSearch` 超时场景模拟（基于 500ms debounce 和 5s timeout）
- 旧版本结果处理及过滤
- `updateSearchImmediate`, `clearSearch`, 和 `resetSearchState`

✨ **Result:** 利用 `fake_async` 使得测试无缝同步，并且在不产生实际延迟的情况下涵盖了超时与防抖逻辑，极大增强了这部分控制逻辑在重构过程中的安全感。

---
*PR created automatically by Jules for task [8999038436035218060](https://jules.google.com/task/8999038436035218060) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `NoteSearchController` 的 `updateSearch` 及相关方法补充单元测试，覆盖防抖、超时和状态重置，降低回归风险。使用 `fake_async` 模拟时间，验证 500ms 防抖、5s 超时、空/短查询的即时处理、旧结果忽略，以及 `updateSearchImmediate`、`clearSearch`、`resetSearchState` 的行为。

<sup>Written for commit aefc373f171a13222d07825d4f3a49e6eb5923fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

