### PR TITLE
🧪 [Add tests for LocationWeatherHelper and LocationSnapshot]

### DIFF
--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -66,6 +66,8 @@ import 'unit/utils/lww_decision_maker_test.dart' as lww_decision_maker_test;
 import 'unit/utils/daily_prompt_generator_test.dart'
     as daily_prompt_generator_test;
 import 'unit/utils/app_logger_test.dart' as app_logger_test;
+import 'unit/utils/location_weather_helper_test.dart'
+    as location_weather_helper_test;
 import 'unit/widgets/anniversary_animation_overlay_test.dart'
     as anniversary_animation_overlay_test;
 import 'unit/widgets/anniversary_notebook_icon_test.dart'
@@ -130,6 +132,7 @@ void main() {
       lww_decision_maker_test.main();
       daily_prompt_generator_test.main();
       app_logger_test.main();
+      location_weather_helper_test.main();
       anniversary_animation_overlay_test.main();
       anniversary_notebook_icon_test.main();
       motion_photo_preview_page_test.main();

--- a/test/unit/utils/location_weather_helper_test.dart
+++ b/test/unit/utils/location_weather_helper_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart' show Position;
+import 'package:mockito/mockito.dart';
+import 'package:thoughtecho/services/location_service.dart';
+import 'package:thoughtecho/utils/location_weather_helper.dart';
+
+class MockLocationService extends Mock implements LocationService {
+  @override
+  bool get hasLocationPermission {
+    return super.noSuchMethod(
+      Invocation.getter(#hasLocationPermission),
+      returnValue: false,
+    );
+  }
+
+  @override
+  Future<bool> requestLocationPermission() {
+    return super.noSuchMethod(
+      Invocation.method(#requestLocationPermission, []),
+      returnValue: Future.value(false),
+    );
+  }
+
+  @override
+  Future<Position?> getCurrentLocation({
+    bool highAccuracy = false,
+    bool skipPermissionRequest = false,
+  }) {
+    return super.noSuchMethod(
+      Invocation.method(#getCurrentLocation, [], {
+        #highAccuracy: highAccuracy,
+        #skipPermissionRequest: skipPermissionRequest,
+      }),
+      returnValue: Future.value(null),
+    );
+  }
+
+  @override
+  String getFormattedLocation() {
+    return super.noSuchMethod(
+      Invocation.method(#getFormattedLocation, []),
+      returnValue: '',
+    );
+  }
+}
+
+void main() {
+  group('LocationSnapshot Tests', () {
+    test('should create LocationSnapshot instance', () {
+      final mockPosition = Position(
+        longitude: 116.4074,
+        latitude: 39.9042,
+        timestamp: DateTime.now(),
+        accuracy: 0.0,
+        altitude: 0.0,
+        altitudeAccuracy: 0.0,
+        heading: 0.0,
+        headingAccuracy: 0.0,
+        speed: 0.0,
+        speedAccuracy: 0.0,
+      );
+
+      final snapshot = LocationSnapshot(
+        position: mockPosition,
+        location: '北京市',
+      );
+
+      expect(snapshot.position, equals(mockPosition));
+      expect(snapshot.location, equals('北京市'));
+    });
+  });
+
+  group('LocationWeatherHelper Tests', () {
+    late MockLocationService mockLocationService;
+
+    setUp(() {
+      mockLocationService = MockLocationService();
+    });
+
+    group('ensureLocationPermission', () {
+      test('should return true if already has permission', () async {
+        when(mockLocationService.hasLocationPermission).thenReturn(true);
+
+        final result = await LocationWeatherHelper.ensureLocationPermission(
+          mockLocationService,
+        );
+
+        expect(result, isTrue);
+        verifyNever(mockLocationService.requestLocationPermission());
+      });
+
+      test('should request permission if not already granted', () async {
+        when(mockLocationService.hasLocationPermission).thenReturn(false);
+        when(mockLocationService.requestLocationPermission())
+            .thenAnswer((_) async => true);
+
+        final result = await LocationWeatherHelper.ensureLocationPermission(
+          mockLocationService,
+        );
+
+        expect(result, isTrue);
+        verify(mockLocationService.requestLocationPermission()).called(1);
+      });
+
+      test('should return false if request is denied', () async {
+        when(mockLocationService.hasLocationPermission).thenReturn(false);
+        when(mockLocationService.requestLocationPermission())
+            .thenAnswer((_) async => false);
+
+        final result = await LocationWeatherHelper.ensureLocationPermission(
+          mockLocationService,
+        );
+
+        expect(result, isFalse);
+        verify(mockLocationService.requestLocationPermission()).called(1);
+      });
+    });
+
+    group('fetchLocation', () {
+      test('should return null if position is null', () async {
+        when(mockLocationService.getCurrentLocation())
+            .thenAnswer((_) async => null);
+
+        final result = await LocationWeatherHelper.fetchLocation(
+          mockLocationService,
+        );
+
+        expect(result, isNull);
+        verifyNever(mockLocationService.getFormattedLocation());
+      });
+
+      test('should return LocationSnapshot if position is available', () async {
+        final mockPosition = Position(
+          longitude: 121.4737,
+          latitude: 31.2304,
+          timestamp: DateTime.now(),
+          accuracy: 0.0,
+          altitude: 0.0,
+          altitudeAccuracy: 0.0,
+          heading: 0.0,
+          headingAccuracy: 0.0,
+          speed: 0.0,
+          speedAccuracy: 0.0,
+        );
+        const mockFormattedLocation = '上海市';
+
+        when(mockLocationService.getCurrentLocation())
+            .thenAnswer((_) async => mockPosition);
+        when(mockLocationService.getFormattedLocation())
+            .thenReturn(mockFormattedLocation);
+
+        final result = await LocationWeatherHelper.fetchLocation(
+          mockLocationService,
+        );
+
+        expect(result, isNotNull);
+        expect(result!.position, equals(mockPosition));
+        expect(result.location, equals(mockFormattedLocation));
+      });
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The `LocationSnapshot` and `LocationWeatherHelper` classes in `lib/utils/location_weather_helper.dart` lacked unit tests, creating a testing gap for location permission handling and position fetching utility logic.
📊 **Coverage:** The new tests in `test/unit/utils/location_weather_helper_test.dart` fully cover:
- `LocationSnapshot` object instantiation and properties assignment.
- `LocationWeatherHelper.ensureLocationPermission`: Already granted, successfully requested, and denied scenarios.
- `LocationWeatherHelper.fetchLocation`: Successful retrieval of location with formatted strings, and failure (null) handling.
✨ **Result:** Enhanced test coverage for the location helper module, ensuring the correctness of permission checking and location fetch abstraction over `LocationService`. Both individual and global test suites run successfully without regressions.

---
*PR created automatically by Jules for task [6279534711080287908](https://jules.google.com/task/6279534711080287908) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `LocationSnapshot` 与 `LocationWeatherHelper` 增加单元测试，覆盖位置权限判断、权限请求与定位获取逻辑，并将新测试接入 `test/all_tests.dart` 参与标准测试套件/CI。验证已授权、请求后授权、拒绝授权、定位成功（含格式化地址）与定位为空等分支，提升位置/天气辅助工具的可靠性与测试覆盖率。

<sup>Written for commit 808b18615dc51cb13dde8bf70e31a20c02c73ca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

