### PR TITLE
⚡ Bolt: optimize N+1 database queries in backup service

### DIFF
--- a/lib/services/database_backup_service.dart
+++ b/lib/services/database_backup_service.dart
@@ -455,46 +455,52 @@ class DatabaseBackupService {
           }
 
           if (!clearExisting && affectedQuoteIds.isNotEmpty) {
-            for (final quoteId in affectedQuoteIds) {
+            final quoteIdList = affectedQuoteIds.toList();
+            const int batchSize = 500;
+            final List<String> quotesToDelete = [];
+
+            for (int i = 0; i < quoteIdList.length; i += batchSize) {
+              final end = (i + batchSize < quoteIdList.length)
+                  ? i + batchSize
+                  : quoteIdList.length;
+              final batchIds = quoteIdList.sublist(i, end);
+              final placeholders = List.filled(batchIds.length, '?').join(',');
+
               final quoteRows = await txn.query(
                 'quotes',
                 columns: ['id', 'last_modified'],
-                where: 'id = ?',
-                whereArgs: [quoteId],
-                limit: 1,
+                where: 'id IN ($placeholders)',
+                whereArgs: batchIds,
               );
-              if (quoteRows.isEmpty) {
-                continue;
-              }
 
-              final localLastModified =
-                  quoteRows.first['last_modified']?.toString();
-              final localTombstone = await txn.query(
-                'quote_tombstones',
-                columns: ['deleted_at'],
-                where: 'quote_id = ?',
-                whereArgs: [quoteId],
-                limit: 1,
-              );
-              if (localTombstone.isEmpty) {
-                continue;
+              for (final row in quoteRows) {
+                final quoteId = row['id'] as String;
+                final localLastModified = row['last_modified']?.toString();
+                final tombstoneDeletedAt = localTombstoneMap[quoteId];
+
+                if (tombstoneDeletedAt == null || tombstoneDeletedAt.isEmpty) {
+                  continue;
+                }
+
+                if (localLastModified == null ||
+                    localLastModified.isEmpty ||
+                    _compareIsoTime(tombstoneDeletedAt, localLastModified) >= 0) {
+                  quotesToDelete.add(quoteId);
+                }
               }
-              final tombstoneDeletedAt =
-                  localTombstone.first['deleted_at']?.toString();
-              if (localLastModified == null || localLastModified.isEmpty) {
+            }
+
+            if (quotesToDelete.isNotEmpty) {
+              for (int i = 0; i < quotesToDelete.length; i += batchSize) {
+                final end = (i + batchSize < quotesToDelete.length)
+                    ? i + batchSize
+                    : quotesToDelete.length;
+                final batchIds = quotesToDelete.sublist(i, end);
+                final placeholders = List.filled(batchIds.length, '?').join(',');
                 await txn.delete(
                   'quotes',
-                  where: 'id = ?',
-                  whereArgs: [quoteId],
-                );
-                continue;
-              }
-
-              if (_compareIsoTime(tombstoneDeletedAt, localLastModified) >= 0) {
-                await txn.delete(
-                  'quotes',
-                  where: 'id = ?',
-                  whereArgs: [quoteId],
+                  where: 'id IN ($placeholders)',
+                  whereArgs: batchIds,
                 );
               }
             }


### PR DESCRIPTION
💡 **What:** Implemented chunked querying and batched deletion in `importDataFromMap` of `DatabaseBackupService`. Replaced individual `quotes` and `quote_tombstones` queries with a single batch query and in-memory map lookup.
🎯 **Why:** The previous implementation performed multiple database queries and deletions per affected quote ID, leading to N+1 performance bottlenecks during large data imports.
📊 **Measured Improvement:** While environmental constraints (timeouts) prevented long-running benchmarks in the sandbox, the reduction from O(N) database round-trips to O(N/500) significantly improves I/O efficiency and reduces transaction duration, especially for backups with many tombstones.

---
*PR created automatically by Jules for task [10722645163011490751](https://jules.google.com/task/10722645163011490751) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化 `DatabaseBackupService` 的导入流程，移除 N+1 查询，改为批量查询与删除。大幅减少数据库往返，导入含大量 tombstone 的备份更快。

- **Refactors**
  - 在 `importDataFromMap` 中使用分片 `IN` 查询批量读取 `quotes`（批大小 500）。
  - 复用内存 `localTombstoneMap`，不再逐条查询 `quote_tombstones`。
  - 按 `deleted_at` 与 `last_modified` 比较收集待删 ID，并用 `IN` 分批删除 `quotes`，将往返从 O(N) 降至约 O(N/500)。

<sup>Written for commit 6e81c6af46742133d9ccaee07095e7cd4ab74789. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

