### PR TITLE
🔒 [强制 WebDAV 连接使用 HTTPS 保护凭据]

### DIFF
--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -167,9 +167,9 @@ class WebDAVSyncService extends ChangeNotifier {
               status == 302 ||
               status == 307 ||
               status == 308) {
-
             // 检查防重定向死循环
-            final redirectCount = (response.requestOptions.extra['redirects'] as int?) ?? 0;
+            final redirectCount =
+                (response.requestOptions.extra['redirects'] as int?) ?? 0;
             if (redirectCount >= 5) {
               return handler.reject(
                 DioException(

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -100,6 +100,9 @@ class WebDAVSyncService extends ChangeNotifier {
     _enabled = enabled;
     _provider = provider;
     _url = url.trim();
+    if (_url.isNotEmpty && !_url.toLowerCase().startsWith('https://')) {
+      throw Exception('HTTPS is required to protect WebDAV credentials');
+    }
     if (!_url.endsWith('/')) _url = '$_url/';
     _username = username.trim();
     _syncOnLaunch = syncOnLaunch;
@@ -136,6 +139,9 @@ class WebDAVSyncService extends ChangeNotifier {
     dio.options.connectTimeout = const Duration(seconds: 15);
     dio.options.receiveTimeout = const Duration(seconds: 20);
     dio.options.sendTimeout = const Duration(seconds: 20);
+
+    // 禁用自动跟随重定向，防止 HTTPS 向 HTTP 降级导致 Basic Auth 凭据泄露
+    dio.options.followRedirects = false;
 
     // 计算 Basic Auth 头
     final basicAuth =

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -199,7 +199,7 @@ class WebDAVSyncService extends ChangeNotifier {
                 newOptions.extra['redirects'] = redirectCount + 1;
 
                 // 如果跨域，则移除认证以防跨域凭据泄露
-                if (resolvedUri.host != response.requestOptions.uri.host) {
+                if (resolvedUri.origin != response.requestOptions.uri.origin) {
                   newOptions.headers.remove('Authorization');
                 }
 

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -16,12 +16,7 @@ import '../services/mmkv_service.dart';
 import '../utils/app_logger.dart';
 
 /// WebDAV 同步状态枚举
-enum WebDAVSyncStatus {
-  idle,
-  syncing,
-  success,
-  failed,
-}
+enum WebDAVSyncStatus { idle, syncing, success, failed }
 
 class WebDAVSyncService extends ChangeNotifier {
   static final WebDAVSyncService _instance = WebDAVSyncService._internal();
@@ -119,7 +114,9 @@ class WebDAVSyncService extends ChangeNotifier {
 
     if (password != null) {
       await _secureStorage.write(
-          key: 'webdav_password', value: password.trim());
+        key: 'webdav_password',
+        value: password.trim(),
+      );
     }
 
     notifyListeners();
@@ -127,7 +124,14 @@ class WebDAVSyncService extends ChangeNotifier {
 
   /// 创建配置好的 Dio 实例用于 WebDAV 请求
   Future<Dio> _createDio(
-      String requestUrl, String requestUsername, String requestPassword) async {
+    String requestUrl,
+    String requestUsername,
+    String requestPassword,
+  ) async {
+    if (!requestUrl.toLowerCase().startsWith('https://')) {
+      throw Exception('HTTPS is required to protect WebDAV credentials');
+    }
+
     final dio = Dio();
     dio.options.connectTimeout = const Duration(seconds: 15);
     dio.options.receiveTimeout = const Duration(seconds: 20);
@@ -136,17 +140,17 @@ class WebDAVSyncService extends ChangeNotifier {
     // 计算 Basic Auth 头
     final basicAuth =
         'Basic ${base64Encode(utf8.encode('$requestUsername:$requestPassword'))}';
-    dio.options.headers = {
-      'Authorization': basicAuth,
-      'Accept': '*/*',
-    };
+    dio.options.headers = {'Authorization': basicAuth, 'Accept': '*/*'};
 
     return dio;
   }
 
   /// 测试 WebDAV 连接
   Future<bool> testConnection(
-      String testUrl, String testUsername, String testPassword) async {
+    String testUrl,
+    String testUsername,
+    String testPassword,
+  ) async {
     try {
       String cleanUrl = testUrl.trim();
       if (!cleanUrl.endsWith('/')) cleanUrl = '$cleanUrl/';
@@ -271,7 +275,8 @@ class WebDAVSyncService extends ChangeNotifier {
       final archive = Archive();
       final jsonBytes = utf8.encode(localDataJson);
       archive.addFile(
-          ArchiveFile('backup_data.json', jsonBytes.length, jsonBytes));
+        ArchiveFile('backup_data.json', jsonBytes.length, jsonBytes),
+      );
       final zipBytes = ZipEncoder().encode(archive);
 
       await dio.put(
@@ -293,8 +298,12 @@ class WebDAVSyncService extends ChangeNotifier {
 
       logInfo('WebDAV 同步成功完成。冲突数: $_lastConflictCount');
     } catch (e, stack) {
-      logError('WebDAV 同步失败',
-          error: e, stackTrace: stack, source: 'WebDAVSyncService');
+      logError(
+        'WebDAV 同步失败',
+        error: e,
+        stackTrace: stack,
+        source: 'WebDAVSyncService',
+      );
       _syncStatus = WebDAVSyncStatus.failed;
       await _mmkv.setString('webdav_sync_status', 'failed');
     } finally {
@@ -356,7 +365,7 @@ class WebDAVSyncService extends ChangeNotifier {
     if (localQuotes.isEmpty) return 0;
 
     final localQuotesMap = {
-      for (final q in localQuotes) (q['id'] as String): q
+      for (final q in localQuotes) (q['id'] as String): q,
     };
 
     int conflictsCloned = 0;
@@ -370,14 +379,16 @@ class WebDAVSyncService extends ChangeNotifier {
       final localQuote = localQuotesMap[quoteId];
       if (localQuote == null) continue;
 
-      final remoteModStr = rqMap['last_modified']?.toString() ??
+      final remoteModStr =
+          rqMap['last_modified']?.toString() ??
           rqMap['lastModified']?.toString() ??
           '';
       if (remoteModStr.isEmpty) continue;
 
       final remoteModTime = DateTime.parse(remoteModStr).toUtc();
-      final localModTime =
-          DateTime.parse(localQuote['last_modified'] as String).toUtc();
+      final localModTime = DateTime.parse(
+        localQuote['last_modified'] as String,
+      ).toUtc();
 
       // 如果两边都有修改，且内容不同，则判定为冲突
       if (localModTime.isAfter(lastSync) && remoteModTime.isAfter(lastSync)) {
@@ -396,7 +407,9 @@ class WebDAVSyncService extends ChangeNotifier {
 
   /// 克隆冲突的笔记，并将分类设为“同步冲突”
   Future<void> _cloneConflictQuote(
-      Database db, Map<String, dynamic> localQuote) async {
+    Database db,
+    Map<String, dynamic> localQuote,
+  ) async {
     try {
       // 1. 确保冲突分类在本地存在
       final catCheck = await db.query(
@@ -470,8 +483,10 @@ class WebDAVSyncService extends ChangeNotifier {
     if (!await mediaRoot.exists()) return;
 
     // 1. 扫描本地所有存在的媒体文件
-    final List<File> localFiles =
-        mediaRoot.listSync(recursive: true).whereType<File>().toList();
+    final List<File> localFiles = mediaRoot
+        .listSync(recursive: true)
+        .whereType<File>()
+        .toList();
 
     final Map<String, File> localMediaMap = {};
     for (final f in localFiles) {
@@ -504,8 +519,9 @@ class WebDAVSyncService extends ChangeNotifier {
               ? utf8.decode(rawData, allowMalformed: true)
               : rawData.toString();
           // 使用 namespace-agnostic 正则提取云端文件的相对路径 URL 尾部
-          final hrefRegExp =
-              RegExp(r'<[a-zA-Z0-9:]*href>([\s\S]*?)<\/[a-zA-Z0-9:]*href>');
+          final hrefRegExp = RegExp(
+            r'<[a-zA-Z0-9:]*href>([\s\S]*?)<\/[a-zA-Z0-9:]*href>',
+          );
           final matches = hrefRegExp.allMatches(xmlData);
 
           for (final m in matches) {
@@ -542,11 +558,7 @@ class WebDAVSyncService extends ChangeNotifier {
           await dio.put(
             uploadUrl,
             data: file.openRead(),
-            options: Options(
-              headers: {
-                'Content-Length': fileLen,
-              },
-            ),
+            options: Options(headers: {'Content-Length': fileLen}),
           );
         } catch (e) {
           logDebug('上传附件失败 ($stdPath): $e');
@@ -559,8 +571,9 @@ class WebDAVSyncService extends ChangeNotifier {
       if (!localMediaMap.containsKey(stdPath)) {
         logDebug('从云端下载本地缺失附件: $stdPath');
         final downloadUrl = '${_url}thoughtecho/media/$stdPath';
-        final localTargetFile =
-            File(p.join(mediaRoot.path, stdPath.replaceAll('/', p.separator)));
+        final localTargetFile = File(
+          p.join(mediaRoot.path, stdPath.replaceAll('/', p.separator)),
+        );
 
         try {
           // 确保父目录存在

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -100,7 +100,9 @@ class WebDAVSyncService extends ChangeNotifier {
     _enabled = enabled;
     _provider = provider;
     _url = url.trim();
-    if (_url.isNotEmpty && !_url.toLowerCase().startsWith('https://')) {
+    if (_enabled &&
+        _url.isNotEmpty &&
+        !_url.toLowerCase().startsWith('https://')) {
       throw Exception('HTTPS is required to protect WebDAV credentials');
     }
     if (!_url.endsWith('/')) _url = '$_url/';
@@ -140,13 +142,93 @@ class WebDAVSyncService extends ChangeNotifier {
     dio.options.receiveTimeout = const Duration(seconds: 20);
     dio.options.sendTimeout = const Duration(seconds: 20);
 
-    // 禁用自动跟随重定向，防止 HTTPS 向 HTTP 降级导致 Basic Auth 凭据泄露
+    // 禁用自动跟随重定向，通过拦截器手动处理安全跳转，防止 HTTPS 向 HTTP 降级泄露凭据
     dio.options.followRedirects = false;
+
+    dio.options.validateStatus = (status) {
+      return status != null &&
+          (status >= 200 && status < 300 ||
+              status == 301 ||
+              status == 302 ||
+              status == 307 ||
+              status == 308);
+    };
 
     // 计算 Basic Auth 头
     final basicAuth =
         'Basic ${base64Encode(utf8.encode('$requestUsername:$requestPassword'))}';
     dio.options.headers = {'Authorization': basicAuth, 'Accept': '*/*'};
+
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onResponse: (response, handler) async {
+          final status = response.statusCode;
+          if (status == 301 ||
+              status == 302 ||
+              status == 307 ||
+              status == 308) {
+
+            // 检查防重定向死循环
+            final redirectCount = (response.requestOptions.extra['redirects'] as int?) ?? 0;
+            if (redirectCount >= 5) {
+              return handler.reject(
+                DioException(
+                  requestOptions: response.requestOptions,
+                  error: 'Redirect limit exceeded',
+                ),
+              );
+            }
+
+            final location = response.headers.value('location');
+            if (location != null && location.isNotEmpty) {
+              final resolvedUri = response.requestOptions.uri.resolve(location);
+              if (resolvedUri.scheme != 'https') {
+                return handler.reject(
+                  DioException(
+                    requestOptions: response.requestOptions,
+                    error: 'HTTPS is required to protect WebDAV credentials',
+                  ),
+                );
+              }
+
+              // 手动跟随安全的 HTTPS 重定向
+              try {
+                final newOptions = response.requestOptions.copyWith(
+                  path: resolvedUri.toString(),
+                );
+                newOptions.extra['redirects'] = redirectCount + 1;
+
+                // 如果跨域，则移除认证以防跨域凭据泄露
+                if (resolvedUri.host != response.requestOptions.uri.host) {
+                  newOptions.headers.remove('Authorization');
+                }
+
+                final newResponse = await dio.fetch(newOptions);
+                return handler.resolve(newResponse);
+              } catch (e) {
+                if (e is DioException) {
+                  return handler.reject(e);
+                }
+                return handler.reject(
+                  DioException(
+                    requestOptions: response.requestOptions,
+                    error: e.toString(),
+                  ),
+                );
+              }
+            }
+            // 收到 3xx 但没有合法的 location 跳转时，显式拒绝（防止全局 validateStatus 放行导致无声失败）
+            return handler.reject(
+              DioException(
+                requestOptions: response.requestOptions,
+                error: 'Redirect failed: Missing or invalid Location header',
+              ),
+            );
+          }
+          return handler.next(response);
+        },
+      ),
+    );
 
     return dio;
   }

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -379,8 +379,7 @@ class WebDAVSyncService extends ChangeNotifier {
       final localQuote = localQuotesMap[quoteId];
       if (localQuote == null) continue;
 
-      final remoteModStr =
-          rqMap['last_modified']?.toString() ??
+      final remoteModStr = rqMap['last_modified']?.toString() ??
           rqMap['lastModified']?.toString() ??
           '';
       if (remoteModStr.isEmpty) continue;
@@ -483,10 +482,8 @@ class WebDAVSyncService extends ChangeNotifier {
     if (!await mediaRoot.exists()) return;
 
     // 1. 扫描本地所有存在的媒体文件
-    final List<File> localFiles = mediaRoot
-        .listSync(recursive: true)
-        .whereType<File>()
-        .toList();
+    final List<File> localFiles =
+        mediaRoot.listSync(recursive: true).whereType<File>().toList();
 
     final Map<String, File> localMediaMap = {};
     for (final f in localFiles) {

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -106,4 +106,36 @@ void main() {
     expect(service.syncStatus, WebDAVSyncStatus.idle);
     expect(service.isSyncing, false);
   });
+
+  test('WebDAVSyncService should enforce HTTPS strictly on saveSettings',
+      () async {
+    final service = WebDAVSyncService();
+
+    expect(
+      service.saveSettings(
+        enabled: true,
+        provider: 'custom',
+        url: 'http://insecure.server.local/dav/',
+        username: 'user',
+        syncOnLaunch: false,
+        syncOnChange: false,
+      ),
+      throwsA(isA<Exception>().having(
+        (e) => e.toString(),
+        'message',
+        contains('HTTPS is required to protect WebDAV credentials'),
+      )),
+    );
+  });
+
+  test('WebDAVSyncService should enforce HTTPS strictly on testConnection',
+      () async {
+    final service = WebDAVSyncService();
+
+    // The testConnection method catches exceptions and returns false.
+    // Instead of throwsA, we should test the boolean result.
+    final result = await service.testConnection(
+        'http://insecure.server.local/dav/', 'user', 'pass');
+    expect(result, isFalse);
+  });
 }

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -107,10 +107,12 @@ void main() {
     expect(service.isSyncing, false);
   });
 
-  test('WebDAVSyncService should enforce HTTPS strictly on saveSettings',
+  test(
+      'WebDAVSyncService should enforce HTTPS strictly on saveSettings only when enabled',
       () async {
     final service = WebDAVSyncService();
 
+    // 当 enabled = true 时，应该抛出异常
     expect(
       service.saveSettings(
         enabled: true,
@@ -126,6 +128,18 @@ void main() {
         contains('HTTPS is required to protect WebDAV credentials'),
       )),
     );
+
+    // 当 enabled = false 时，应当允许用户暂存设置而不被阻止
+    await service.saveSettings(
+      enabled: false,
+      provider: 'custom',
+      url: 'http://insecure.server.local/dav/',
+      username: 'user',
+      syncOnLaunch: false,
+      syncOnChange: false,
+    );
+    expect(service.enabled, false);
+    expect(service.url, 'http://insecure.server.local/dav/');
   });
 
   test('WebDAVSyncService should enforce HTTPS strictly on testConnection',


### PR DESCRIPTION
🎯 **What:**
增加了针对 WebDAV 连接（在 `_createDio` 阶段）URL 的校验逻辑，强制要求只允许 `https://` 开头的地址。

⚠️ **Risk:**
如果不强制使用 HTTPS 加密传输，WebDAV 的身份凭据（用户名和密码）在请求 Basic Auth 时将以 Base64 编码的明文形式发送。一旦网络环境中存在嗅探或中间人（MitM）攻击，将会导致凭据极易被直接窃取，严重威胁用户数据安全。

🛡️ **Solution:**
在网络请求基础构建方法 `_createDio` 中引入了 URL 校验逻辑 `!requestUrl.toLowerCase().startsWith('https://')`。如果用户配置了未加密的 `http://` 地址，程序会直接抛出 `Exception`，并在发出包含 Auth Header 的请求前中止操作，彻底消除凭据明文泄露的风险。此策略对测试连接（testConnection）以及所有实际的数据同步均生效。

---
*PR created automatically by Jules for task [12077407080983299588](https://jules.google.com/task/12077407080983299588) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
强制 WebDAV 全链路仅用 HTTPS，并安全处理 3xx 重定向以防降级或跨域泄露凭据。校验覆盖保存设置（仅启用时）、连接测试与所有同步请求。

- **Bug Fixes**
  - 在 `dio` 中禁用自动重定向，手动处理 301/302/307/308：仅允许跳转到 HTTPS，解析相对 URI，最多 5 次，跨域移除 `Authorization`，缺失/非法 Location 明确失败。
  - 在请求构建处强校验 URL 必须为 HTTPS；`testConnection` 捕获异常返回 false。
  - `saveSettings` 仅在 `enabled=true` 时拒绝 `http://`；新增单测覆盖 `saveSettings` 与 `testConnection` 的校验。

- **迁移**
  - 将现有 `http://` 配置更新为 `https://`。
  - 若服务器不支持 HTTPS，请为 WebDAV 配置 TLS 或通过反向代理启用 HTTPS。

<sup>Written for commit 1450ff6c263a98256cfde65bb277e1038b102328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 优化了 WebDAV 同步实现的内部结构与可读性。

* **Bug Fixes / 行为变更**
  * 强制要求使用 HTTPS：保存非 HTTPS WebDAV URL 将被拒绝，连接测试在非 HTTPS 时返回失败。

* **Tests**
  * 新增/调整单元测试以覆盖上述 HTTPS 要求和连接测试行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shangjin-Xiao/ThoughtEcho/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->