### PR TITLE
📏 标尺: 补充 updateSearchImmediate 的测试

### DIFF
--- a/.jules/caliper.md
+++ b/.jules/caliper.md
@@ -15,6 +15,6 @@
 **对策:** 为此类明确的输入输出映射纯函数编写了极简的单元测试。覆盖了正常情况（如常见的图片、视频、音频扩展名与大小映射）、边界条件（如未知文件类型、空字符串）及容错情况（大写扩展名）。测试完全隔离并只断言基本逻辑。
 ## 2026-05-03 - 补充 SearchController 的测试
 **对策:** 添加了针对 `clearSearch` 方法的单元测试。利用 `fake_async` 模拟防抖延时并确保方法能正确取消进行中的定时器。同时修复了代码中的 bug，确保当 `_isSearching` 为 true 时（不论 `_searchQuery` 是否为空），清除逻辑也能正确重置搜索状态并触发状态更新。
-## 2024-05-27 - 补充 updateSearchImmediate 的测试
+## 2026-05-04 - 补充 updateSearchImmediate 的测试
 **盲点:** `NoteSearchController` 的 `updateSearchImmediate` 方法缺乏测试，导致搜索防抖取消逻辑和立即状态更新未受覆盖。
 **对策:** 在 `test/unit/controllers/search_controller_test.dart` 中新增针对 `updateSearchImmediate` 的单元测试，利用 `fakeAsync` 模拟验证正在进行的延时任务能够被正确取消，并验证正常及无变化时的状态更新情况。

--- a/.jules/caliper.md
+++ b/.jules/caliper.md
@@ -15,3 +15,6 @@
 **对策:** 为此类明确的输入输出映射纯函数编写了极简的单元测试。覆盖了正常情况（如常见的图片、视频、音频扩展名与大小映射）、边界条件（如未知文件类型、空字符串）及容错情况（大写扩展名）。测试完全隔离并只断言基本逻辑。
 ## 2026-05-03 - 补充 SearchController 的测试
 **对策:** 添加了针对 `clearSearch` 方法的单元测试。利用 `fake_async` 模拟防抖延时并确保方法能正确取消进行中的定时器。同时修复了代码中的 bug，确保当 `_isSearching` 为 true 时（不论 `_searchQuery` 是否为空），清除逻辑也能正确重置搜索状态并触发状态更新。
+## 2024-05-27 - 补充 updateSearchImmediate 的测试
+**盲点:** `NoteSearchController` 的 `updateSearchImmediate` 方法缺乏测试，导致搜索防抖取消逻辑和立即状态更新未受覆盖。
+**对策:** 在 `test/unit/controllers/search_controller_test.dart` 中新增针对 `updateSearchImmediate` 的单元测试，利用 `fakeAsync` 模拟验证正在进行的延时任务能够被正确取消，并验证正常及无变化时的状态更新情况。

--- a/test/unit/controllers/search_controller_test.dart
+++ b/test/unit/controllers/search_controller_test.dart
@@ -50,7 +50,9 @@ void main() {
       controller = NoteSearchController();
     });
 
-    test('should update query, reset states, and notify listeners when query is new', () {
+    test(
+        'should update query, reset states, and notify listeners when query is new',
+        () {
       controller.setSearchState(true);
       // It's hard to set _searchError, but we can verify it becomes null.
 
@@ -84,7 +86,8 @@ void main() {
       fakeAsync((async) {
         // Trigger a search that will start a 500ms debounce timer
         controller.updateSearch('delayed query');
-        expect(controller.searchQuery, ''); // Query hasn't updated yet due to debounce
+        expect(controller.searchQuery,
+            ''); // Query hasn't updated yet due to debounce
         expect(controller.isSearching, true);
 
         // Call updateSearchImmediate before the debounce timer fires

--- a/test/unit/controllers/search_controller_test.dart
+++ b/test/unit/controllers/search_controller_test.dart
@@ -43,6 +43,68 @@ void main() {
     });
   });
 
+  group('NoteSearchController - updateSearchImmediate', () {
+    late NoteSearchController controller;
+
+    setUp(() {
+      controller = NoteSearchController();
+    });
+
+    test('should update query, reset states, and notify listeners when query is new', () {
+      controller.setSearchState(true);
+      // It's hard to set _searchError, but we can verify it becomes null.
+
+      bool notified = false;
+      controller.addListener(() {
+        notified = true;
+      });
+
+      controller.updateSearchImmediate('immediate query');
+
+      expect(controller.searchQuery, 'immediate query');
+      expect(controller.isSearching, false);
+      expect(controller.searchError, null);
+      expect(notified, true);
+    });
+
+    test('should not notify listeners if query is unchanged', () {
+      controller.updateSearchImmediate('test query');
+      expect(controller.searchQuery, 'test query');
+
+      bool notified = false;
+      controller.addListener(() {
+        notified = true;
+      });
+
+      controller.updateSearchImmediate('test query');
+      expect(notified, false);
+    });
+
+    test('should cancel pending debounce timer', () {
+      fakeAsync((async) {
+        // Trigger a search that will start a 500ms debounce timer
+        controller.updateSearch('delayed query');
+        expect(controller.searchQuery, ''); // Query hasn't updated yet due to debounce
+        expect(controller.isSearching, true);
+
+        // Call updateSearchImmediate before the debounce timer fires
+        controller.updateSearchImmediate('immediate query');
+
+        // Check immediate update worked
+        expect(controller.searchQuery, 'immediate query');
+        expect(controller.isSearching, false);
+
+        // Fast forward time past the debounce period
+        async.elapse(const Duration(milliseconds: 600));
+
+        // The delayed update should have been cancelled, so the query remains 'immediate query'
+        expect(controller.searchQuery, 'immediate query');
+        // And it should not have become isSearching again due to delayed task firing
+        expect(controller.isSearching, false);
+      });
+    });
+  });
+
   group('NoteSearchController - clearSearch', () {
     late NoteSearchController controller;
 


### PR DESCRIPTION
🎯 **What:** The `updateSearchImmediate` method in `NoteSearchController` was previously untested, leaving a gap in validating immediate search state updates and debounce timer cancellations.
📊 **Coverage:** The new test group covers:
- The happy path: updates the query, resets `isSearching` and `searchError`, and notifies listeners.
- The no-op path: ensures listeners are not notified if the new query is identical to the current query.
- Timer cancellation: using `fakeAsync`, verifies that calling `updateSearchImmediate` correctly cancels any pending 500ms debounce timer from `updateSearch`.
✨ **Result:** Enhanced test coverage for the search controller's state management, ensuring immediate searches correctly clear asynchronous delays and update states deterministically.

---
*PR created automatically by Jules for task [11651969390980651870](https://jules.google.com/task/11651969390980651870) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `NoteSearchController` 的 `updateSearchImmediate` 补充单元测试，验证立即更新与防抖取消；修复测试文件的 Dart 格式并更新 `.jules/caliper.md` 记录变更。提升搜索状态更新的可预测性与回归保障。

- **测试**
  - 新查询：更新 query，重置 `isSearching`/`searchError`，并通知监听者
  - 无变化：相同 query 不触发通知
  - 取消定时：用 `fakeAsync` 验证可取消 `updateSearch` 的 500ms 防抖任务

<sup>Written for commit 9da38555bf7ddb229b004b5215e9f369b098884c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 为搜索控制器添加了全面的单元测试，确保搜索查询更新、错误状态清除和搜索进度指示等功能正确运行。
  * 新增测试验证了待处理搜索操作的及时取消机制，防止延迟更新对查询结果的干扰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->