### PR TITLE
🧹 Remove commented-out SizedBox in insights_page.dart

### DIFF
--- a/lib/pages/insights_page.dart
+++ b/lib/pages/insights_page.dart
@@ -28,7 +28,7 @@ class InsightsPage extends StatefulWidget {
 class _InsightsPageState extends State<InsightsPage> {
   bool _isLoading = false;
   Stream<String>?
-      _insightsStream; // Used only to provide stream to StreamBuilder for connection state
+  _insightsStream; // Used only to provide stream to StreamBuilder for connection state
   bool _isGenerating = false; // 新增状态变量表示是否正在生成
   bool _showAnalysisSelection = true; // 控制显示分析选择还是结果
   final TextEditingController _customPromptController = TextEditingController();
@@ -37,7 +37,7 @@ class _InsightsPageState extends State<InsightsPage> {
   String _accumulatedInsightsText =
       ''; // Added state variable for accumulated insights text
   StreamSubscription<String>?
-      _insightsSubscription; // Stream subscription for manual accumulation
+  _insightsSubscription; // Stream subscription for manual accumulation
 
   // 分析类型
   List<Map<String, dynamic>> _getAnalysisTypes(AppLocalizations l10n) {
@@ -421,8 +421,8 @@ class _InsightsPageState extends State<InsightsPage> {
         analysisStyle: _selectedAnalysisStyle,
         customPrompt:
             _showCustomPrompt && _customPromptController.text.isNotEmpty
-                ? _customPromptController.text
-                : null,
+            ? _customPromptController.text
+            : null,
       );
 
       if (!mounted) {
@@ -578,9 +578,9 @@ class _InsightsPageState extends State<InsightsPage> {
                 _isGenerating
                     ? l10n.viewing
                     : (_accumulatedInsightsText.isNotEmpty && !_isLoading)
-                        ? l10n
-                            .viewHistory // Reuse "View History" or similar, or just "View Result"
-                        : l10n.startAnalysis,
+                    ? l10n
+                          .viewHistory // Reuse "View History" or similar, or just "View Result"
+                    : l10n.startAnalysis,
               ),
               icon: _isGenerating
                   ? const SizedBox(
@@ -667,8 +667,6 @@ class _InsightsPageState extends State<InsightsPage> {
         children: [
           // 收藏功能移至周期报告页，智能洞察页专注AI分析
           // _buildWeeklyFavoritesSection(theme),
-
-          // const SizedBox(height: 24),
           Text(
             l10n.selectAnalysisMethod,
             style: theme.textTheme.titleMedium?.copyWith(
@@ -734,8 +732,9 @@ class _InsightsPageState extends State<InsightsPage> {
                     color: isSelected
                         ? theme.colorScheme.onSecondaryContainer
                         : theme.colorScheme.onSurface,
-                    fontWeight:
-                        isSelected ? FontWeight.bold : FontWeight.normal,
+                    fontWeight: isSelected
+                        ? FontWeight.bold
+                        : FontWeight.normal,
                   ),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(20),
@@ -766,8 +765,9 @@ class _InsightsPageState extends State<InsightsPage> {
                     )
                   : null,
             ),
-            padding:
-                _showCustomPrompt ? const EdgeInsets.all(16) : EdgeInsets.zero,
+            padding: _showCustomPrompt
+                ? const EdgeInsets.all(16)
+                : EdgeInsets.zero,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -1138,53 +1138,57 @@ class _InsightsPageState extends State<InsightsPage> {
                           data:
                               _accumulatedInsightsText, // Use accumulated text
                           selectable: true,
-                          styleSheet:
-                              MarkdownStyleSheet.fromTheme(theme).copyWith(
-                            p: theme.textTheme.bodyMedium?.copyWith(
-                              height: 1.6,
-                              fontSize: 16,
-                            ),
-                            h1: theme.textTheme.headlineMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: theme.primaryColor,
-                              height: 1.5,
-                            ),
-                            h2: theme.textTheme.titleLarge?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: theme.colorScheme.onSurface,
-                              height: 1.5,
-                            ),
-                            h3: theme.textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.w600,
-                              height: 1.4,
-                            ),
-                            listBullet: theme.textTheme.bodyMedium
-                                ?.copyWith(color: theme.primaryColor),
-                            blockquote: theme.textTheme.bodyMedium?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
-                              fontStyle: FontStyle.italic,
-                            ),
-                            blockquoteDecoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest
-                                  .withValues(alpha: 0.5),
-                              borderRadius: BorderRadius.circular(8),
-                              border: Border(
-                                left: BorderSide(
+                          styleSheet: MarkdownStyleSheet.fromTheme(theme)
+                              .copyWith(
+                                p: theme.textTheme.bodyMedium?.copyWith(
+                                  height: 1.6,
+                                  fontSize: 16,
+                                ),
+                                h1: theme.textTheme.headlineMedium?.copyWith(
+                                  fontWeight: FontWeight.bold,
                                   color: theme.primaryColor,
-                                  width: 4,
+                                  height: 1.5,
+                                ),
+                                h2: theme.textTheme.titleLarge?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                  color: theme.colorScheme.onSurface,
+                                  height: 1.5,
+                                ),
+                                h3: theme.textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                  height: 1.4,
+                                ),
+                                listBullet: theme.textTheme.bodyMedium
+                                    ?.copyWith(color: theme.primaryColor),
+                                blockquote: theme.textTheme.bodyMedium
+                                    ?.copyWith(
+                                      color: theme.colorScheme.onSurfaceVariant,
+                                      fontStyle: FontStyle.italic,
+                                    ),
+                                blockquoteDecoration: BoxDecoration(
+                                  color: theme
+                                      .colorScheme
+                                      .surfaceContainerHighest
+                                      .withValues(alpha: 0.5),
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border(
+                                    left: BorderSide(
+                                      color: theme.primaryColor,
+                                      width: 4,
+                                    ),
+                                  ),
+                                ),
+                                code: theme.textTheme.bodySmall?.copyWith(
+                                  fontFamily: 'monospace',
+                                  backgroundColor:
+                                      theme.colorScheme.surfaceContainerHighest,
+                                ),
+                                codeblockDecoration: BoxDecoration(
+                                  color:
+                                      theme.colorScheme.surfaceContainerHighest,
+                                  borderRadius: BorderRadius.circular(8),
                                 ),
                               ),
-                            ),
-                            code: theme.textTheme.bodySmall?.copyWith(
-                              fontFamily: 'monospace',
-                              backgroundColor:
-                                  theme.colorScheme.surfaceContainerHighest,
-                            ),
-                            codeblockDecoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest,
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                          ),
                         ),
                       ],
                     ),

--- a/lib/pages/insights_page.dart
+++ b/lib/pages/insights_page.dart
@@ -28,7 +28,7 @@ class InsightsPage extends StatefulWidget {
 class _InsightsPageState extends State<InsightsPage> {
   bool _isLoading = false;
   Stream<String>?
-  _insightsStream; // Used only to provide stream to StreamBuilder for connection state
+      _insightsStream; // Used only to provide stream to StreamBuilder for connection state
   bool _isGenerating = false; // 新增状态变量表示是否正在生成
   bool _showAnalysisSelection = true; // 控制显示分析选择还是结果
   final TextEditingController _customPromptController = TextEditingController();
@@ -37,7 +37,7 @@ class _InsightsPageState extends State<InsightsPage> {
   String _accumulatedInsightsText =
       ''; // Added state variable for accumulated insights text
   StreamSubscription<String>?
-  _insightsSubscription; // Stream subscription for manual accumulation
+      _insightsSubscription; // Stream subscription for manual accumulation
 
   // 分析类型
   List<Map<String, dynamic>> _getAnalysisTypes(AppLocalizations l10n) {
@@ -421,8 +421,8 @@ class _InsightsPageState extends State<InsightsPage> {
         analysisStyle: _selectedAnalysisStyle,
         customPrompt:
             _showCustomPrompt && _customPromptController.text.isNotEmpty
-            ? _customPromptController.text
-            : null,
+                ? _customPromptController.text
+                : null,
       );
 
       if (!mounted) {
@@ -578,9 +578,9 @@ class _InsightsPageState extends State<InsightsPage> {
                 _isGenerating
                     ? l10n.viewing
                     : (_accumulatedInsightsText.isNotEmpty && !_isLoading)
-                    ? l10n
-                          .viewHistory // Reuse "View History" or similar, or just "View Result"
-                    : l10n.startAnalysis,
+                        ? l10n
+                            .viewHistory // Reuse "View History" or similar, or just "View Result"
+                        : l10n.startAnalysis,
               ),
               icon: _isGenerating
                   ? const SizedBox(
@@ -732,9 +732,8 @@ class _InsightsPageState extends State<InsightsPage> {
                     color: isSelected
                         ? theme.colorScheme.onSecondaryContainer
                         : theme.colorScheme.onSurface,
-                    fontWeight: isSelected
-                        ? FontWeight.bold
-                        : FontWeight.normal,
+                    fontWeight:
+                        isSelected ? FontWeight.bold : FontWeight.normal,
                   ),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(20),
@@ -765,9 +764,8 @@ class _InsightsPageState extends State<InsightsPage> {
                     )
                   : null,
             ),
-            padding: _showCustomPrompt
-                ? const EdgeInsets.all(16)
-                : EdgeInsets.zero,
+            padding:
+                _showCustomPrompt ? const EdgeInsets.all(16) : EdgeInsets.zero,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -1138,57 +1136,53 @@ class _InsightsPageState extends State<InsightsPage> {
                           data:
                               _accumulatedInsightsText, // Use accumulated text
                           selectable: true,
-                          styleSheet: MarkdownStyleSheet.fromTheme(theme)
-                              .copyWith(
-                                p: theme.textTheme.bodyMedium?.copyWith(
-                                  height: 1.6,
-                                  fontSize: 16,
-                                ),
-                                h1: theme.textTheme.headlineMedium?.copyWith(
-                                  fontWeight: FontWeight.bold,
+                          styleSheet:
+                              MarkdownStyleSheet.fromTheme(theme).copyWith(
+                            p: theme.textTheme.bodyMedium?.copyWith(
+                              height: 1.6,
+                              fontSize: 16,
+                            ),
+                            h1: theme.textTheme.headlineMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: theme.primaryColor,
+                              height: 1.5,
+                            ),
+                            h2: theme.textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: theme.colorScheme.onSurface,
+                              height: 1.5,
+                            ),
+                            h3: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              height: 1.4,
+                            ),
+                            listBullet: theme.textTheme.bodyMedium
+                                ?.copyWith(color: theme.primaryColor),
+                            blockquote: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                              fontStyle: FontStyle.italic,
+                            ),
+                            blockquoteDecoration: BoxDecoration(
+                              color: theme.colorScheme.surfaceContainerHighest
+                                  .withValues(alpha: 0.5),
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border(
+                                left: BorderSide(
                                   color: theme.primaryColor,
-                                  height: 1.5,
-                                ),
-                                h2: theme.textTheme.titleLarge?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: theme.colorScheme.onSurface,
-                                  height: 1.5,
-                                ),
-                                h3: theme.textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                  height: 1.4,
-                                ),
-                                listBullet: theme.textTheme.bodyMedium
-                                    ?.copyWith(color: theme.primaryColor),
-                                blockquote: theme.textTheme.bodyMedium
-                                    ?.copyWith(
-                                      color: theme.colorScheme.onSurfaceVariant,
-                                      fontStyle: FontStyle.italic,
-                                    ),
-                                blockquoteDecoration: BoxDecoration(
-                                  color: theme
-                                      .colorScheme
-                                      .surfaceContainerHighest
-                                      .withValues(alpha: 0.5),
-                                  borderRadius: BorderRadius.circular(8),
-                                  border: Border(
-                                    left: BorderSide(
-                                      color: theme.primaryColor,
-                                      width: 4,
-                                    ),
-                                  ),
-                                ),
-                                code: theme.textTheme.bodySmall?.copyWith(
-                                  fontFamily: 'monospace',
-                                  backgroundColor:
-                                      theme.colorScheme.surfaceContainerHighest,
-                                ),
-                                codeblockDecoration: BoxDecoration(
-                                  color:
-                                      theme.colorScheme.surfaceContainerHighest,
-                                  borderRadius: BorderRadius.circular(8),
+                                  width: 4,
                                 ),
                               ),
+                            ),
+                            code: theme.textTheme.bodySmall?.copyWith(
+                              fontFamily: 'monospace',
+                              backgroundColor:
+                                  theme.colorScheme.surfaceContainerHighest,
+                            ),
+                            codeblockDecoration: BoxDecoration(
+                              color: theme.colorScheme.surfaceContainerHighest,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
                         ),
                       ],
                     ),


### PR DESCRIPTION
🎯 What: Removed a commented-out `SizedBox` from `lib/pages/insights_page.dart`.
💡 Why: To clean up dead code and improve code readability and maintainability.
✅ Verification: Ran `dart format`, `flutter analyze`, and `flutter test test/all_tests.dart` to ensure no functionality was broken.
✨ Result: Cleaner code in `InsightsPage` with slightly reduced file noise.

---
*PR created automatically by Jules for task [1702932437909312487](https://jules.google.com/task/1702932437909312487) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
移除 `lib/pages/insights_page.dart` 中注释掉的 `SizedBox` 并使用 `dart format` 整理格式，清理死代码、降低文件噪音；无功能变更。已运行 `flutter analyze` 与 `flutter test test/all_tests.dart` 验证通过。

<sup>Written for commit 1bb9f54f2994e817c4f8882836ec9547edacc30b. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/277?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新说明

* **代码维护**
  * 进行了代码结构和格式优化调整，无功能变更。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->