### PR TITLE
🌐 译者: [提取硬编码] HitokotoWidget 中的“每日一言”和“加载中...”

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -30,3 +30,6 @@
 **规则:**
 - 将 `应用更改` 替换为现存键值 `applyChanges`
 - 对于缺失项，新增 `appendToOriginal` (Append to Original) 到各语言 `arb` 文件，并遵循极简规范翻译。
+## 2026-05-25 - [HitokotoWidget 提取硬编码]
+**发现:** HitokotoWidget 中存在 "每日一言" 和 "加载中..." 硬编码
+**规则:** 分别替换为 featureDailyQuote 和 loading。

--- a/lib/widgets/hitokoto_widget.dart
+++ b/lib/widgets/hitokoto_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import '../gen_l10n/app_localizations.dart';
 import '../utils/color_utils.dart'; // Import color_utils
 
 class HitokotoWidget extends StatelessWidget {
@@ -22,12 +22,12 @@ class HitokotoWidget extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              AppLocalizations.of(context)!.featureDailyQuote,
+              AppLocalizations.of(context).featureDailyQuote,
               style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
             Text(
-              quote['content'] ?? AppLocalizations.of(context)!.loading,
+              quote['content'] ?? AppLocalizations.of(context).loading,
               style: const TextStyle(fontSize: 14, height: 1.5),
             ),
             if (quote['author'] != null && quote['author'].isNotEmpty)

--- a/lib/widgets/hitokoto_widget.dart
+++ b/lib/widgets/hitokoto_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../utils/color_utils.dart'; // Import color_utils
 
 class HitokotoWidget extends StatelessWidget {
@@ -20,13 +21,13 @@ class HitokotoWidget extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              '每日一言',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            Text(
+              AppLocalizations.of(context)!.featureDailyQuote,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
             Text(
-              quote['content'] ?? '加载中...',
+              quote['content'] ?? AppLocalizations.of(context)!.loading,
               style: const TextStyle(fontSize: 14, height: 1.5),
             ),
             if (quote['author'] != null && quote['author'].isNotEmpty)


### PR DESCRIPTION
- 提取 `lib/widgets/hitokoto_widget.dart` 中硬编码的“每日一言”为 `featureDailyQuote`
- 提取硬编码的“加载中...”为 `loading`
- 更新翻译日志 `.jules/translator.md`

---
*PR created automatically by Jules for task [13284188913741674983](https://jules.google.com/task/13284188913741674983) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 HitokotoWidget 中的“每日一言”和“加载中...”提取为本地化键，去除硬编码，提升多语言支持。同步更新翻译日志，并修复 CI 静态分析的空检查警告。

- **Refactors**
  - 使用 `AppLocalizations` 渲染 `featureDailyQuote` 与 `loading`
  - 更新 `.jules/translator.md`

- **Bug Fixes**
  - 修复 CI 静态分析的空检查警告

<sup>Written for commit 474dcdbd50ff5e7c515aa298660a4a95ebf262b1. Summary will update on new commits. <a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/286?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 强化了应用的国际化功能。将原有的硬编码文案整合至本地化资源系统，用户界面文案现可根据系统语言设置自动适配，提升多语言支持的完整性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->