### PR TITLE
🧪 补充 NetworkService AI Header 逻辑测试

### DIFF
--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -103,22 +103,19 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
     // 时间段筛选
     if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-      final dayPeriodPlaceholders = selectedDayPeriods
-          .map((_) => '?')
-          .join(',');
+      final dayPeriodPlaceholders =
+          selectedDayPeriods.map((_) => '?').join(',');
       conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
       args.addAll(selectedDayPeriods);
     }
 
-    final whereClause = conditions.isNotEmpty
-        ? 'WHERE ${conditions.join(' AND ')}'
-        : '';
+    final whereClause =
+        conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
 
     // ⚡ Bolt: 使用标量子查询替代 LEFT JOIN 和 GROUP BY，避免在 LIMIT 分页前全表聚合的性能瓶颈
 
     final sanitizedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
-    final query =
-        '''
+    final query = '''
       SELECT 
         q.*
       FROM quotes q
@@ -230,14 +227,12 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
       if (!includeDeleted) {
         conditions.add('(q.is_deleted = 0 OR q.is_deleted IS NULL)');
       }
-      final where = conditions.isNotEmpty
-          ? 'WHERE ${conditions.join(' AND ')}'
-          : '';
+      final where =
+          conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
 
       // 只取必要列，不取 delta_content/ai_analysis/summary/keywords
       final sanitizedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
-      final query =
-          '''
+      final query = '''
         SELECT q.id, q.content, q.date, q.source, q.source_author, q.source_work,
                q.category_id, q.color_hex, q.location, q.latitude, q.longitude,
                q.weather, q.temperature, q.edit_source, q.day_period,
@@ -375,9 +370,8 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
       // 时间段筛选
       if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-        final dayPeriodPlaceholders = selectedDayPeriods
-            .map((_) => '?')
-            .join(',');
+        final dayPeriodPlaceholders =
+            selectedDayPeriods.map((_) => '?').join(',');
         conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
         args.addAll(selectedDayPeriods);
       }
@@ -396,17 +390,15 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
         finalArgs.insertAll(0, tagIds);
 
-        final whereClause = conditions.isNotEmpty
-            ? 'WHERE ${conditions.join(' AND ')}'
-            : '';
+        final whereClause =
+            conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
 
         query =
             'SELECT COUNT(DISTINCT q.id) as count FROM quotes q$joins $whereClause';
       } else {
         // 没有标签筛选，使用简单的 COUNT
-        final whereClause = conditions.isNotEmpty
-            ? 'WHERE ${conditions.join(' AND ')}'
-            : '';
+        final whereClause =
+            conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
         query = 'SELECT COUNT(*) as count FROM quotes q $whereClause';
       }
 

--- a/lib/services/localsend/localsend_server.dart
+++ b/lib/services/localsend/localsend_server.dart
@@ -5,7 +5,7 @@ import 'dart:io';
 import 'constants.dart';
 import 'receive_controller.dart';
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
+
 import 'package:thoughtecho/utils/app_logger.dart';
 
 /// Simple HTTP server for LocalSend protocol

--- a/lib/services/network_service.dart
+++ b/lib/services/network_service.dart
@@ -274,6 +274,13 @@ class NetworkService {
     );
   }
 
+  @visibleForTesting
+  Map<String, String> buildAIHeadersForTesting(
+    AIProviderSettings? provider,
+    AISettings? legacySettings,
+  ) =>
+      _buildAIHeaders(provider, legacySettings);
+
   /// 构建AI请求头
   Map<String, String> _buildAIHeaders(
     AIProviderSettings? provider,

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -37,6 +37,7 @@ import 'unit/services/smart_push_security_test.dart'
 import 'unit/services/error_recovery_manager_test.dart'
     as error_recovery_manager_test;
 import 'unit/services/localsend_security_test.dart' as localsend_security_test;
+import 'unit/services/network_service_test.dart' as network_service_test;
 import 'storage_management_test.dart' as storage_management_test;
 import 'performance/day_period_patch_test.dart' as day_period_patch_test;
 
@@ -96,6 +97,7 @@ void main() {
       smart_push_security_test.main();
       error_recovery_manager_test.main();
       localsend_security_test.main();
+      network_service_test.main();
       storage_management_test.main();
       day_period_patch_test.main();
     });

