### PR TITLE
🧪 [testing] add test for HttpUtils empty API response edge cases

### DIFF
--- a/lib/utils/http_utils.dart
+++ b/lib/utils/http_utils.dart
@@ -11,6 +11,11 @@ class HttpUtils {
   // 单例Dio实例
   static Dio? _dioInstance;
 
+  @visibleForTesting
+  static set dioInstanceForTesting(Dio? dio) {
+    _dioInstance = dio;
+  }
+
   // 获取Dio实例
   static Dio get _dio {
     if (_dioInstance == null) {

--- a/test/unit/utils/http_utils_test.dart
+++ b/test/unit/utils/http_utils_test.dart
@@ -1,7 +1,35 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dio/dio.dart';
+import 'package:mockito/mockito.dart';
 import 'package:thoughtecho/utils/http_utils.dart';
 import 'dart:convert';
+
+class MockDio extends Mock implements Dio {
+  @override
+  Future<Response<T>> get<T>(
+    String? path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    CancelToken? cancelToken,
+    ProgressCallback? onReceiveProgress,
+  }) {
+    return super.noSuchMethod(
+      Invocation.method(#get, [
+        path
+      ], {
+        #data: data,
+        #queryParameters: queryParameters,
+        #options: options,
+        #cancelToken: cancelToken,
+        #onReceiveProgress: onReceiveProgress,
+      }),
+      returnValue: Future.value(Response<T>(
+        requestOptions: RequestOptions(path: path ?? ''),
+      )),
+    ) as Future<Response<T>>;
+  }
+}
 
 void main() {
   group('HttpUtils._convertDioResponseToHttpResponse', () {
@@ -106,6 +134,53 @@ void main() {
       final result = HttpUtils.convertDioResponseToHttpResponse(dioResponse);
 
       expect(result.statusCode, 0); // Default when null
+    });
+  });
+
+  group('HttpUtils.secureGet edge cases', () {
+    late MockDio mockDio;
+
+    setUp(() {
+      mockDio = MockDio();
+      HttpUtils.dioInstanceForTesting = mockDio;
+    });
+
+    tearDown(() {
+      HttpUtils.dioInstanceForTesting = null;
+    });
+
+    test('should handle empty response body gracefully', () async {
+      when(mockDio.get<dynamic>(
+        any,
+        options: anyNamed('options'),
+      )).thenAnswer((_) async => Response<dynamic>(
+            requestOptions: RequestOptions(path: 'https://api.example.com'),
+            statusCode: 200,
+            data: '', // Empty body
+            headers: Headers(),
+          ));
+
+      final result = await HttpUtils.secureGet('https://api.example.com');
+
+      expect(result.statusCode, 200);
+      expect(result.body, '');
+    });
+
+    test('should handle null response body gracefully', () async {
+      when(mockDio.get<dynamic>(
+        any,
+        options: anyNamed('options'),
+      )).thenAnswer((_) async => Response<dynamic>(
+            requestOptions: RequestOptions(path: 'https://api.example.com'),
+            statusCode: 200,
+            data: null, // Null body
+            headers: Headers(),
+          ));
+
+      final result = await HttpUtils.secureGet('https://api.example.com');
+
+      expect(result.statusCode, 200);
+      expect(result.body, 'null');
     });
   });
 }


### PR DESCRIPTION
🎯 **What:** The untested edge case for empty (`''`) and `null` API responses in `HttpUtils.secureGet` has been covered. A `@visibleForTesting` setter for injecting a mock `Dio` instance was added to `HttpUtils`, enabling tests to supply mock network behaviors.
📊 **Coverage:** Two edge cases in HTTP response handling are now explicitly tested: gracefully handling an empty string `''` body, and gracefully handling a `null` body. A manual `MockDio` implementation was used to prevent timeout problems related to `build_runner`.
✨ **Result:** Test coverage for `HttpUtils.secureGet` edge cases is improved, ensuring the app handles empty/null Dio responses predictably.

---
*PR created automatically by Jules for task [233353931723453283](https://jules.google.com/task/233353931723453283) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `HttpUtils.secureGet` 补充空字符串和 null 响应体的单测，确保空/空值响应被稳定处理。新增 `@visibleForTesting` 的 `dioInstanceForTesting` 注入口，便于在测试中注入 `dio` mock。

- **Refactors**
  - 新增 `HttpUtils.dioInstanceForTesting` 以注入 `Dio`（仅测试可见）
  - 使用手写 `MockDio` 覆盖 `get`，避免 `build_runner` 超时问题

<sup>Written for commit 29f4a24ac6f5f7cd8b2b0c658c237cdde7c99ba0. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/281?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

