### PR TITLE
🎨 Palette: Add localized tooltips to CodeBlockWidget copy button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-05-24 - Missing Tooltips on IconButtons
 **Learning:** Found multiple instances where `IconButton` widgets were missing `tooltip` properties. This affects accessibility for screen readers and tooltips on web/desktop.
 **Action:** Added semantic string tooltips or translated string references across the settings and subpages. The Python script was improved to find these, but `IconButton` wrappers can mask these errors from naive regex tools.
+## 2025-05-18 - [Localize code copy button]
+**Learning:** Hardcoded text like "复制代码" and "已复制" in `IconButton` tooltips inside `CodeBlockWidget` breaks accessibility for non-Chinese speakers using screen readers.
+**Action:** Always extract text to ARB localization files and use `AppLocalizations.of(context)` for tooltips, ensuring screen readers receive correctly localized labels for UI actions.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3652,4 +3652,6 @@
   "offlineQuoteSourceTagOnly": "Previously saved daily quotes",
   "offlineQuoteSourceAll": "Random local records",
   "noLocalSavedQuotes": "No previously saved daily quotes yet"
-}
+,
+  "copyCode": "Copy code",
+  "copiedCode": "Copied"}

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3652,4 +3652,6 @@
   "offlineQuoteSourceTagOnly": "历史保存的每日一言",
   "offlineQuoteSourceAll": "随机展示全部本地记录",
   "noLocalSavedQuotes": "还没有历史保存的每日一言"
-}
+,
+  "copyCode": "复制代码",
+  "copiedCode": "已复制"}

--- a/lib/widgets/enhanced_markdown_widgets.dart
+++ b/lib/widgets/enhanced_markdown_widgets.dart
@@ -68,7 +68,9 @@ class _CodeBlockWidgetState extends State<CodeBlockWidget> {
                     minHeight: 24,
                   ),
                   onPressed: _copyCode,
-                  tooltip: _isCopied ? '已复制' : '复制代码',
+                  tooltip: _isCopied
+                      ? AppLocalizations.of(context).copiedCode
+                      : AppLocalizations.of(context).copyCode,
                 ),
               ],
             ),

--- a/replace_code.py
+++ b/replace_code.py
@@ -1,0 +1,10 @@
+with open("lib/widgets/enhanced_markdown_widgets.dart", "r", encoding="utf-8") as f:
+    content = f.read()
+
+import re
+
+new_content = content.replace("tooltip: _isCopied ? '已复制' : '复制代码',", "tooltip: _isCopied ? AppLocalizations.of(context).copiedCode : AppLocalizations.of(context).copyCode,")
+
+with open("lib/widgets/enhanced_markdown_widgets.dart", "w", encoding="utf-8") as f:
+    f.write(new_content)
+print("Updated dart file.")

--- a/replace_markdown_widget.py
+++ b/replace_markdown_widget.py
@@ -1,0 +1,10 @@
+with open("lib/widgets/enhanced_markdown_widgets.dart", "r", encoding="utf-8") as f:
+    content = f.read()
+
+import re
+
+new_content = content.replace("tooltip: _isCopied ? '已复制' : '复制代码',", "tooltip: _isCopied ? AppLocalizations.of(context).copiedCode : AppLocalizations.of(context).copyCode,")
+
+with open("lib/widgets/enhanced_markdown_widgets.dart", "w", encoding="utf-8") as f:
+    f.write(new_content)
+print("Updated dart file.")

--- a/update_l10n.py
+++ b/update_l10n.py
@@ -1,0 +1,36 @@
+import json
+import re
+import sys
+
+def add_key_to_arb(filepath, key, value):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # We'll just insert it before the last closing brace
+    # and hope the JSON remains valid.
+
+    # Simple JSON parsing to ensure we can just add a key
+    data = json.loads(content)
+    if key in data:
+        print(f"Key {key} already exists in {filepath}")
+        return
+
+    data[key] = value
+
+    # Dump it back preserving the original format as much as possible is hard with json module
+    # So we use regex to inject it
+
+    match = re.search(r'}(\s*)$', content)
+    if match:
+        insertion = f',\n  "{key}": "{value}"'
+        new_content = content[:match.start()] + insertion + content[match.start():]
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(new_content)
+        print(f"Added {key} to {filepath}")
+    else:
+        print(f"Failed to find end of JSON in {filepath}")
+
+add_key_to_arb('lib/l10n/app_zh.arb', 'copyCode', '复制代码')
+add_key_to_arb('lib/l10n/app_en.arb', 'copyCode', 'Copy code')
+add_key_to_arb('lib/l10n/app_zh.arb', 'copiedCode', '已复制')
+add_key_to_arb('lib/l10n/app_en.arb', 'copiedCode', 'Copied')


### PR DESCRIPTION
💡 What: Updated the `CodeBlockWidget` to use localized strings for the copy button tooltip instead of hardcoded Chinese text. Added `copyCode` and `copiedCode` to ARB localization files.
🎯 Why: Enhances accessibility by ensuring screen readers announce the correct translated text for the copy button, rather than reading foreign text or failing to provide proper context.
♿ Accessibility: The `tooltip` property of the `IconButton` now relies on `AppLocalizations`, allowing assistive technologies to read "Copy code" or "Copied" correctly based on the user's selected language.

---
*PR created automatically by Jules for task [18446625906003643730](https://jules.google.com/task/18446625906003643730) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `CodeBlockWidget` 的复制按钮提示从硬编码中文改为使用 `AppLocalizations`。现在提示与读屏会按用户语言显示“复制代码/已复制”，提升可访问性。

- **New Features**
  - 在 `enhanced_markdown_widgets.dart` 中将 tooltip 切换为 `AppLocalizations.of(context).copyCode` / `copiedCode`。
  - 在 `app_en.arb` 与 `app_zh.arb` 中新增 `copyCode`、`copiedCode` 文案。

<sup>Written for commit 70abb9dfbdc507e91782b855fbdda05033299ab6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **功能改进**
  * 为代码复制按钮的提示文本添加了多语言本地化支持，现已支持英文和中文

<!-- end of auto-generated comment: release notes by coderabbit.ai -->