### PR TITLE
🧹 整理: 提取应用级 Providers 到独立的构建类以提升可读性

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,9 +23,6 @@ import 'package:logging/logging.dart' as logging;
 
 // 项目内部
 import 'package:thoughtecho/services/ai_analysis_database_service.dart';
-import 'package:thoughtecho/services/note_sync_service.dart';
-import 'package:thoughtecho/services/ai_service.dart';
-import 'package:thoughtecho/services/backup_service.dart';
 import 'package:thoughtecho/services/database_service.dart';
 import 'package:thoughtecho/services/location_service.dart';
 import 'package:thoughtecho/services/mmkv_service.dart';
@@ -37,7 +34,6 @@ import 'package:thoughtecho/services/clipboard_service.dart';
 import 'package:thoughtecho/services/media_cleanup_service.dart';
 import 'package:thoughtecho/services/apk_download_service.dart';
 import 'package:thoughtecho/services/version_check_service.dart';
-import 'package:thoughtecho/services/insight_history_service.dart';
 import 'package:thoughtecho/services/connectivity_service.dart';
 import 'package:thoughtecho/services/feature_guide_service.dart';
 import 'package:thoughtecho/services/data_directory_service.dart';
@@ -47,10 +43,10 @@ import 'package:thoughtecho/services/smart_push_service.dart';
 import 'package:thoughtecho/services/background_push_handler.dart';
 import 'package:workmanager/workmanager.dart';
 import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
-import 'controllers/search_controller.dart';
 import 'utils/app_logger.dart';
 import 'utils/global_exception_handler.dart';
 import 'theme/app_theme.dart';
+import 'providers/app_providers.dart';
 import 'pages/home_page.dart';
 import 'pages/onboarding_page.dart';
 import 'pages/backup_restore_page.dart';
