### PR TITLE
🧹 代码健康: 修复流式错误处理中的死代码

### DIFF
--- a/lib/utils/streaming_utils.dart
+++ b/lib/utils/streaming_utils.dart
@@ -266,9 +266,10 @@ class StreamingUtils {
 
       if (response.statusCode != 200) {
         String errorBody = '';
-        if (response.data is Stream) {
+        if (response.data is ResponseBody) {
+          final responseBody = response.data as ResponseBody;
           final chunks = <int>[];
-          await for (final chunk in response.data) {
+          await for (final chunk in responseBody.stream) {
             chunks.addAll(chunk);
           }
           errorBody = utf8.decode(chunks);
@@ -306,13 +307,11 @@ class StreamingUtils {
             final responseData = e.response!.data;
             if (responseData is String) {
               errorBody = responseData;
-            } else if (responseData is Stream) {
+            } else if (responseData is ResponseBody) {
               // 对于流式响应，需要读取流数据
               final chunks = <int>[];
-              await for (final chunk in responseData) {
-                if (chunk is List<int>) {
-                  chunks.addAll(chunk);
-                }
+              await for (final chunk in responseData.stream) {
+                chunks.addAll(chunk);
               }
               errorBody = utf8.decode(chunks);
             } else {

--- a/lib/utils/streaming_utils.dart
+++ b/lib/utils/streaming_utils.dart
@@ -285,8 +285,12 @@ class StreamingUtils {
       }
 
       // 处理流式响应
+      final streamData = response.data is ResponseBody
+          ? (response.data as ResponseBody).stream
+          : response.data;
+
       await _processStreamResponseDio(
-        response.data,
+        streamData,
         onResponse,
         onComplete,
         onError,


### PR DESCRIPTION
🎯 **What:**
修复了 `lib/utils/streaming_utils.dart` 中处理流式响应错误时的两处死代码警告。将原来的 `response.data is Stream` 判断更正为 `response.data is ResponseBody` 并读取其内部的 `.stream`。

💡 **Why:**
在 Dio 中，当 `ResponseType` 被设置为 `stream` 时，HTTP 响应体返回的对象类型是 `ResponseBody` 而不是直接的 `Stream`。因此，先前的 `is Stream` 分支实际上永远无法进入，从而使这部分专门处理流式错误响应的解析逻辑失效，导致错误信息未能被正确解析并输出。修复后能够正确的识别和提取由流式接口返回的具体错误内容。

✅ **Verification:**
1. 验证 `flutter analyze lib/utils/streaming_utils.dart`，已不再报出该代码段相关的提示或警告。
2. 运行 `flutter test`，全部用例通过（273 个测试用例，未引入 regression）。
3. 已通过局部验证脚本确认了 Dio `ResponseType.stream` 确实返回 `ResponseBody`，修复逻辑准确无误。

✨ **Result:**
移除了潜在的冗余无用代码并使原定的流错误解码逻辑重新生效，提升了代码健康度和错误处理的健壮性。

---
*PR created automatically by Jules for task [7999403803209037959](https://jules.google.com/task/7999403803209037959) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `dio` 的 `ResponseType.stream` 场景中对流的类型判断与读取，统一从 `ResponseBody.stream` 获取字节。确保 200 与非 200 响应都能被正确解码并传递处理。

- **Bug Fixes**
  - 非 200 错误处理：将 `response.data is Stream` 更正为 `response.data is ResponseBody`，使用 `.stream` 聚合并 `utf8.decode`；同步修正 `DioException` 分支，移除无法命中的逻辑。
  - 200 正常流响应：当返回 `ResponseBody` 时，提取 `.stream` 传入 `_processStreamResponseDio`（其期望 `Stream<List<int>>`），修复参数类型错误。

<sup>Written for commit 49a8da0689040ef228cf90085a131fc5a2295dce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

