### PR TITLE
🗃️ 黑匣: [完善 mDNSDiscoveryService 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -19,3 +19,7 @@
 ## 2024-05-31 - [完善 NetworkService 模块的结构化日志]
 **异常:** NetworkService 的 GET 和 POST 方法在遇到 DioException 时，只返回了携带简短 error 信息的 HttpResponse，没有使用统一的 AppLogger 进行上报；AI 流式请求和重试拦截器中的错误捕获存在空捕获或缺失堆栈信息的情况，会导致线上排查困难且掩盖了重试中途的隐蔽错误。
 **拦截:** 修改所有拦截点，强制使用 `catch (e, stack)` 进行捕获，并使用 `AppLogger.e('...', error: e, stackTrace: stack, source: 'NetworkService')` 上报。所有日志中均仅记录 url、状态码和异常对象，绝不包含用户授权凭证、请求体或响应体内容。
+
+## 2025-05-18 - 🗃️ 黑匣: [完善 mDNSDiscoveryService 模块的结构化日志]
+**异常:** [mDNSDiscoveryService 模块在启动服务和扫描时如果报错，缺少详细的堆栈信息和统一的 logError 格式。特别是 `_scanForService` 使用了 `debugPrint` 掩盖了潜在隐患。]
+**拦截:** [修改了该文件，在 catch 中统一添加 `stack` 捕获，并使用带有 error 和 stackTrace 参数的 `logError`，便于定位底层网络异常情况。]

--- a/lib/services/mdns_discovery_service.dart
+++ b/lib/services/mdns_discovery_service.dart
@@ -50,8 +50,9 @@ class MDNSDiscoveryService extends ChangeNotifier {
       _scanTimer = Timer(timeout, () {
         stopDiscovery();
       });
-    } catch (e) {
-      logError('mdns_discovery_start_fail error=$e', source: 'mDNS');
+    } catch (e, stack) {
+      logError('mdns_discovery_start_fail error=$e',
+          error: e, stackTrace: stack, source: 'mDNS');
       _isScanning = false;
       notifyListeners();
     }
@@ -93,8 +94,9 @@ class MDNSDiscoveryService extends ChangeNotifier {
           }
         }
       }
-    } catch (e) {
-      debugPrint('mDNS: 扫描 $serviceType 失败 - $e');
+    } catch (e, stack) {
+      logError('mDNS: 扫描 $serviceType 失败 - $e',
+          error: e, stackTrace: stack, source: 'mDNS');
     }
   }
 

--- a/test/unit/services/mdns_discovery_service_test.dart
+++ b/test/unit/services/mdns_discovery_service_test.dart
@@ -2,8 +2,15 @@ library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/services/mdns_discovery_service.dart';
+import 'package:thoughtecho/utils/app_logger.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    AppLogger.initialize();
+  });
+
   group('MDNSServiceRegistration', () {
     late MDNSServiceRegistration registration;
 


### PR DESCRIPTION
展示封装前后的日志内容差异，并明确声明已确认未包含任何敏感数据。
- mDNSDiscoveryService 模块在启动服务和扫描时如果报错，缺少详细的堆栈信息和统一的 logError 格式。特别是 `_scanForService` 使用了 `debugPrint` 掩盖了潜在隐患。
- 修改了该文件，在 catch 中统一添加 `stack` 捕获，并使用带有 error 和 stackTrace 参数的 `logError`，便于定位底层网络异常情况。

---
*PR created automatically by Jules for task [7213183537233726273](https://jules.google.com/task/7213183537233726273) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `MDNSDiscoveryService` 增强结构化错误日志，统一捕获堆栈并用 `logError` 上报，替换 `debugPrint`。黑匣文档已更新并确认日志不含敏感信息。

- **Bug Fixes**
  - `startDiscovery`/`_scanForService` 改为 `catch (e, stack)`，统一调用 `logError(error: e, stackTrace: stack, source: 'mDNS')`
  - 移除 `debugPrint`，使用结构化错误日志，便于定位底层网络异常
  - 测试中初始化 `AppLogger`；更新黑匣条目，注明日志不包含凭证或请求/响应体等敏感数据

<sup>Written for commit d738a0aca04dd274109af80b780eb04c8f7b131b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了服务发现功能的错误日志记录，现在包含更详细的诊断信息，有助于更好地追踪和识别潜在的网络问题。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/249)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->