### PR TITLE
🧪 [testing improvement] Add tests for LocalSend SendSession model

### DIFF
--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -39,6 +39,7 @@ import 'unit/services/error_recovery_manager_test.dart'
 import 'unit/services/intelligent_memory_manager_test.dart'
     as intelligent_memory_manager_test;
 import 'unit/services/localsend_security_test.dart' as localsend_security_test;
+import 'unit/services/localsend/send_session_test.dart' as send_session_test;
 import 'unit/services/network_service_test.dart' as network_service_test;
 import 'unit/services/webdav_sync_service_test.dart'
     as webdav_sync_service_test;
@@ -106,6 +107,7 @@ void main() {
       smart_push_security_test.main();
       error_recovery_manager_test.main();
       localsend_security_test.main();
+      send_session_test.main();
       network_service_test.main();
       storage_management_test.main();
       day_period_patch_test.main();

--- a/test/unit/services/localsend/send_session_test.dart
+++ b/test/unit/services/localsend/send_session_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/services/localsend/localsend_send_provider.dart';
+import 'package:thoughtecho/services/localsend/models/device.dart';
+import 'package:thoughtecho/services/localsend/models/session_status.dart';
+import 'dart:io';
+
+void main() {
+  group('SendSession Tests', () {
+    test('Can create a SendSession instance', () {
+      final session = SendSession(
+        sessionId: 'test-session-id',
+        target: Device.empty,
+        files: [],
+        status: SessionStatus.waiting,
+      );
+
+      expect(session.sessionId, 'test-session-id');
+      expect(session.remoteSessionId, isNull);
+      expect(session.target, Device.empty);
+      expect(session.files, isEmpty);
+      expect(session.status, SessionStatus.waiting);
+      expect(session.fileTokens, isNull);
+      expect(session.errorMessage, isNull);
+    });
+
+    group('copyWith Tests', () {
+      test('copyWith updates specified fields', () {
+        final session = SendSession(
+          sessionId: 'test-session-id',
+          target: Device.empty,
+          files: [],
+          status: SessionStatus.waiting,
+        );
+
+        final newTarget = Device.empty.copyWith(alias: 'new-alias');
+        final newFiles = [File('test.txt')];
+        final newTokens = {'test.txt': 'token123'};
+
+        final updatedSession = session.copyWith(
+          sessionId: 'new-session-id',
+          remoteSessionId: 'remote-id',
+          target: newTarget,
+          files: newFiles,
+          status: SessionStatus.sending,
+          fileTokens: newTokens,
+          errorMessage: 'error',
+        );
+
+        expect(updatedSession.sessionId, 'new-session-id');
+        expect(updatedSession.remoteSessionId, 'remote-id');
+        expect(updatedSession.target, newTarget);
+        expect(updatedSession.files, newFiles);
+        expect(updatedSession.status, SessionStatus.sending);
+        expect(updatedSession.fileTokens, newTokens);
+        expect(updatedSession.errorMessage, 'error');
+      });
+
+      test('copyWith retains old fields when not specified', () {
+        final session = SendSession(
+          sessionId: 'test-session-id',
+          remoteSessionId: 'remote-id',
+          target: Device.empty,
+          files: [],
+          status: SessionStatus.waiting,
+          fileTokens: {'file': 'token'},
+          errorMessage: 'error',
+        );
+
+        final updatedSession = session.copyWith();
+
+        expect(updatedSession.sessionId, session.sessionId);
+        expect(updatedSession.remoteSessionId, session.remoteSessionId);
+        expect(updatedSession.target, session.target);
+        expect(updatedSession.files, session.files);
+        expect(updatedSession.status, session.status);
+        expect(updatedSession.fileTokens, session.fileTokens);
+        expect(updatedSession.errorMessage, session.errorMessage);
+      });
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `SendSession` data model in `lib/services/localsend/localsend_send_provider.dart` was missing unit tests. It is a critical data class that holds the state of a file transfer session.

📊 **Coverage:** What scenarios are now tested
- Initialization with required properties.
- Full overriding via the `copyWith` method to verify new fields are updated.
- Partial overriding via the `copyWith` method to verify omitted fields retain their existing values.

✨ **Result:** The improvement in test coverage
Increased test coverage for LocalSend data models, ensuring stability during future refactoring of file sending mechanisms.

---
*PR created automatically by Jules for task [12607363764563017669](https://jules.google.com/task/12607363764563017669) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 LocalSend 的 `SendSession` 模型新增单元测试，覆盖初始化、`copyWith` 全量更新和部分更新（未传字段保持原值）。并把测试加入 `test/all_tests.dart`，减少回归风险。

<sup>Written for commit 98665a4c79c54b75b0d8d001241ae87d4b41b73c. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/282?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **Tests**
  * 新增 SendSession 单元测试套件，验证构造函数初始化与复制方法功能
  * 更新测试入口聚合清单，将新增测试纳入 Service Tests 组执行

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->