### PR TITLE
🧪 改进测试: 补充 StreamFileSelector 单元测试

### DIFF
--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -69,6 +69,7 @@ import 'unit/utils/app_logger_test.dart' as app_logger_test;
 import 'unit/utils/location_weather_helper_test.dart'
     as location_weather_helper_test;
 import 'unit/utils/chat_markdown_styles_test.dart' as chat_markdown_styles_test;
+import 'unit/utils/stream_file_selector_test.dart' as stream_file_selector_test;
 import 'unit/widgets/anniversary_animation_overlay_test.dart'
     as anniversary_animation_overlay_test;
 import 'unit/widgets/anniversary_notebook_icon_test.dart'
@@ -135,6 +136,7 @@ void main() {
       app_logger_test.main();
       location_weather_helper_test.main();
       chat_markdown_styles_test.main();
+      stream_file_selector_test.main();
       anniversary_animation_overlay_test.main();
       anniversary_notebook_icon_test.main();
       motion_photo_preview_page_test.main();

--- a/test/unit/utils/stream_file_selector_test.dart
+++ b/test/unit/utils/stream_file_selector_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+import 'package:thoughtecho/utils/stream_file_selector.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('StreamFileSelector', () {
+    const channel = MethodChannel('thoughtecho/file_selector');
+
+    setUp(() {
+      StreamFileSelector.disableNativeSelector();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'isAvailable') {
+          return true;
+        }
+        return null;
+      });
+    });
+
+    tearDown(() {
+      StreamFileSelector.disableNativeSelector();
+    });
+
+    test('enableNativeSelector should set _useNativeSelector to true',
+        () async {
+      StreamFileSelector.enableNativeSelector();
+      final isAvailable =
+          await StreamFileSelector.isNativeFileSelectorAvailable();
+      expect(isAvailable, isTrue);
+    });
+
+    test('disableNativeSelector should set _useNativeSelector to false',
+        () async {
+      StreamFileSelector.enableNativeSelector();
+      StreamFileSelector.disableNativeSelector();
+      final isAvailable =
+          await StreamFileSelector.isNativeFileSelectorAvailable();
+      expect(isAvailable, isFalse);
+    });
+
+    test(
+        'isNativeFileSelectorAvailable should return false if useNativeSelector is false',
+        () async {
+      final isAvailable =
+          await StreamFileSelector.isNativeFileSelectorAvailable();
+      expect(isAvailable, isFalse);
+    });
+
+    test('isNativeFileSelectorAvailable should handle timeout gracefully',
+        () async {
+      StreamFileSelector.enableNativeSelector();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'isAvailable') {
+          // 模拟超时
+          await Future.delayed(const Duration(milliseconds: 2100));
+          return true;
+        }
+        return null;
+      });
+
+      final isAvailable =
+          await StreamFileSelector.isNativeFileSelectorAvailable();
+      expect(isAvailable, isFalse);
+    });
+
+    test('isNativeFileSelectorAvailable should handle exception gracefully',
+        () async {
+      StreamFileSelector.enableNativeSelector();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'isAvailable') {
+          throw Exception('Method call failed');
+        }
+        return null;
+      });
+
+      final isAvailable =
+          await StreamFileSelector.isNativeFileSelectorAvailable();
+      expect(isAvailable, isFalse);
+    });
+  });
+}

--- a/test/unit/utils/stream_file_selector_test.dart
+++ b/test/unit/utils/stream_file_selector_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/utils/stream_file_selector.dart';
 
 void main() {


### PR DESCRIPTION
🎯 **What:**
The `StreamFileSelector` utility class lacked unit tests, creating a gap in testing its configuration methods and method channel integration.

📊 **Coverage:**
- Covered `enableNativeSelector` logic.
- Covered `disableNativeSelector` logic.
- Covered `isNativeFileSelectorAvailable` behavior under various conditions:
  - When the native selector is explicitly disabled.
  - When the underlying `MethodChannel` times out gracefully.
  - When the underlying `MethodChannel` throws an exception.
- Tests are completely isolated via `TestDefaultBinaryMessengerBinding` mocking the `thoughtecho/file_selector` channel.

✨ **Result:**
Improved overall code coverage and reliability by ensuring the configuration and environment checking aspects of the `StreamFileSelector` are formally verified in the `test/all_tests.dart` suite without regressions.

---
*PR created automatically by Jules for task [2181378595275555115](https://jules.google.com/task/2181378595275555115) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `StreamFileSelector` 增加单元测试，覆盖启用/禁用原生选择器与可用性判断，并验证 `MethodChannel` 的超时和异常处理。对齐任务 2181378595275555115 的测试覆盖要求，提升稳定性与覆盖率。

- **测试覆盖**
  - 覆盖 `enableNativeSelector` / `disableNativeSelector`
  - 验证 `isNativeFileSelectorAvailable` 在禁用、超时、异常时的返回值
  - 通过 `TestDefaultBinaryMessengerBinding` mock `thoughtecho/file_selector` 通道，保证测试隔离
  - 在 `test/all_tests.dart` 中注册并运行该测试

<sup>Written for commit f59ffc96df1c40f1fe588de36f65c070bdad0ef2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 增加了文件选择器功能的单元测试覆盖，包含状态管理、超时处理和异常处理等测试场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->