### PR TITLE
🔒 强制 APK 下载服务使用 HTTPS

### DIFF
--- a/lib/services/apk_download_service.dart
+++ b/lib/services/apk_download_service.dart
@@ -73,8 +73,9 @@ class ApkDownloadService {
   static int? _currentNotificationId;
 
   /// 下载进度通知器
-  static ValueNotifier<DownloadProgress> progressNotifier =
-      ValueNotifier(const DownloadProgress());
+  static ValueNotifier<DownloadProgress> progressNotifier = ValueNotifier(
+    const DownloadProgress(),
+  );
 
   /// 下载取消令牌
   static CancelToken? _cancelToken;
@@ -123,6 +124,11 @@ class ApkDownloadService {
     String version,
   ) async {
     try {
+      // 强制使用 HTTPS
+      if (!apkUrl.toLowerCase().startsWith('https://')) {
+        throw Exception('Insecure download URL: APK downloads must use HTTPS');
+      }
+
       // 检查存储权限
       final hasPermission = await _checkStoragePermission();
       if (!hasPermission) {
@@ -326,7 +332,9 @@ class ApkDownloadService {
             final progressPercent = (progress * 100).round();
             _cachedDownloadProgress = l10n.apkDownloadProgress(progressPercent);
             _showDownloadNotification(
-                _cachedDownloadProgress!, progressPercent);
+              _cachedDownloadProgress!,
+              progressPercent,
+            );
           } else {
             // 未知总大小，仅更新已下载字节数
             progressNotifier.value = DownloadProgress(
@@ -463,7 +471,8 @@ class ApkDownloadService {
 
     await notificationsPlugin
         .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>()
+          AndroidFlutterLocalNotificationsPlugin
+        >()
         ?.createNotificationChannel(androidChannel);
   }
 
@@ -603,11 +612,7 @@ class _DownloadProgressDialog extends StatelessWidget {
     return AlertDialog(
       title: Row(
         children: [
-          Icon(
-            Icons.system_update,
-            color: colorScheme.primary,
-            size: 24,
-          ),
+          Icon(Icons.system_update, color: colorScheme.primary, size: 24),
           const SizedBox(width: 12),
           Expanded(child: Text(l10n.apkDownloadTitle)),
         ],
@@ -616,7 +621,8 @@ class _DownloadProgressDialog extends StatelessWidget {
         valueListenable: ApkDownloadService.progressNotifier,
         builder: (context, progress, _) {
           final hasTotalSize = progress.totalBytes > 0;
-          final isIndeterminate = progress.status == DownloadStatus.idle ||
+          final isIndeterminate =
+              progress.status == DownloadStatus.idle ||
               (!hasTotalSize && progress.status == DownloadStatus.downloading);
 
           return Column(
@@ -706,12 +712,7 @@ class _DownloadProgressDialog extends StatelessWidget {
           );
         },
       ),
-      actions: [
-        TextButton(
-          onPressed: onCancel,
-          child: Text(l10n.cancel),
-        ),
-      ],
+      actions: [TextButton(onPressed: onCancel, child: Text(l10n.cancel))],
     );
   }
 }

--- a/lib/services/apk_download_service.dart
+++ b/lib/services/apk_download_service.dart
@@ -73,9 +73,8 @@ class ApkDownloadService {
   static int? _currentNotificationId;
 
   /// 下载进度通知器
-  static ValueNotifier<DownloadProgress> progressNotifier = ValueNotifier(
-    const DownloadProgress(),
-  );
+  static ValueNotifier<DownloadProgress> progressNotifier =
+      ValueNotifier(const DownloadProgress());
 
   /// 下载取消令牌
   static CancelToken? _cancelToken;
@@ -332,9 +331,7 @@ class ApkDownloadService {
             final progressPercent = (progress * 100).round();
             _cachedDownloadProgress = l10n.apkDownloadProgress(progressPercent);
             _showDownloadNotification(
-              _cachedDownloadProgress!,
-              progressPercent,
-            );
+                _cachedDownloadProgress!, progressPercent);
           } else {
             // 未知总大小，仅更新已下载字节数
             progressNotifier.value = DownloadProgress(
@@ -471,8 +468,7 @@ class ApkDownloadService {
 
     await notificationsPlugin
         .resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin
-        >()
+            AndroidFlutterLocalNotificationsPlugin>()
         ?.createNotificationChannel(androidChannel);
   }
 
@@ -612,7 +608,11 @@ class _DownloadProgressDialog extends StatelessWidget {
     return AlertDialog(
       title: Row(
         children: [
-          Icon(Icons.system_update, color: colorScheme.primary, size: 24),
+          Icon(
+            Icons.system_update,
+            color: colorScheme.primary,
+            size: 24,
+          ),
           const SizedBox(width: 12),
           Expanded(child: Text(l10n.apkDownloadTitle)),
         ],
@@ -621,8 +621,7 @@ class _DownloadProgressDialog extends StatelessWidget {
         valueListenable: ApkDownloadService.progressNotifier,
         builder: (context, progress, _) {
           final hasTotalSize = progress.totalBytes > 0;
-          final isIndeterminate =
-              progress.status == DownloadStatus.idle ||
+          final isIndeterminate = progress.status == DownloadStatus.idle ||
               (!hasTotalSize && progress.status == DownloadStatus.downloading);
 
           return Column(
@@ -712,7 +711,12 @@ class _DownloadProgressDialog extends StatelessWidget {
           );
         },
       ),
-      actions: [TextButton(onPressed: onCancel, child: Text(l10n.cancel))],
+      actions: [
+        TextButton(
+          onPressed: onCancel,
+          child: Text(l10n.cancel),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
🎯 **What:** 
修复了 `ApkDownloadService` 中下载应用安装包时允许使用未加密的 HTTP 协议的问题。

⚠️ **Risk:** 
如果在公共 Wi-Fi 或不安全的网络环境下，通过明文 HTTP 协议下载 APK 更新，攻击者可以使用中间人攻击 (MitM) 篡改正在下载的安装包，导致用户设备被植入恶意软件。

🛡️ **Solution:** 
在 `downloadAndInstallApk` 方法最初始的位置添加了 URL 前缀检查。如果 URL 没有使用 `https://`，服务将立即抛出异常，从而通过现有的错误捕获机制中断下载流程并向用户展示失败提示，确保只有受 TLS/SSL 加密保护的资源才能被下载安装。

---
*PR created automatically by Jules for task [15793895789352231556](https://jules.google.com/task/15793895789352231556) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
强制 APK 下载仅使用 HTTPS，阻止通过未加密的 HTTP 更新，降低中间人篡改风险。
在 `ApkDownloadService` 的 `downloadAndInstallApk` 开头校验 `apkUrl` 是否以 `https://` 开头；否则抛出异常并中断下载，沿用现有错误提示流程。

<sup>Written for commit 186e71a31218ed8ed0bd148137e7f69fbd36f394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

