### PR TITLE
🎨 Palette: 修复无文本可交互组件缺少 Semantics 标签的无障碍缺陷

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,6 @@
 ## 2025-05-18 - [Localize code copy button]
 **Learning:** Hardcoded text like "复制代码" and "已复制" in `IconButton` tooltips inside `CodeBlockWidget` breaks accessibility for non-Chinese speakers using screen readers.
 **Action:** Always extract text to ARB localization files and use `AppLocalizations.of(context)` for tooltips, ensuring screen readers receive correctly localized labels for UI actions.
+## 2026-05-19 - [Fix Missing Semantic Labels for Custom GestureDetectors]
+**Learning:** Found multiple custom `GestureDetector` widgets missing `Semantics` wrappers, making interactive UI elements inaccessible to screen readers. For instance, the video placeholder in `MediaPlayerWidget` and the close button in `FeatureGuidePopover`.
+**Action:** Always wrap interactive `GestureDetector` and `InkWell` widgets (especially those without text) with `Semantics(button: true, label: ...)` to ensure keyboard navigation and screen reader accessibility.

--- a/lib/widgets/feature_guide_popover.dart
+++ b/lib/widgets/feature_guide_popover.dart
@@ -134,11 +134,11 @@ class _FeatureGuidePopoverState extends State<FeatureGuidePopover>
   Widget _buildCenteredPopover(BuildContext context) {
     return Material(
       color: Colors.black.withValues(alpha: 0.3),
-      child: GestureDetector(
-        onTap: () => _handleDismiss(),
-        child: Semantics(
-          label: 'Dismiss',
-          button: true,
+      child: Semantics(
+        label: MaterialLocalizations.of(context).closeButtonTooltip,
+        button: true,
+        child: GestureDetector(
+          onTap: () => _handleDismiss(),
           child: Center(
             child: FadeTransition(
               opacity: _fadeAnimation,
@@ -469,15 +469,19 @@ class _FeatureGuidePopoverState extends State<FeatureGuidePopover>
                   ),
                 ),
               ),
-              GestureDetector(
-                onTap: () => _handleDismiss(),
-                child: Padding(
-                  padding: const EdgeInsets.all(2),
-                  child: Icon(
-                    Icons.close,
-                    size: 14,
-                    color: theme.textTheme.bodySmall?.color?.withValues(
-                      alpha: 0.7,
+              Semantics(
+                button: true,
+                label: MaterialLocalizations.of(context).closeButtonTooltip,
+                child: GestureDetector(
+                  onTap: () => _handleDismiss(),
+                  child: Padding(
+                    padding: const EdgeInsets.all(2),
+                    child: Icon(
+                      Icons.close,
+                      size: 14,
+                      color: theme.textTheme.bodySmall?.color?.withValues(
+                        alpha: 0.7,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/widgets/media_player_widget.dart
+++ b/lib/widgets/media_player_widget.dart
@@ -423,40 +423,45 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
 
   /// 新增：视频占位符，等待用户点击
   Widget _buildVideoPlaceholder() {
-    return GestureDetector(
-      onTap: _startVideoInitialization,
-      child: Container(
-        width: widget.width ?? 300,
-        height: widget.height ?? 200,
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surfaceContainer,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+    return Semantics(
+      button: true,
+      label: l10n.clickToPlayVideo,
+      child: GestureDetector(
+        onTap: _startVideoInitialization,
+        child: Container(
+          width: widget.width ?? 300,
+          height: widget.height ?? 200,
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainer,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color:
+                  Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+            ),
           ),
-        ),
-        child: Center(
-          child: _isInitializing
-              ? _buildVideoLoadingState() // 复用加载动画
-              : Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      Icons.play_circle_outline,
-                      size: 48,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      l10n.clickToPlayVideo,
-                      style: TextStyle(
-                        color: Theme.of(
-                          context,
-                        ).colorScheme.onSurface.withValues(alpha: 0.7),
+          child: Center(
+            child: _isInitializing
+                ? _buildVideoLoadingState() // 复用加载动画
+                : Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.play_circle_outline,
+                        size: 48,
+                        color: Theme.of(context).colorScheme.primary,
                       ),
-                    ),
-                  ],
-                ),
+                      const SizedBox(height: 8),
+                      Text(
+                        l10n.clickToPlayVideo,
+                        style: TextStyle(
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                    ],
+                  ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
💡 What: 
为 `FeatureGuidePopover` 的关闭按钮（由 `GestureDetector` 包裹 `Icon` 构成）添加了 `Semantics` 包装，并配置了 `MaterialLocalizations.of(context).closeButtonTooltip` 标签。
为 `MediaPlayerWidget` 的视频点击播放占位符（同样由 `GestureDetector` 构成）添加了 `Semantics` 包装，并配置了对应的多语言提示词 `l10n.clickToPlayVideo`。

🎯 Why: 
部分使用原生 `GestureDetector` 实现的纯图标/图片区域由于缺乏明确的 `Semantics` 信息，屏幕阅读器无法将其识别为按钮或读出其功能描述。这个改进显著提升了应用的可访问性 (Accessibility)。

♿ Accessibility: 
- `FeatureGuidePopover` 的关闭操作现在能被屏幕阅读器正确宣读为“关闭”按钮。
- `MediaPlayerWidget` 在视频尚未初始化前的占位图现在可以被读出“点击以播放视频”按钮提示。

---
*PR created automatically by Jules for task [4015848958530934165](https://jules.google.com/task/4015848958530934165) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为无文本的交互区域补充 `Semantics` 标签，修复屏幕阅读器无法识别按钮的问题，整体提升可访问性。

- **Bug Fixes**
  - `FeatureGuidePopover`：为关闭操作添加 `Semantics(button: true, label: MaterialLocalizations.of(context).closeButtonTooltip)`；全屏遮罩与关闭图标均可被读为“关闭”。
  - `MediaPlayerWidget`：为视频点击播放占位符添加 `Semantics(button: true, label: l10n.clickToPlayVideo)`，屏幕阅读器可读为“点击以播放视频”。

<sup>Written for commit 70cb46970413b6ca75ac329473dc457e4237d688. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/272?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本说明

* **Bug Fixes**
  * 改进了弹窗关闭按钮的无障碍访问性，现已支持键盘导航和屏幕阅读器识别
  * 增强了视频占位符的可访问性，使用本地化标签确保屏幕阅读器可正确识别

* **Documentation**
  * 补充了交互组件语义标注的最佳实践指南，提升应用的无障碍用户体验

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->