### PR TITLE
🧪 [testing] add unit tests for AppLogger

### DIFF
--- a/lib/utils/app_logger.dart
+++ b/lib/utils/app_logger.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:thoughtecho/services/unified_log_service.dart';
 
 /// 全局日志工具类，用于替换 logDebug
@@ -13,6 +14,12 @@ class AppLogger {
   static UnifiedLogService get _service {
     _logService ??= UnifiedLogService.instance;
     return _logService!;
+  }
+
+  /// 用于测试的日志服务注入
+  @visibleForTesting
+  static set serviceForTesting(UnifiedLogService service) {
+    _logService = service;
   }
 
   /// 记录详细日志 (verbose)

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -65,6 +65,7 @@ import 'unit/utils/report_period_utils_test.dart' as report_period_utils_test;
 import 'unit/utils/lww_decision_maker_test.dart' as lww_decision_maker_test;
 import 'unit/utils/daily_prompt_generator_test.dart'
     as daily_prompt_generator_test;
+import 'unit/utils/app_logger_test.dart' as app_logger_test;
 import 'unit/widgets/anniversary_animation_overlay_test.dart'
     as anniversary_animation_overlay_test;
 import 'unit/widgets/anniversary_notebook_icon_test.dart'
@@ -128,6 +129,7 @@ void main() {
       report_period_utils_test.main();
       lww_decision_maker_test.main();
       daily_prompt_generator_test.main();
+      app_logger_test.main();
       anniversary_animation_overlay_test.main();
       anniversary_notebook_icon_test.main();
       motion_photo_preview_page_test.main();

--- a/test/unit/utils/app_logger_test.dart
+++ b/test/unit/utils/app_logger_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/app_logger.dart';
+import 'package:thoughtecho/services/unified_log_service.dart';
+
+class FakeUnifiedLogService implements UnifiedLogService {
+  final List<Map<String, dynamic>> logRecords = [];
+
+  @override
+  void verbose(String message,
+      {String? source, Object? error, StackTrace? stackTrace}) {
+    log(UnifiedLogLevel.verbose, message,
+        source: source, error: error, stackTrace: stackTrace);
+  }
+
+  @override
+  void debug(String message,
+      {String? source, Object? error, StackTrace? stackTrace}) {
+    log(UnifiedLogLevel.debug, message,
+        source: source, error: error, stackTrace: stackTrace);
+  }
+
+  @override
+  void info(String message,
+      {String? source, Object? error, StackTrace? stackTrace}) {
+    log(UnifiedLogLevel.info, message,
+        source: source, error: error, stackTrace: stackTrace);
+  }
+
+  @override
+  void warning(String message,
+      {String? source, Object? error, StackTrace? stackTrace}) {
+    log(UnifiedLogLevel.warning, message,
+        source: source, error: error, stackTrace: stackTrace);
+  }
+
+  @override
+  void error(String message,
+      {String? source, Object? error, StackTrace? stackTrace}) {
+    log(UnifiedLogLevel.error, message,
+        source: source, error: error, stackTrace: stackTrace);
+  }
+
+  @override
+  void log(UnifiedLogLevel level, String message,
+      {String? source, Object? error, StackTrace? stackTrace}) {
+    logRecords.add({
+      'level': level,
+      'message': message,
+      'source': source,
+      'error': error,
+      'stackTrace': stackTrace,
+    });
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('AppLogger Test', () {
+    late FakeUnifiedLogService fakeService;
+
+    setUp(() {
+      fakeService = FakeUnifiedLogService();
+      AppLogger.serviceForTesting = fakeService;
+    });
+
+    test('AppLogger methods route to UnifiedLogService correctly', () {
+      AppLogger.v('verbose msg', source: 'src_v');
+      AppLogger.d('debug msg', source: 'src_d');
+      AppLogger.i('info msg', source: 'src_i');
+      AppLogger.w('warning msg', source: 'src_w');
+      AppLogger.e('error msg', source: 'src_e');
+      AppLogger.log(UnifiedLogLevel.info, 'log msg', source: 'src_l');
+
+      expect(fakeService.logRecords.length, 6);
+
+      expect(fakeService.logRecords[0]['level'], UnifiedLogLevel.verbose);
+      expect(fakeService.logRecords[0]['message'], 'verbose msg');
+      expect(fakeService.logRecords[0]['source'], 'src_v');
+
+      expect(fakeService.logRecords[1]['level'], UnifiedLogLevel.debug);
+      expect(fakeService.logRecords[1]['message'], 'debug msg');
+      expect(fakeService.logRecords[1]['source'], 'src_d');
+
+      expect(fakeService.logRecords[2]['level'], UnifiedLogLevel.info);
+      expect(fakeService.logRecords[2]['message'], 'info msg');
+      expect(fakeService.logRecords[2]['source'], 'src_i');
+
+      expect(fakeService.logRecords[3]['level'], UnifiedLogLevel.warning);
+      expect(fakeService.logRecords[3]['message'], 'warning msg');
+      expect(fakeService.logRecords[3]['source'], 'src_w');
+
+      expect(fakeService.logRecords[4]['level'], UnifiedLogLevel.error);
+      expect(fakeService.logRecords[4]['message'], 'error msg');
+      expect(fakeService.logRecords[4]['source'], 'src_e');
+
+      expect(fakeService.logRecords[5]['level'], UnifiedLogLevel.info);
+      expect(fakeService.logRecords[5]['message'], 'log msg');
+      expect(fakeService.logRecords[5]['source'], 'src_l');
+    });
+
+    test('Global logging functions route correctly', () {
+      appLog('appLog msg', level: UnifiedLogLevel.warning, source: 'src_app');
+      logDebug('logDebug msg', source: 'src_dbg');
+      logError('logError msg', source: 'src_err');
+      logInfo('logInfo msg', source: 'src_inf');
+      logWarning('logWarning msg', source: 'src_wrn');
+
+      expect(fakeService.logRecords.length, 5);
+
+      expect(fakeService.logRecords[0]['level'], UnifiedLogLevel.warning);
+      expect(fakeService.logRecords[0]['message'], 'appLog msg');
+
+      expect(fakeService.logRecords[1]['level'], UnifiedLogLevel.debug);
+      expect(fakeService.logRecords[1]['message'], 'logDebug msg');
+
+      expect(fakeService.logRecords[2]['level'], UnifiedLogLevel.error);
+      expect(fakeService.logRecords[2]['message'], 'logError msg');
+
+      expect(fakeService.logRecords[3]['level'], UnifiedLogLevel.info);
+      expect(fakeService.logRecords[3]['message'], 'logInfo msg');
+
+      expect(fakeService.logRecords[4]['level'], UnifiedLogLevel.warning);
+      expect(fakeService.logRecords[4]['message'], 'logWarning msg');
+    });
+
+    test('logDebug ignores null or empty messages', () {
+      logDebug(null);
+      logDebug('');
+      expect(fakeService.logRecords.length, 0);
+    });
+
+    test('Specific category logging functions route correctly', () {
+      logHttp('http msg', source: 'custom_http');
+      logRetry('retry msg');
+      logAI('ai msg');
+      logDio('dio msg');
+      logDatabase('db msg');
+      logFile('file msg');
+      logPerformance('perf msg');
+      logUserAction('action msg');
+      logSecurity('security msg');
+
+      expect(fakeService.logRecords.length, 9);
+      expect(fakeService.logRecords[0]['source'], 'custom_http');
+      expect(fakeService.logRecords[1]['source'], 'RETRY');
+      expect(fakeService.logRecords[2]['source'], 'AI');
+      expect(fakeService.logRecords[3]['source'], 'DIO');
+      expect(fakeService.logRecords[4]['source'], 'Database');
+      expect(fakeService.logRecords[5]['source'], 'File');
+      expect(fakeService.logRecords[6]['source'], 'Performance');
+      expect(fakeService.logRecords[7]['source'], 'UserAction');
+      expect(fakeService.logRecords[8]['source'], 'Security');
+    });
+
+    test('logConditional routes correctly based on condition', () {
+      logConditional(false, 'false msg');
+      expect(fakeService.logRecords.length, 0);
+
+      logConditional(true, 'true msg',
+          level: UnifiedLogLevel.warning, source: 'cond');
+      expect(fakeService.logRecords.length, 1);
+      expect(fakeService.logRecords[0]['level'], UnifiedLogLevel.warning);
+      expect(fakeService.logRecords[0]['message'], 'true msg');
+      expect(fakeService.logRecords[0]['source'], 'cond');
+    });
+  });
+}

--- a/test/widget/pages/webdav_sync_page_test.dart
+++ b/test/widget/pages/webdav_sync_page_test.dart
@@ -128,7 +128,9 @@ void main() {
     await tester.pumpWidget(buildTestApp());
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('如何获取应用密码？'));
+    final helpButtonFinder = find.text('如何获取应用密码？');
+    await tester.ensureVisible(helpButtonFinder);
+    await tester.tap(helpButtonFinder);
     await tester.pumpAndSettle();
 
     expect(launchUrlCalled, isTrue);


### PR DESCRIPTION
🎯 **What:** The `AppLogger` utility class and global logging wrapper functions lacked dedicated test coverage.
📊 **Coverage:** A new test suite `app_logger_test.dart` was added to verify all standard logging methods, global wrapper functions (`logDebug`, `logError`, etc.), and category-specific logging functions (`logHttp`, `logAI`, etc.) using a mock injected via a newly exposed `@visibleForTesting` setter. Edge cases like empty string parameters are also validated.
✨ **Result:** Increased codebase reliability by ensuring the global app logging infrastructure correctly routes payloads and metadata to the underlying unified service. Fixed an unrelated flaky WebDAV UI test to ensure CI test stability.

---
*PR created automatically by Jules for task [10699506070888639495](https://jules.google.com/task/10699506070888639495) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `AppLogger` 增加单元测试，覆盖标准方法、全局包装（`appLog`/`logDebug`/`logError` 等）和分类日志（`logHttp`/`logAI` 等），并新增 `@visibleForTesting` 的 `serviceForTesting` 用于注入 `UnifiedLogService` 模拟，验证日志级别/来源转发及空消息忽略等边界。同步修复 `webdav_sync_page_test.dart` 的偶发点击失败，先 `ensureVisible` 再点击以稳定 CI。

<sup>Written for commit f0f8050d0b76ef7884962b3a79e94cd9a68b8862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 新增应用日志记录的综合单元测试，覆盖各级别日志输出及特定场景的日志记录
  * 改进WebDAV同步页面测试的可靠性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->