### PR TITLE
🧪 [testing improvement] 增加 ChatMarkdownStyleSheet 单元测试

### DIFF
--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -68,6 +68,7 @@ import 'unit/utils/daily_prompt_generator_test.dart'
 import 'unit/utils/app_logger_test.dart' as app_logger_test;
 import 'unit/utils/location_weather_helper_test.dart'
     as location_weather_helper_test;
+import 'unit/utils/chat_markdown_styles_test.dart' as chat_markdown_styles_test;
 import 'unit/widgets/anniversary_animation_overlay_test.dart'
     as anniversary_animation_overlay_test;
 import 'unit/widgets/anniversary_notebook_icon_test.dart'
@@ -133,6 +134,7 @@ void main() {
       daily_prompt_generator_test.main();
       app_logger_test.main();
       location_weather_helper_test.main();
+      chat_markdown_styles_test.main();
       anniversary_animation_overlay_test.main();
       anniversary_notebook_icon_test.main();
       motion_photo_preview_page_test.main();

--- a/test/unit/utils/chat_markdown_styles_test.dart
+++ b/test/unit/utils/chat_markdown_styles_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/chat_markdown_styles.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ChatMarkdownStyleSheet', () {
+    // 准备一个测试用的 ThemeData
+    final lightTheme = ThemeData(
+      brightness: Brightness.light,
+      colorScheme: const ColorScheme.light(
+        onSurface: Colors.black87,
+        surfaceContainerHighest: Color(0xFFEEEEEE),
+        primary: Colors.blue,
+        outline: Colors.grey,
+      ),
+      textTheme: const TextTheme(
+        bodyLarge: TextStyle(fontSize: 16, color: Colors.black),
+        bodyMedium: TextStyle(fontSize: 14, color: Colors.black54),
+        headlineLarge: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+      ),
+    );
+
+    final darkTheme = ThemeData(
+      brightness: Brightness.dark,
+      colorScheme: const ColorScheme.dark(
+        onSurface: Colors.white70,
+        surface: Color(0xFF333333),
+        primary: Colors.lightBlue,
+        outline: Colors.white24,
+      ),
+      textTheme: const TextTheme(
+        bodyLarge: TextStyle(fontSize: 16, color: Colors.white),
+        bodyMedium: TextStyle(fontSize: 14, color: Colors.white54),
+        headlineLarge: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+      ),
+    );
+
+    test('create generates styles correctly for light mode', () {
+      final styleSheet =
+          ChatMarkdownStyleSheet.create(lightTheme, isDarkMode: false);
+
+      // 验证基础颜色
+      expect(styleSheet.p?.color, equals(lightTheme.colorScheme.onSurface));
+
+      // 验证代码块背景色 (浅色模式使用 surfaceContainerHighest with alpha 0.5)
+      final expectedCodeBg =
+          lightTheme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5);
+      expect(styleSheet.code?.backgroundColor, equals(expectedCodeBg));
+      expect((styleSheet.codeblockDecoration as BoxDecoration).color,
+          equals(expectedCodeBg));
+
+      // 验证引用块样式
+      final expectedBlockquoteBg =
+          lightTheme.colorScheme.primary.withValues(alpha: 0.08);
+      expect((styleSheet.blockquoteDecoration as BoxDecoration).color,
+          equals(expectedBlockquoteBg));
+      expect(styleSheet.blockquotePadding,
+          equals(const EdgeInsets.fromLTRB(16, 12, 16, 12)));
+
+      // 验证其他基础属性
+      expect(styleSheet.codeblockPadding, equals(const EdgeInsets.all(16)));
+      expect(styleSheet.p?.fontSize, equals(16));
+      expect(styleSheet.h1?.fontSize, equals(24));
+    });
+
+    test('create generates styles correctly for dark mode', () {
+      final styleSheet =
+          ChatMarkdownStyleSheet.create(darkTheme, isDarkMode: true);
+
+      // 验证基础颜色
+      expect(styleSheet.p?.color, equals(darkTheme.colorScheme.onSurface));
+
+      // 验证代码块背景色 (深色模式使用 surface with alpha 0.8)
+      final expectedCodeBg =
+          darkTheme.colorScheme.surface.withValues(alpha: 0.8);
+      expect(styleSheet.code?.backgroundColor, equals(expectedCodeBg));
+      expect((styleSheet.codeblockDecoration as BoxDecoration).color,
+          equals(expectedCodeBg));
+
+      // 验证引用块样式
+      final expectedBlockquoteBg =
+          darkTheme.colorScheme.primary.withValues(alpha: 0.08);
+      expect((styleSheet.blockquoteDecoration as BoxDecoration).color,
+          equals(expectedBlockquoteBg));
+    });
+
+    test('createCodeFriendly overrides code styles correctly', () {
+      final styleSheet = ChatMarkdownStyleSheet.createCodeFriendly(lightTheme);
+
+      // 验证重写后的 code 字体属性
+      expect(styleSheet.code?.fontSize, equals(13));
+      expect(
+        styleSheet.code?.fontFamily,
+        equals(
+            'JetBrains Mono, SF Mono, Consolas, Monaco, Courier New, monospace'),
+      );
+      expect(styleSheet.code?.letterSpacing, equals(0.3));
+
+      // 验证重写后的 padding
+      expect(styleSheet.codeblockPadding, equals(const EdgeInsets.all(20)));
+
+      // 验证基础样式没有丢失
+      expect(styleSheet.p?.color, equals(lightTheme.colorScheme.onSurface));
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:**
在 `test/unit/utils/` 目录下新增了 `chat_markdown_styles_test.dart` 测试文件，以弥补 `ChatMarkdownStyleSheet` 类在样式生成上的测试缺失，并已将其导入 `test/all_tests.dart` 中。

📊 **Coverage:**
- 测试覆盖了浅色模式下 `MarkdownStyleSheet` 中各项关键属性（段落、代码块、引用块及 padding）的正确映射。
- 测试覆盖了深色模式下颜色/背景属性的正确映射，验证了 `ThemeData` 的状态切换行为。
- 测试覆盖了 `createCodeFriendly` 方法，确认代码字体集、字号和内边距的重写逻辑符合预期且未丢失基础样式。

✨ **Result:**
成功增加并运行通过了针对聊天和代码友好风格 Markdown 样式的独立断言测试，保障了未来在修改该组件或其依赖的主题配置时的可靠性，防止非预期回归。

---
*PR created automatically by Jules for task [16007884676996344850](https://jules.google.com/task/16007884676996344850) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
新增 `test/unit/utils/chat_markdown_styles_test.dart`，为 `ChatMarkdownStyleSheet` 的样式生成提供单元测试。已在 `test/all_tests.dart` 注册，强化明/暗模式与 `createCodeFriendly` 的回归保护。

- **测试覆盖**
  - 明/暗模式下 `MarkdownStyleSheet` 关键属性映射：段落、代码块、引用块、padding/背景色
  - `ThemeData` 切换时颜色与背景的正确性
  - `createCodeFriendly` 的字体族、字号、字距与 padding 覆盖，并验证基础样式未丢失

<sup>Written for commit 37bf667dc2c9ddd1358f71fe76c57813d9d4bdd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

