### PR TITLE
🌐 译者: 提取硬编码并补全多语言词条

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -25,3 +25,8 @@
 **规则:**
 - 寻找现存翻译键值复用，并遵循极简规范。
 - 对于缺失项，新增 `manualApiTestTitle`, `manualApiTestDesc`, `testResultLabel`, `fillAllFieldsError`, `testReportTitle`, `testParamsLabel`, `keyFormatCheckLabel`, `sendRequestLabel`, `responseResultLabel` 到各语言 `arb` 文件。
+## 2024-05-26 - [提取编辑器 AI 助理特性的硬编码中文字符串]
+**发现:** 编辑器 AI 助理特性（`editor_ai_features.dart`）界面中的硬编码文本：`应用更改` 和 `附加到原文`
+**规则:**
+- 将 `应用更改` 替换为现存键值 `applyChanges`
+- 对于缺失项，新增 `appendToOriginal` (Append to Original) 到各语言 `arb` 文件，并遵循极简规范翻译。

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -31,5 +31,7 @@
   "dailyQuoteApiNinjasApiKeyConfigured": "Dienstschlüssel konfiguriert",
   "dailyQuoteApiNinjasApiKeyMissing": "Noch kein Dienstschlüssel konfiguriert",
   "dailyQuoteApiNinjasApiKeyInvalid": "Das Format des Dienstschlüssels scheint ungültig zu sein",
-  "dailyQuoteApi": "Dienstanbieter für tägliche Zitate"
+  "dailyQuoteApi": "Dienstanbieter für tägliche Zitate",
+  "applyChanges": "Änderungen übernehmen",
+  "appendToOriginal": "An Original anhängen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3660,7 +3660,8 @@
   "offlineQuoteSourceDesc": "Choose what appears on the home page when offline or when local-only is enabled",
   "offlineQuoteSourceTagOnly": "Previously saved daily quotes",
   "offlineQuoteSourceAll": "Random local records",
-  "noLocalSavedQuotes": "No previously saved daily quotes yet"
-,
+  "noLocalSavedQuotes": "No previously saved daily quotes yet",
   "copyCode": "Copy code",
-  "copiedCode": "Copied"}
+  "copiedCode": "Copied",
+  "appendToOriginal": "Append to Original"
+}

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -31,5 +31,7 @@
   "dailyQuoteApiNinjasApiKeyInvalid": "El formato de la clave de servicio parece inválido",
   "featureDailyQuote": "Cita diaria",
   "hitokotoTypeJoke": "Humor",
-  "dailyQuoteApi": "Proveedor de cita diaria"
+  "dailyQuoteApi": "Proveedor de cita diaria",
+  "applyChanges": "Aplicar cambios",
+  "appendToOriginal": "Añadir al original"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3526,5 +3526,6 @@
   "insertVideo": "Insérer une vidéo",
   "insertAudio": "Insérer un audio",
   "clipboardFoundHint": "Contenu du presse-papiers trouvé, appuyez pour ajouter comme note",
-  "operationFailedSimple": "L'opération a échoué"
+  "operationFailedSimple": "L'opération a échoué",
+  "appendToOriginal": "Ajouter à l'original"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3544,5 +3544,6 @@
   "offlineQuoteSourceTitle": "オフライン/ローカルの一言ソース",
   "offlineQuoteSourceDesc": "オフライン時やローカルのみ使用時にホーム画面に表示する内容",
   "offlineQuoteSourceTagOnly": "「今日の一言」タグのノートのみ表示",
-  "offlineQuoteSourceAll": "すべてのノートをランダムに表示"
+  "offlineQuoteSourceAll": "すべてのノートをランダムに表示",
+  "appendToOriginal": "原文に追加"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -3535,10 +3535,10 @@
   "trashRetentionPeriod": "휴지통 보관 기간",
   "trashRetentionOption7Days": "7일",
   "trashRetentionOption30Days": "30일",
-  "trashRetentionOption90Days": "90일"
-  ,"insertImage": "이미지 삽입",
+  "trashRetentionOption90Days": "90일",
+  "insertImage": "이미지 삽입",
   "insertVideo": "동영상 삽입",
   "insertAudio": "오디오 삽입",
   "clipboardFoundHint": "클립보드 내용 발견, 탭하여 노트로 추가",
-  "operationFailed": "작업 실패"
+  "appendToOriginal": "원본에 추가"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3660,7 +3660,8 @@
   "offlineQuoteSourceDesc": "无网络或仅展示本地记录时，首页显示什么内容",
   "offlineQuoteSourceTagOnly": "历史保存的每日一言",
   "offlineQuoteSourceAll": "随机展示全部本地记录",
-  "noLocalSavedQuotes": "还没有历史保存的每日一言"
-,
+  "noLocalSavedQuotes": "还没有历史保存的每日一言",
   "copyCode": "复制代码",
-  "copiedCode": "已复制"}
+  "copiedCode": "已复制",
+  "appendToOriginal": "附加到原文"
+}

--- a/lib/pages/note_editor/editor_ai_features.dart
+++ b/lib/pages/note_editor/editor_ai_features.dart
@@ -139,7 +139,7 @@ extension _NoteEditorAIFeatures on _NoteFullEditorPageState {
             polishInput,
           ), // 调用流式方法，使用正确的参数名
           displayTextTransformer: QuillAiApplyUtils.stripMediaMarkersForDisplay,
-          applyButtonText: '应用更改', // 应用按钮文本
+          applyButtonText: l10n.applyChanges, // 应用按钮文本
           onApply: (fullText) {
             // 用户点击"应用更改"时调用
             // 返回结果给showDialog的await调用
@@ -196,7 +196,7 @@ extension _NoteEditorAIFeatures on _NoteFullEditorPageState {
           textStream: aiService.streamContinueText(
             plainText,
           ), // 调用流式方法，使用正确的参数名
-          applyButtonText: '附加到原文', // 应用按钮文本
+          applyButtonText: l10n.appendToOriginal, // 应用按钮文本
           onApply: (fullText) {
             // 用户点击"附加到原文"时调用
             // 返回结果给showDialog的await调用


### PR DESCRIPTION
- 提取了 `lib/pages/note_editor/editor_ai_features.dart` 中的硬编码文本：`应用更改` 和 `附加到原文`。
- 将 `应用更改` 替换为现存翻译键 `l10n.applyChanges`。
- 补全了 `l10n.appendToOriginal` 在所有支持语言中的翻译。

---
*PR created automatically by Jules for task [15499935099252214258](https://jules.google.com/task/15499935099252214258) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将编辑器 AI 功能中的硬编码按钮文案改为使用 `l10n.applyChanges`/`l10n.appendToOriginal`。同时为 `appendToOriginal` 补全所有支持语言的翻译，提升一致性与可维护性。

<sup>Written for commit 14b35f1525c96de96ec9aa30845f567a5ec82d11. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/268?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **本地化与国际化**
  * 为编辑器AI助理功能添加了多语言支持，包括英语、德语、法语、西班牙语、日语、韩语和中文。
  * 修复了多个语言资源文件的格式问题，确保本地化文本正确映射。

* **Bug Fixes**
  * 更正了语言文件中的JSON结构和分隔符错误。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->