### PR TITLE
🧹 [移除 HTTP 错误处理中的冗余类型检查]

### DIFF
--- a/lib/utils/http_utils.dart
+++ b/lib/utils/http_utils.dart
@@ -136,11 +136,7 @@ class HttpUtils {
 
       try {
         if (e.response?.data != null) {
-          if (e.response!.data is String) {
-            errorBody = e.response!.data;
-          } else {
-            errorBody = e.response!.data.toString();
-          }
+          errorBody = e.response!.data.toString();
         }
       } catch (readError) {
         logDebug('读取错误响应体失败: $readError');


### PR DESCRIPTION
🎯 What:
移除了 `lib/utils/http_utils.dart` 中第 141 行对 `e.response!.data is String` 的冗余类型检查和条件分支。

💡 Why:
因为在 Dart 中调用 `.toString()`，当对象本身是 `String` 类型时将安全地返回其本身，无额外开销或副作用；如果为非字符串类型，则会执行相应对象的 `.toString()`，这与原来的逻辑意图完全一致。移除此无用类型判断不仅消除了静态分析器的警告，也提高了代码的整洁性和可读性。

✅ Verification:
1. 通过 `cat` 等命令验证代码已正确修改。
2. 运行 `flutter analyze lib/utils/http_utils.dart` 未发现任何报错。
3. 运行 `flutter test test/all_tests.dart` 及相关单元测试 `test/unit/utils/http_utils_test.dart` 确认现有 HTTP 功能无异常或退化。

✨ Result:
优化了 HTTP 工具类的错误处理逻辑，减少了冗余代码。

---
*PR created automatically by Jules for task [7875094794370199908](https://jules.google.com/task/7875094794370199908) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
移除 `lib/utils/http_utils.dart` 中 HTTP 错误处理里对 `e.response!.data is String` 的冗余分支，直接使用 `toString()` 获取错误体。保持行为不变，减少冗余代码并消除静态分析警告。

<sup>Written for commit b288d48362c5b44e740de5de72f20037db432e8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