--- a/test/unit/services/localsend_security_test.dart
+++ b/test/unit/services/localsend_security_test.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/services/localsend/localsend_server.dart';
-import 'package:meta/meta.dart';
+
 
 // Extension to access private method for testing
 extension LocalSendServerTest on LocalSendServer {

--- a/test/unit/services/localsend_security_test.dart
+++ b/test/unit/services/localsend_security_test.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/services/localsend/localsend_server.dart';
 
-
 // Extension to access private method for testing
 extension LocalSendServerTest on LocalSendServer {
   bool testIsSafeAddress(InternetAddress address) {

--- a/test/unit/services/network_service_test.dart
+++ b/test/unit/services/network_service_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/services/network_service.dart';
+import 'package:thoughtecho/models/ai_provider_settings.dart';
+import 'package:thoughtecho/models/ai_settings.dart';
+
+void main() {
+  group('NetworkService AI Headers Tests', () {
+    late NetworkService networkService;
+
+    setUp(() {
+      networkService = NetworkService.instance;
+    });
+
+    test(
+        'should build default headers when both provider and legacy settings are null',
+        () {
+      final headers = networkService.buildAIHeadersForTesting(null, null);
+
+      expect(headers, isA<Map<String, String>>());
+      expect(headers.length, 1);
+      expect(headers['Content-Type'], 'application/json');
+    });
+
+    test('should build headers for Anthropic provider', () {
+      final provider = AIProviderSettings(
+        id: 'test_anthropic',
+        name: 'Anthropic',
+        apiUrl: 'https://api.anthropic.com/v1/messages',
+        apiKey: 'test-anthropic-key',
+        model: 'claude-3-haiku-20240307',
+      );
+
+      final headers = networkService.buildAIHeadersForTesting(provider, null);
+
+      expect(headers.length, 3);
+      expect(headers['Content-Type'], 'application/json');
+      expect(headers['anthropic-version'], '2023-06-01');
+      expect(headers['x-api-key'], 'test-anthropic-key');
+      expect(headers.containsKey('Authorization'), isFalse);
+    });
+
+    test('should build headers for OpenRouter provider', () {
+      final provider = AIProviderSettings(
+        id: 'test_openrouter',
+        name: 'OpenRouter',
+        apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
+        apiKey: 'test-openrouter-key',
+        model: 'openai/gpt-3.5-turbo',
+      );
+
+      final headers = networkService.buildAIHeadersForTesting(provider, null);
+
+      expect(headers.length, 4);
+      expect(headers['Content-Type'], 'application/json');
+      expect(headers['Authorization'], 'Bearer test-openrouter-key');
+      expect(headers['HTTP-Referer'], 'https://thoughtecho.app');
+      expect(headers['X-Title'], 'ThoughtEcho App');
+    });
+
+    test('should build headers for standard provider (like OpenAI)', () {
+      final provider = AIProviderSettings(
+        id: 'test_openai',
+        name: 'OpenAI',
+        apiUrl: 'https://api.openai.com/v1/chat/completions',
+        apiKey: 'test-openai-key',
+        model: 'gpt-3.5-turbo',
+      );
+
+      final headers = networkService.buildAIHeadersForTesting(provider, null);
+
+      expect(headers.length, 2);
+      expect(headers['Content-Type'], 'application/json');
+      expect(headers['Authorization'], 'Bearer test-openai-key');
+    });
+
+    test('should build headers using legacy settings if provider is null', () {
+      final legacySettings = AISettings(
+        apiUrl: 'https://legacy.api.com',
+        apiKey: 'test-legacy-key',
+        model: 'legacy-model',
+      );
+
+      final headers =
+          networkService.buildAIHeadersForTesting(null, legacySettings);
+
+      expect(headers.length, 2);
+      expect(headers['Content-Type'], 'application/json');
+      expect(headers['Authorization'], 'Bearer test-legacy-key');
+    });
+
+    test('should prioritize provider settings over legacy settings', () {
+      final provider = AIProviderSettings(
+        id: 'test_openai2',
+        name: 'OpenAI',
+        apiUrl: 'https://api.openai.com/v1/chat/completions',
+        apiKey: 'test-openai-key',
+        model: 'gpt-3.5-turbo',
+      );
+
+      final legacySettings = AISettings(
+        apiUrl: 'https://legacy.api.com',
+        apiKey: 'test-legacy-key',
+        model: 'legacy-model',
+      );
+
+      final headers =
+          networkService.buildAIHeadersForTesting(provider, legacySettings);
+
+      expect(headers.length, 2);
+      expect(headers['Content-Type'], 'application/json');
+      expect(headers['Authorization'],
+          'Bearer test-openai-key'); // Uses provider key
+    });
+  });
+}

--- a/test/unit/services/weather_service_test.dart
+++ b/test/unit/services/weather_service_test.dart
@@ -4,7 +4,7 @@ library;
 import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:mockito/annotations.dart';
+
 import 'package:thoughtecho/services/weather_service.dart';
 import 'package:thoughtecho/services/network_service.dart';
 import 'package:thoughtecho/services/weather_cache_manager.dart';

--- a/test/widget/pages/note_editor_draft_behavior_test.dart
+++ b/test/widget/pages/note_editor_draft_behavior_test.dart
@@ -14,14 +14,19 @@ import 'package:thoughtecho/services/settings_service.dart';
 import '../../test_setup.dart';
 
 class _TestSettingsService extends ChangeNotifier implements SettingsService {
+  @override
   bool get autoAttachLocation => false;
 
+  @override
   bool get autoAttachWeather => false;
 
+  @override
   String? get defaultAuthor => null;
 
+  @override
   String? get defaultSource => null;
 
+  @override
   List<String> get defaultTagIds => const [];
 
   @override


### PR DESCRIPTION
🎯 **What:** The `NetworkService._buildAIHeaders` private method, which performs essential data transformation based on configuration, lacked test coverage. 
📊 **Coverage:** A new test suite was added in `test/unit/services/network_service_test.dart` containing cases for null parameters, Anthropic provider, OpenRouter provider, standard provider, legacy configurations, and prioritization. It has also been integrated into `test/all_tests.dart`.
✨ **Result:** Test coverage improved for the core AI header processing logic, ensuring greater confidence against future regressions.

---
*PR created automatically by Jules for task [5954216513629211506](https://jules.google.com/task/5954216513629211506) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `NetworkService` 的 `_buildAIHeaders` 增加单元测试，覆盖多提供商与回退逻辑，提升请求头构建的可靠性。同步整理 SQL 拼接格式并清理少量无用导入/注解（含补齐 `@override`），无行为变化。

- **测试**
  - 新增 `test/unit/services/network_service_test.dart`：空参数、Anthropic、OpenRouter、标准提供商、旧版配置、优先级。
  - 在 `test/all_tests.dart` 注册测试套件。
  - 在 `NetworkService` 添加 `@visibleForTesting` 的 `buildAIHeadersForTesting`。

<sup>Written for commit da73eaa4b0499d5ca3d90b40a82a8259cbdfc6e6. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/259?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