@@ -310,88 +306,23 @@ Future<void> main() async {
         // 使用ValueNotifier跟踪服务初始化状态
         final servicesInitialized = ValueNotifier<bool>(false);
 
-        // TODO(refactor): The provider tree is growing large. Consider grouping related
-        // providers or moving some initialization logic to a dedicated Bootstrapper class.
         runApp(
           MultiProvider(
-            providers: [
-              ChangeNotifierProvider(create: (_) => settingsService),
-              // 兼容性说明：DatabaseService现在有dispose方法，但Provider会自动处理
-              ChangeNotifierProvider(create: (_) => databaseService),
-              ChangeNotifierProvider(create: (_) => locationService),
-              ChangeNotifierProvider(create: (_) => weatherService),
-              ChangeNotifierProvider(create: (_) => clipboardService),
-              ChangeNotifierProvider(create: (_) => unifiedLogService),
-              ChangeNotifierProvider(create: (_) => appTheme),
-              ChangeNotifierProvider(create: (_) => aiAnalysisDbService),
-              ChangeNotifierProvider(create: (_) => connectivityService),
-              ChangeNotifierProvider(create: (_) => featureGuideService),
-              ChangeNotifierProvider(create: (_) => smartPushService),
-              ChangeNotifierProvider(create: (_) => NoteSearchController()),
-              ChangeNotifierProxyProvider<SettingsService,
-                  InsightHistoryService>(
-                create: (context) => InsightHistoryService(
-                  settingsService: context.read<SettingsService>(),
-                ),
-                update: (context, settingsService, insightHistoryService) =>
-                    insightHistoryService ??
-                    InsightHistoryService(settingsService: settingsService),
-              ),
-              Provider.value(
-                value: mmkvService,
-              ), // 使用 Provider.value 提供 MMKVService
-              // 提供初始化状态的值
-              Provider<ValueNotifier<bool>>.value(
-                value: servicesInitialized,
-              ),
-              ValueListenableProvider<bool>.value(value: servicesInitialized),
-              ChangeNotifierProxyProvider<SettingsService, AIService>(
-                create: (context) =>
-                    AIService(settingsService: context.read<SettingsService>()),
-                update: (context, settings, previous) =>
-                    previous ?? AIService(settingsService: settings),
-              ),
-              ProxyProvider3<DatabaseService, SettingsService,
-                  AIAnalysisDatabaseService, BackupService>(
-                update: (
-                  context,
-                  dbService,
-                  settingsService,
-                  aiService,
-                  previous,
-                ) =>
-                    BackupService(
-                  databaseService: dbService,
-                  settingsService: settingsService,
-                  aiAnalysisDbService: aiService,
-                ),
-              ),
-              ChangeNotifierProxyProvider4<BackupService, DatabaseService,
-                  SettingsService, AIAnalysisDatabaseService, NoteSyncService>(
-                create: (context) => NoteSyncService(
-                  backupService: context.read<BackupService>(),
-                  databaseService: context.read<DatabaseService>(),
-                  settingsService: context.read<SettingsService>(),
-                  aiAnalysisDbService:
-                      context.read<AIAnalysisDatabaseService>(),
-                ),
-                update: (
-                  context,
-                  backupService,
-                  databaseService,
-                  settingsService,
-                  aiAnalysisDbService,
-                  previous,
-                ) =>
-                    previous ??
-                    NoteSyncService(
-                      backupService: backupService,
-                      databaseService: databaseService,
-                      settingsService: settingsService,
-                      aiAnalysisDbService: aiAnalysisDbService,
-                    ),
-              ),
-            ],
+            providers: buildAppProviders(
+              settingsService: settingsService,
+              databaseService: databaseService,
+              locationService: locationService,
+              weatherService: weatherService,
+              clipboardService: clipboardService,
+              unifiedLogService: unifiedLogService,
+              appTheme: appTheme,
+              aiAnalysisDbService: aiAnalysisDbService,
+              connectivityService: connectivityService,
+              featureGuideService: featureGuideService,
+              smartPushService: smartPushService,
+              mmkvService: mmkvService,
+              servicesInitialized: servicesInitialized,
+            ),
             child: Builder(
               builder: (context) {
                 return MyApp(

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/foundation.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+
+import '../services/ai_analysis_database_service.dart';
+import '../services/ai_service.dart';
+import '../services/backup_service.dart';
+import '../services/clipboard_service.dart';
+import '../services/connectivity_service.dart';
+import '../services/database_service.dart';
+import '../services/feature_guide_service.dart';
+import '../services/insight_history_service.dart';
+import '../services/location_service.dart';
+import '../services/mmkv_service.dart';
+import '../services/note_sync_service.dart';
+import '../services/settings_service.dart';
+import '../services/smart_push_service.dart';
+import '../services/unified_log_service.dart';
+import '../services/weather_service.dart';
+import '../theme/app_theme.dart';
+import '../controllers/search_controller.dart';
+
+/// 构建应用级别的所有 Provider
+List<SingleChildWidget> buildAppProviders({
+  required SettingsService settingsService,
+  required DatabaseService databaseService,
+  required LocationService locationService,
+  required WeatherService weatherService,
+  required ClipboardService clipboardService,
+  required UnifiedLogService unifiedLogService,
+  required AppTheme appTheme,
+  required AIAnalysisDatabaseService aiAnalysisDbService,
+  required ConnectivityService connectivityService,
+  required FeatureGuideService featureGuideService,
+  required SmartPushService smartPushService,
+  required MMKVService mmkvService,
+  required ValueNotifier<bool> servicesInitialized,
+}) {
+  return [
+    ChangeNotifierProvider(create: (_) => settingsService),
+    // 兼容性说明：DatabaseService现在有dispose方法，但Provider会自动处理
+    ChangeNotifierProvider(create: (_) => databaseService),
+    ChangeNotifierProvider(create: (_) => locationService),
+    ChangeNotifierProvider(create: (_) => weatherService),
+    ChangeNotifierProvider(create: (_) => clipboardService),
+    ChangeNotifierProvider(create: (_) => unifiedLogService),
+    ChangeNotifierProvider(create: (_) => appTheme),
+    ChangeNotifierProvider(create: (_) => aiAnalysisDbService),
+    ChangeNotifierProvider(create: (_) => connectivityService),
+    ChangeNotifierProvider(create: (_) => featureGuideService),
+    ChangeNotifierProvider(create: (_) => smartPushService),
+    ChangeNotifierProvider(create: (_) => NoteSearchController()),
+    ChangeNotifierProxyProvider<SettingsService, InsightHistoryService>(
+      create: (context) => InsightHistoryService(
+        settingsService: context.read<SettingsService>(),
+      ),
+      update: (context, settingsService, insightHistoryService) =>
+          insightHistoryService ??
+          InsightHistoryService(settingsService: settingsService),
+    ),
+    Provider.value(
+      value: mmkvService,
+    ), // 使用 Provider.value 提供 MMKVService
+    // 提供初始化状态的值
+    Provider<ValueNotifier<bool>>.value(
+      value: servicesInitialized,
+    ),
+    ValueListenableProvider<bool>.value(value: servicesInitialized),
+    ChangeNotifierProxyProvider<SettingsService, AIService>(
+      create: (context) =>
+          AIService(settingsService: context.read<SettingsService>()),
+      update: (context, settings, previous) =>
+          previous ?? AIService(settingsService: settings),
+    ),
+    ProxyProvider3<DatabaseService, SettingsService, AIAnalysisDatabaseService,
+        BackupService>(
+      update: (
+        context,
+        dbService,
+        settingsService,
+        aiService,
+        previous,
+      ) =>
+          BackupService(
+        databaseService: dbService,
+        settingsService: settingsService,
+        aiAnalysisDbService: aiService,
+      ),
+    ),
+    ChangeNotifierProxyProvider4<BackupService, DatabaseService,
+        SettingsService, AIAnalysisDatabaseService, NoteSyncService>(
+      create: (context) => NoteSyncService(
+        backupService: context.read<BackupService>(),
+        databaseService: context.read<DatabaseService>(),
+        settingsService: context.read<SettingsService>(),
+        aiAnalysisDbService: context.read<AIAnalysisDatabaseService>(),
+      ),
+      update: (
+        context,
+        backupService,
+        databaseService,
+        settingsService,
+        aiAnalysisDbService,
+        previous,
+      ) =>
+          previous ??
+          NoteSyncService(
+            backupService: backupService,
+            databaseService: databaseService,
+            settingsService: settingsService,
+            aiAnalysisDbService: aiAnalysisDbService,
+          ),
+    ),
+  ];
+}


### PR DESCRIPTION
🎯 **What:** The large list of application-level providers inline within `runApp`'s `MultiProvider` in `lib/main.dart` has been extracted to a new dedicated builder method `buildAppProviders` located in `lib/providers/app_providers.dart`. This resolves an existing `TODO(refactor)` comment regarding the growing provider tree.

💡 **Why:** This significantly improves the readability of `main.dart` and centralizes the initialization logic of the application's global dependencies, making it easier to maintain and test.

✅ **Verification:** Verified by running `dart analyze` to ensure no unused imports remain in `main.dart` and no unresolved references exist in the new file. Also executed `bash -c 'flutter test test/all_tests.dart'` to confirm that no existing functionality was broken. 

✨ **Result:** A cleaner `main.dart` focused on app structure rather than dependency setup, leading to better maintainability and encapsulation.

---
*PR created automatically by Jules for task [1666639867520737064](https://jules.google.com/task/1666639867520737064) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `runApp` 中的应用级 `MultiProvider` 抽离为独立构建方法 `buildAppProviders`，放入新文件 `lib/providers/app_providers.dart`。`lib/main.dart` 现更专注于应用结构，无功能改动。

- **Refactors**
  - 新增 `buildAppProviders(...)`，统一返回 `List<SingleChildWidget>` 初始化全局依赖。
  - `main.dart` 改为调用该方法，移除内联 providers 与多余导入，仅保留 `providers/app_providers.dart` 引用。
  - 原有依赖关系保持一致（含 `ChangeNotifierProxyProvider`、`ProxyProvider3/4`、`ValueListenableProvider`），行为不变。
  - 精简约 85 行，提升可读性与后续测试/复用性。

<sup>Written for commit afda74da6771e9973c95da9289c2ebd3d1434c22. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/275?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

