### PR TITLE
🔒 修复 LocalSend HTTP 服务器绑定漏洞

### DIFF
--- a/lib/services/localsend/localsend_server.dart
+++ b/lib/services/localsend/localsend_server.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'constants.dart';
 import 'receive_controller.dart';
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:thoughtecho/utils/app_logger.dart';
 
 /// Simple HTTP server for LocalSend protocol
@@ -16,22 +17,25 @@ class LocalSendServer {
   int _port = defaultPort;
   final Set<String> _preApprovedFingerprints = {}; // 预先批准一次性
   Function(String sessionId, int totalBytes, String senderAlias)?
-      _onReceiveSessionCreated;
+  _onReceiveSessionCreated;
   Future<bool> Function(String sessionId, int totalBytes, String senderAlias)?
-      _onApprovalNeeded;
+  _onApprovalNeeded;
 
   bool get isRunning => _isRunning;
   int get port => _port;
 
   /// Start the HTTP server
+  /// [bindAddress] defaults to loopbackIPv4 for security.
+  /// Set to [InternetAddress.anyIPv4] only if network access is required and handled.
   Future<void> start({
     int? port,
+    InternetAddress? bindAddress,
     Function(String filePath)? onFileReceived,
     Function(int received, int total)? onReceiveProgress,
     Function(String sessionId, int totalBytes, String senderAlias)?
-        onReceiveSessionCreated,
+    onReceiveSessionCreated,
     Future<bool> Function(String sessionId, int totalBytes, String senderAlias)?
-        onApprovalNeeded,
+    onApprovalNeeded,
   }) async {
     if (_isRunning) return;
 
@@ -62,18 +66,25 @@ class LocalSendServer {
     // ensure fingerprint ready before advertising info endpoint
     await _receiveController.initializeFingerprint();
 
+    final address = bindAddress ?? InternetAddress.loopbackIPv4;
     try {
-      logInfo('server_start_attempt port=$_port', source: 'LocalSend');
+      logInfo(
+        'server_start_attempt address=${address.address} port=$_port',
+        source: 'LocalSend',
+      );
 
       // Try to bind to the specified port
-      _server = await HttpServer.bind(InternetAddress.anyIPv4, _port);
+      _server = await HttpServer.bind(address, _port);
       _server!.autoCompress = true;
 
       // Set up request handling
       _server!.listen(_handleRequest);
 
       _isRunning = true;
-      logInfo('server_started port=$_port', source: 'LocalSend');
+      logInfo(
+        'server_started address=${address.address} port=$_port',
+        source: 'LocalSend',
+      );
     } catch (e) {
       logWarning('server_start_fail port=$_port error=$e', source: 'LocalSend');
 
@@ -88,12 +99,15 @@ class LocalSendServer {
       for (int altPort in alternativePorts) {
         try {
           logDebug('server_try_port port=$altPort', source: 'LocalSend');
-          _server = await HttpServer.bind(InternetAddress.anyIPv4, altPort);
+          _server = await HttpServer.bind(address, altPort);
           _server!.autoCompress = true;
           _server!.listen(_handleRequest);
           _port = altPort == 0 ? _server!.port : altPort;
           _isRunning = true;
-          logInfo('server_started_alt port=$_port', source: 'LocalSend');
+          logInfo(
+            'server_started_alt address=${address.address} port=$_port',
+            source: 'LocalSend',
+          );
           break;
         } catch (e) {
           // Continue trying
@@ -129,10 +143,22 @@ class LocalSendServer {
   /// Handle incoming HTTP requests
   Future<void> _handleRequest(HttpRequest request) async {
     try {
+      final remoteAddress = request.connectionInfo?.remoteAddress;
       logDebug(
-        'req method=${request.method} path=${request.uri.path}',
+        'req method=${request.method} path=${request.uri.path} remote=${remoteAddress?.address}',
         source: 'LocalSend',
       );
+
+      // Security: Reject requests from non-safe addresses (not loopback, link-local, or private)
+      if (remoteAddress != null && !_isSafeAddress(remoteAddress)) {
+        logSecurity(
+          'blocked_request remote=${remoteAddress.address} path=${request.uri.path}',
+          source: 'LocalSend',
+        );
+        request.response.statusCode = HttpStatus.forbidden;
+        await request.response.close();
+        return;
+      }
 
       request.response.headers.add('Connection', 'keep-alive');
 
@@ -368,4 +394,29 @@ class LocalSendServer {
 
   /// Get receive controller
   ReceiveController get receiveController => _receiveController;
+
+  /// Check if the address is safe (loopback, link-local, or private network)
+  bool _isSafeAddress(InternetAddress address) =>
+      isSafeAddressForTesting(address);
+
+  @visibleForTesting
+  bool isSafeAddressForTesting(InternetAddress address) {
+    if (address.isLoopback || address.isLinkLocal) return true;
+
+    if (address.type == InternetAddressType.IPv4) {
+      final bytes = address.rawAddress;
+      // 10.0.0.0/8
+      if (bytes[0] == 10) return true;
+      // 172.16.0.0/12
+      if (bytes[0] == 172 && (bytes[1] >= 16 && bytes[1] <= 31)) return true;
+      // 192.168.0.0/16
+      if (bytes[0] == 192 && bytes[1] == 168) return true;
+    } else if (address.type == InternetAddressType.IPv6) {
+      final bytes = address.rawAddress;
+      // fc00::/7 (Unique Local Address)
+      if ((bytes[0] & 0xfe) == 0xfc) return true;
+    }
+
+    return false;
+  }
 }

--- a/lib/services/note_sync_service.dart
+++ b/lib/services/note_sync_service.dart
@@ -84,9 +84,9 @@ class NoteSyncService extends ChangeNotifier {
     required DatabaseService databaseService,
     required SettingsService settingsService,
     required AIAnalysisDatabaseService aiAnalysisDbService,
-  })  : _backupService = backupService,
-        _databaseService = databaseService,
-        _settingsService = settingsService {
+  }) : _backupService = backupService,
+       _databaseService = databaseService,
+       _settingsService = settingsService {
     AppLogger.d('NoteSyncService 构造函数完成', source: 'NoteSyncService');
   }
   bool get skipSyncConfirmation => _settingsService.syncSkipConfirm;
@@ -143,8 +143,14 @@ class NoteSyncService extends ChangeNotifier {
       // 启动LocalSend服务器
       // ensure fingerprint ready before server start
       await DeviceIdentityManager.I.getFingerprint();
+
+      // 安全性：对于点对点同步，我们必须绑定到所有接口，
+      // 以便在同一本地网络上的其他设备能够发现并访问。
+      // 访问通过 LocalSendServer 中的 _isSafeAddress 过滤进行保护，
+      // 并且任何数据传输都需要强制的手动审批机制。
       await _localSendServer!.start(
         port: defaultPort, // 明确指定端口
+        bindAddress: InternetAddress.anyIPv4,
         onFileReceived: (filePath) async {
           // 文件接收完毕后开始处理合并
           await processSyncPackage(filePath);
@@ -552,11 +558,13 @@ class NoteSyncService extends ChangeNotifier {
   }
 
   Future<void> _preflightCheck(Device target) async {
-    final dio = Dio(BaseOptions(
-      connectTimeout: const Duration(seconds: 3),
-      receiveTimeout: const Duration(seconds: 3),
-      validateStatus: (_) => true,
-    ));
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 3),
+        receiveTimeout: const Duration(seconds: 3),
+        validateStatus: (_) => true,
+      ),
+    );
     try {
       final infoUrlV2 =
           'http://${target.ip}:${target.port}/api/localsend/v2/info';
@@ -578,15 +586,9 @@ class NoteSyncService extends ChangeNotifier {
         }
       }
       if (statusCode >= 200 && statusCode < 300) {
-        AppLogger.d(
-          'Preflight OK: $statusCode',
-          source: 'NoteSyncService',
-        );
+        AppLogger.d('Preflight OK: $statusCode', source: 'NoteSyncService');
       } else {
-        AppLogger.w(
-          'Preflight warn: $statusCode',
-          source: 'NoteSyncService',
-        );
+        AppLogger.w('Preflight warn: $statusCode', source: 'NoteSyncService');
       }
     } finally {
       dio.close();
@@ -668,7 +670,8 @@ class NoteSyncService extends ChangeNotifier {
     // 通知策略：
     // 1. 状态或消息变化立即通知
     // 2. 进度变化累计 >=0.5% 或 距上次>=_minUiNotifyIntervalMs 才通知（更实时）
-    final shouldNotify = statusChanged ||
+    final shouldNotify =
+        statusChanged ||
         messageChanged ||
         progressDelta >= 0.002 || // 0.2% 进度变化就刷新
         timeDeltaMs >= _minUiNotifyIntervalMs ||
@@ -927,8 +930,7 @@ class NoteSyncService extends ChangeNotifier {
     String sessionId,
     int totalBytes,
     String senderAlias,
-  ) =>
-      _handleReceiveSessionCreated(sessionId, totalBytes, senderAlias);
+  ) => _handleReceiveSessionCreated(sessionId, totalBytes, senderAlias);
 
   @visibleForTesting
   void debugHandleReceiveProgress(int received, int total) =>

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -36,6 +36,7 @@ import 'unit/services/smart_push_security_test.dart'
     as smart_push_security_test;
 import 'unit/services/error_recovery_manager_test.dart'
     as error_recovery_manager_test;
+import 'unit/services/localsend_security_test.dart' as localsend_security_test;
 import 'storage_management_test.dart' as storage_management_test;
 import 'performance/day_period_patch_test.dart' as day_period_patch_test;
 
@@ -94,6 +95,7 @@ void main() {
       mdns_discovery_service_test.main();
       smart_push_security_test.main();
       error_recovery_manager_test.main();
+      localsend_security_test.main();
       storage_management_test.main();
       day_period_patch_test.main();
     });

--- a/test/unit/services/localsend_security_test.dart
+++ b/test/unit/services/localsend_security_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/services/localsend/localsend_server.dart';
+import 'package:meta/meta.dart';
+
+// Extension to access private method for testing
+extension LocalSendServerTest on LocalSendServer {
+  bool testIsSafeAddress(InternetAddress address) {
+    // We can't easily access private method from another file even with extension
+    // unless it's in the same library or we use a workaround.
+    // Since I can't change the library structure easily, I might make it visible for testing in the source.
+    return isSafeAddressForTesting(address);
+  }
+}
+
+void main() {
+  group('LocalSendServer Security Tests', () {
+    late LocalSendServer server;
+
+    setUp(() {
+      server = LocalSendServer();
+    });
+
+    test('isSafeAddress identifies loopback addresses as safe', () {
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('127.0.0.1')),
+        isTrue,
+      );
+      expect(server.isSafeAddressForTesting(InternetAddress('::1')), isTrue);
+    });
+
+    test('isSafeAddress identifies link-local addresses as safe', () {
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('169.254.1.1')),
+        isTrue,
+      );
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('fe80::1')),
+        isTrue,
+      );
+    });
+
+    test('isSafeAddress identifies private IPv4 ranges as safe', () {
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('10.0.0.1')),
+        isTrue,
+      );
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('10.255.255.255')),
+        isTrue,
+      );
+
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('172.16.0.1')),
+        isTrue,
+      );
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('172.31.255.255')),
+        isTrue,
+      );
+
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('192.168.1.1')),
+        isTrue,
+      );
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('192.168.255.255')),
+        isTrue,
+      );
+    });
+
+    test('isSafeAddress identifies private IPv6 (ULA) as safe', () {
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('fd00::1')),
+        isTrue,
+      );
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('fc00::1')),
+        isTrue,
+      );
+    });
+
+    test('isSafeAddress identifies public addresses as unsafe', () {
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('8.8.8.8')),
+        isFalse,
+      );
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('1.1.1.1')),
+        isFalse,
+      );
+      expect(
+        server.isSafeAddressForTesting(InternetAddress('2001:4860:4860::8888')),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** 修复了 `LocalSendServer` 中不安全的 HTTP 服务器绑定漏洞。

⚠️ **Risk:** 之前服务器默认绑定到 `anyIPv4` (0.0.0.0)，这意味着同一局域网下的任何人都可以访问该服务器。如果用户在不安全的网络环境下使用，可能会导致数据泄露或被恶意利用。

🛡️ **Solution:** 
1. 将 `LocalSendServer` 的默认绑定地址改为 `loopbackIPv4` (127.0.0.1)，实现“默认安全”。
2. 为 `start` 方法增加可选的 `bindAddress` 参数，允许调用者（如 `NoteSyncService`）显式选择绑定到所有网卡以支持 P2P 功能。
3. 引入 IP 访问控制机制 (`_isSafeAddress`)，即使绑定到所有网卡，也会拒绝来自非本地（回环、链路本地、私有网络）IP 的请求。
4. 增加了针对各种 IP 范围（回环、链路本地、私有、公有）的单元测试。

---
*PR created automatically by Jules for task [372997894277704572](https://jules.google.com/task/372997894277704572) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `LocalSendServer` 默认绑定到回环地址并加入来源 IP 访问控制，修复默认暴露在局域网的安全漏洞；`NoteSyncService` 在 P2P 同步时显式绑定 `anyIPv4` 以维持局域网可用性。

- **Bug Fixes**
  - 将服务器默认绑定改为 `InternetAddress.loopbackIPv4`；为 `start` 新增可选参数 `bindAddress`。
  - 在请求处理前校验来源 IP（回环、链路本地、私有网段、IPv6 ULA），其他来源直接 403；新增 `isSafeAddressForTesting`。
  - 绑定与日志包含 address+port，备用端口重试使用同一地址。
  - 新增单元测试覆盖回环/链路本地/私有/公有 IP；接入 `all_tests.dart`；`NoteSyncService` 启动时传 `InternetAddress.anyIPv4` 支持 P2P。

- **Migration**
  - 需要局域网访问的调用方请在 `LocalSendServer.start` 传 `bindAddress: InternetAddress.anyIPv4`。
  - 若只需本机使用，无需改动（默认监听 `127.0.0.1`）。

<sup>Written for commit 15087c115c020be4f89d57c1adeaba909fae2f2f. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/252?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

