### PR TITLE
🧪 补充 refreshWeather 降级回退的测试

### DIFF
--- a/test/unit/services/weather_service_test.dart
+++ b/test/unit/services/weather_service_test.dart
@@ -58,6 +58,16 @@ class MockWeatherCacheManager extends Mock implements WeatherCacheManager {
       returnValue: Future.value(),
     );
   }
+
+  @override
+  Future<WeatherData?> loadWeatherDataIgnoreExpiry(
+      {double? latitude, double? longitude}) {
+    return super.noSuchMethod(
+      Invocation.method(#loadWeatherDataIgnoreExpiry, [],
+          {#latitude: latitude, #longitude: longitude}),
+      returnValue: Future.value(null),
+    );
+  }
 }
 
 void main() {
@@ -143,6 +153,66 @@ void main() {
       expect(weatherService.state, equals(WeatherServiceState.success));
       expect(weatherService.hasData, isTrue);
       expect(weatherService.temperatureValue, equals(20.5));
+    });
+
+    test(
+        'refreshWeather should handle API failure and fallback to expired cache',
+        () async {
+      // Arrange
+      const latitude = 39.9042;
+      const longitude = 116.4074;
+
+      when(mockCacheManager.initialize()).thenAnswer((_) async => {});
+
+      // Simulate API failure
+      when(mockNetworkService.get(
+        any,
+        timeoutSeconds: anyNamed('timeoutSeconds'),
+      )).thenAnswer((_) async => HttpResponse('', 500, headers: {}));
+
+      final expiredMockData = WeatherData(
+        key: 'partly_cloudy',
+        description: 'Partly Cloudy',
+        temperature: 15.0,
+        temperatureText: '15°C',
+        iconCode: '02d',
+        timestamp: DateTime.now().subtract(const Duration(days: 1)),
+        latitude: latitude,
+        longitude: longitude,
+      );
+
+      when(mockCacheManager.loadWeatherDataIgnoreExpiry(
+        latitude: anyNamed('latitude'),
+        longitude: anyNamed('longitude'),
+      )).thenAnswer((_) async => expiredMockData);
+
+      // Act
+      await weatherService.refreshWeather(latitude, longitude);
+
+      // Assert
+      // Verify cache loading was bypassed initially
+      verifyNever(mockCacheManager.loadWeatherData(
+        latitude: anyNamed('latitude'),
+        longitude: anyNamed('longitude'),
+      ));
+
+      // Verify network API was called
+      verify(mockNetworkService.get(
+        argThat(contains('latitude=$latitude')),
+        timeoutSeconds: anyNamed('timeoutSeconds'),
+      )).called(1);
+
+      // Verify fallback to expired cache
+      verify(mockCacheManager.loadWeatherDataIgnoreExpiry(
+        latitude: latitude,
+        longitude: longitude,
+      )).called(1);
+
+      // Verify state was updated to cached with expired data
+      expect(weatherService.state, equals(WeatherServiceState.cached));
+      expect(weatherService.hasData, isTrue);
+      expect(weatherService.temperatureValue, equals(15.0));
+      expect(weatherService.lastError, isNotNull);
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** 
补充 `WeatherService` 中的 `refreshWeather` 在网络请求失败后的测试场景。该场景下，应使用忽略过期时间的方式读取缓存来提供离线天气降级显示。

📊 **Coverage:**
- 测试了 API 故障（例如 500 错误）场景下，服务能够正确地捕获异常并拦截
- 断言了服务能够调用 `loadWeatherDataIgnoreExpiry` 加载过期的缓存
- 断言了加载过期缓存后，状态会被置为 `WeatherServiceState.cached` 并显示降级的数据

✨ **Result:**
不仅完成了针对网络成功跳过缓存功能的回归测试，还补充了当 API 请求失败时从本地容灾的错误边界条件验证，显著提升了天气获取模块的代码健壮性与测试覆盖率。

---
*PR created automatically by Jules for task [61469672905090115](https://jules.google.com/task/61469672905090115) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 WeatherService.refreshWeather 补充 API 失败场景的降级回退测试。验证会调用 loadWeatherDataIgnoreExpiry 读取过期缓存，状态变为 cached，并展示降级数据与记录 lastError。

<sup>Written for commit df4443328425e9d5ca14d17311c196b11e868667. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/262?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 测试

* 增强了天气服务的单元测试覆盖范围，以验证缓存故障回退机制。

---

**注：** 本次更新为内部测试改进，不影响用户体验。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->