### PR TITLE
🧪 [补充 renderLineNumbers 的单元测试]

### DIFF
--- a/lib/constants/card_templates.dart
+++ b/lib/constants/card_templates.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
+
 import '../models/generated_card.dart';
 
 /// 卡片模板常量 - 优化版
@@ -1029,21 +1031,6 @@ ${_renderTextLines(textLines, 200.0, contentStartY, _contentFontSize, '#881337',
         (contentAreaHeight - contentHeight) / 2 +
         contentFontSize;
 
-    // 生成行号
-    String renderLineNumbers(
-      int count,
-      double startY,
-      double lineSpacing,
-      double fontSize,
-    ) {
-      final buffer = StringBuffer();
-      for (int i = 0; i < count; i++) {
-        buffer.writeln(
-            '<text x="50" y="${startY + i * lineSpacing}" text-anchor="end" fill="#4b5563" font-family="monospace" font-size="${fontSize.toStringAsFixed(0)}">${i + 1}</text>');
-      }
-      return buffer.toString();
-    }
-
     return '''
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 $_viewBoxWidth $_viewBoxHeight" preserveAspectRatio="xMidYMid meet">
   <!-- 背景 -->
@@ -1061,7 +1048,7 @@ ${_renderTextLines(textLines, 200.0, contentStartY, _contentFontSize, '#881337',
   <rect x="0" y="40" width="60" height="560" fill="#1e1e1e"/>
   
   <!-- 行号 -->
-  ${renderLineNumbers(textLines.length, contentStartY, contentFontSize * _lineHeight, lineNumberFontSize)}
+  ${CardTemplates.renderLineNumbers(textLines.length, contentStartY, contentFontSize * _lineHeight, lineNumberFontSize)}
 
   <!-- 内容文字 (左对齐) -->
   ${(() {
@@ -1968,6 +1955,21 @@ ${_renderTextLines(textLines, 200.0, contentStartY, _contentFontSize, '#ffffff',
   static String _capitalizeFirst(String text) {
     if (text.isEmpty) return text;
     return text[0].toUpperCase() + text.substring(1);
+  }
+
+  @visibleForTesting
+  static String renderLineNumbers(
+    int count,
+    double startY,
+    double lineSpacing,
+    double fontSize,
+  ) {
+    final buffer = StringBuffer();
+    for (int i = 0; i < count; i++) {
+      buffer.writeln(
+          '<text x="50" y="${startY + i * lineSpacing}" text-anchor="end" fill="#4b5563" font-family="monospace" font-size="${fontSize.toStringAsFixed(0)}">${i + 1}</text>');
+    }
+    return buffer.toString();
   }
 
   /// XML转义

--- a/lib/services/database/database_query_mixin.dart
+++ b/lib/services/database/database_query_mixin.dart
@@ -179,24 +179,22 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
         });
 
         // 异步执行查询
-        query()
-            .then((result) {
-              timeoutTimer?.cancel();
-              if (!completer.isCompleted) {
-                completer.complete(result);
-              }
-            })
-            .catchError((error) {
-              timeoutTimer?.cancel();
-              if (!completer.isCompleted) {
-                logError(
-                  '数据库查询失败: $error',
-                  error: error,
-                  source: 'DatabaseService',
-                );
-                completer.completeError(error);
-              }
-            });
+        query().then((result) {
+          timeoutTimer?.cancel();
+          if (!completer.isCompleted) {
+            completer.complete(result);
+          }
+        }).catchError((error) {
+          timeoutTimer?.cancel();
+          if (!completer.isCompleted) {
+            logError(
+              '数据库查询失败: $error',
+              error: error,
+              source: 'DatabaseService',
+            );
+            completer.completeError(error);
+          }
+        });
 
         final result = await completer.future;
         timeoutTimer.cancel();
@@ -298,9 +296,8 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
 
     // 时间段筛选
     if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-      final dayPeriodPlaceholders = selectedDayPeriods
-          .map((_) => '?')
-          .join(',');
+      final dayPeriodPlaceholders =
+          selectedDayPeriods.map((_) => '?').join(',');
       conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
       args.addAll(selectedDayPeriods);
     }
@@ -338,9 +335,8 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     joinClause = '';
     groupByClause = '';
 
-    final where = conditions.isNotEmpty
-        ? 'WHERE ${conditions.join(' AND ')}'
-        : '';
+    final where =
+        conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
 
     final correctedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
 
@@ -348,8 +344,7 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     // 优化：指定查询列，排除大文本字段(ai_analysis, summary等)以提升列表加载性能
     // 注意：delta_content 必须保留！列表卡片通过 QuoteContent 组件渲染富文本（加粗、图片等）
     // 性能提升：(SELECT GROUP_CONCAT(tag_id) ...) 仅对 LIMIT 返回的数据执行
-    final query =
-        '''
+    final query = '''
       SELECT
         q.id, q.content, q.date, q.source, q.source_author, q.source_work,
         q.category_id, q.color_hex, q.location, q.latitude, q.longitude,
@@ -385,8 +380,8 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
       final level = queryTime > 1000
           ? '🔴 严重慢查询'
           : queryTime > 500
-          ? '⚠️ 慢查询警告'
-          : 'ℹ️ 性能提示';
+              ? '⚠️ 慢查询警告'
+              : 'ℹ️ 性能提示';
       logDebug('$level: 查询耗时 ${queryTime}ms');
 
       if (queryTime > 500) {

--- a/test/unit/constants/card_templates_render_line_numbers_test.dart
+++ b/test/unit/constants/card_templates_render_line_numbers_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/constants/card_templates.dart';
+
+void main() {
+  group('CardTemplates renderLineNumbers test', () {
+    test('应该渲染 0 行数字当 count 为 0', () {
+      final result = CardTemplates.renderLineNumbers(0, 100.0, 20.0, 14.0);
+      expect(result, equals(''));
+    });
+
+    test('应该渲染 1 行数字当 count 为 1', () {
+      final result = CardTemplates.renderLineNumbers(1, 100.0, 20.0, 14.0);
+      expect(
+          result,
+          contains(
+              '<text x="50" y="100.0" text-anchor="end" fill="#4b5563" font-family="monospace" font-size="14">1</text>'));
+      expect(result.trim().split('\n').length, 1);
+    });
+
+    test('应该渲染多行数字', () {
+      final result = CardTemplates.renderLineNumbers(3, 100.0, 20.0, 14.0);
+      expect(
+          result,
+          contains(
+              '<text x="50" y="100.0" text-anchor="end" fill="#4b5563" font-family="monospace" font-size="14">1</text>'));
+      expect(
+          result,
+          contains(
+              '<text x="50" y="120.0" text-anchor="end" fill="#4b5563" font-family="monospace" font-size="14">2</text>'));
+      expect(
+          result,
+          contains(
+              '<text x="50" y="140.0" text-anchor="end" fill="#4b5563" font-family="monospace" font-size="14">3</text>'));
+
+      final lines = result.trim().split('\n');
+      expect(lines.length, 3);
+    });
+
+    test('格式化的 font-size 应该忽略小数部分', () {
+      final result = CardTemplates.renderLineNumbers(1, 100.0, 20.0, 14.8);
+      expect(
+          result, contains('font-size="15"')); // 14.8.toStringAsFixed(0) is 15
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The `renderLineNumbers` function, an internal string generator for SVG rendering in the developer template, was untested because it was a local function embedded in `devTemplate`.
📊 **Coverage:** This PR extracts the function to a `@visibleForTesting` static method and adds unit tests that explicitly verify string generation when count is 0, 1, or more, as well as correct float-to-integer conversion of font sizes.
✨ **Result:** Enhanced the reliability and unit test coverage of the application's card template rendering engine.

---
*PR created automatically by Jules for task [14859628714547400678](https://jules.google.com/task/14859628714547400678) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `renderLineNumbers` 从 `devTemplate` 提取为 `CardTemplates` 的 `@visibleForTesting` 静态方法，并在模板中改为直接调用。新增单元测试覆盖 0/1/多行与字体大小四舍五入，并修复 CI 因格式化失败导致的检查错误，提升 SVG 行号渲染的稳定性与测试覆盖率。

<sup>Written for commit 639569e149645083e921ce6c5862c9e687483d94. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/284?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * 添加了行号显示功能的单元测试，验证不同场景下的正确渲染和计数逻辑

* **Refactor**
  * 优化了代码结构和架构设计，提升整体可维护性和代码质量

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->