### PR TITLE
🔒 Fix cleartext HTTP vulnerability in NoteSyncService

### DIFF
--- a/lib/services/note_sync_service.dart
+++ b/lib/services/note_sync_service.dart
@@ -428,8 +428,9 @@ class NoteSyncService extends ChangeNotifier {
     // 注意：即使本地设置了 skipSyncConfirmation，我们仍然需要发送 intent
     // 以便接收方知道即将到来的同步，并且接收方可以根据自己的设置决定是否需要审批
     try {
+      final protocol = target.https ? 'https' : 'http';
       final uri = Uri.parse(
-        'http://${target.ip}:${target.port}/api/thoughtecho/v1/sync-intent',
+        '$protocol://${target.ip}:${target.port}/api/thoughtecho/v1/sync-intent',
       );
       final fp = await DeviceIdentityManager.I.getFingerprint();
       // 直接使用 discoveryService 的设备型号，它已经正确地从设备信息中获取
@@ -566,10 +567,11 @@ class NoteSyncService extends ChangeNotifier {
       ),
     );
     try {
+      final protocol = target.https ? 'https' : 'http';
       final infoUrlV2 =
-          'http://${target.ip}:${target.port}/api/localsend/v2/info';
+          '$protocol://${target.ip}:${target.port}/api/localsend/v2/info';
       final infoUrlV1 =
-          'http://${target.ip}:${target.port}/api/localsend/v1/info';
+          '$protocol://${target.ip}:${target.port}/api/localsend/v1/info';
       int statusCode = 0;
       try {
         final resp = await dio.get(infoUrlV2);


### PR DESCRIPTION
🎯 What: Replaced hardcoded `http://` URLs with dynamic protocol resolution (`https` vs `http`) based on the target device's capabilities in `NoteSyncService`.
⚠️ Risk: Sync intents and preflight check requests containing potentially sensitive data or triggering synchronization processes were being sent in cleartext HTTP, exposing them to interception or manipulation on local networks.
🛡️ Solution: The `_sendSyncIntent` and `_preflightCheck` methods now dynamically evaluate `target.https` to construct URLs securely using `https://` if supported by the peer device, only falling back to `http://` as a last resort.

---
*PR created automatically by Jules for task [16436466364504628319](https://jules.google.com/task/16436466364504628319) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `NoteSyncService` 中同步意图与预检请求使用明文 HTTP 的问题，按对端能力优先使用 HTTPS。降低在局域网中被窃听或篡改的风险。

- **Bug Fixes**
  - 在 `_sendSyncIntent` 和 `_preflightCheck` 中基于 `target.https` 动态选择协议（`https` 优先，`http` 回退）。
  - 更新请求 URL：`/api/thoughtecho/v1/sync-intent`、`/api/localsend/v2/info`、`/api/localsend/v1/info`。

<sup>Written for commit 167fc1d9cc1aa3feb0ec02ecd592842c5e57bab6. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/255?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

