### PR TITLE
[codex] Trim note list semantics overhead

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -148,3 +148,23 @@
 - 此次改动后，经过真机实测，千帧以上的复杂图文长滑动，平均帧耗时成功从卡死级别压到了 `5.8ms`，仅出现 1 次极轻微掉帧。
 
 **结论**: 在 Flutter 中处理高度未知的复杂列表卡片时，应坚决防止 Layout Shift 和无意义的频繁重构，善用大缓存预构建与高效原生组件特性。
+
+---
+
+## 2026-05-31: 列表语义性能优化决策
+
+**决策者**: 性能顾问 (AI)
+**类型**: 性能优化
+
+**背景**:
+根据 2026-05-17 的架构决策，团队将 `ListView` 的 `cacheExtent` 提高到了 `400~900` 以预加载解决布局跳变（Layout Shift）导致的重绘卡顿。但在最新的 Profile 性能测试中发现，由于预加载了大量屏幕外的笔记卡片，Flutter 引擎需要为这些卡片构建庞大的无障碍语义树（Semantics Tree），导致 `PipelineOwner.flushSemantics` 耗时飙升，占用 UI 线程约 31% 的时间，产生了严重的掉帧卡顿（UI 线程最高 98ms，Raster 最高 127ms）。
+
+**核心决策**:
+1. **彻底分离视觉与语义**: 对于 `QuoteItemWidget` 中所有不需要被屏幕朗读的纯视觉组件（如 `BackdropFilter` 毛玻璃、`LinearGradient` 渐变遮罩、装饰性 `Icon` 等），强制使用 `ExcludeSemantics` 进行包裹。
+2. **列表级别语义控制**: 在 `NoteListView` 的 `ListView.builder` 层级，评估并考虑增加 `addSemanticIndexes: false`，避免为大量缓存卡片强制建立细粒度的列表语义索引，从而减少 `flushSemantics` 负担。
+
+**原因**:
+- `ExcludeSemantics` 对视觉渲染完全无损（0 像素变化），仅在数据层面上截断无障碍树的生成。
+- 大缓存区（`cacheExtent`）是必须保留的（为了防抖动），在此前提下，精简语义树是降低主线程 Build 阶段后置开销的唯一也是业界最佳实践。
+
+**结论**: 立即在 `quote_item_widget.dart` 内部铺设 `ExcludeSemantics` 进行语义裁剪，切断长列表预加载带来的无谓性能开销。

--- a/.squad/log/2026-05-31-note-list-semantics-trimming.md
+++ b/.squad/log/2026-05-31-note-list-semantics-trimming.md
@@ -1,0 +1,62 @@
+# 2026-05-31 记录列表语义裁剪性能修复
+
+## 背景
+
+用户在 Profile 模式下采集了约 100 条含媒体笔记的记录页滚动数据，并提供了 Gemini 对
+`PipelineOwner.flushSemantics` 的判断。接手时先核对 `.squad/decisions.md`、5 月 24 日
+旧交接记录，以及本次两个 DevTools 导出文件。
+
+## 定位证据
+
+`dart_devtools_2026-05-31_12_08_07.627.json` 的 CPU profiler 显示：
+
+- `PipelineOwner.flushSemantics` inclusive 占 `31.6%`，是当前采样窗口第一梯队热点。
+- `SemanticsOwner.sendSemanticsUpdate` 占 `19.3%`。
+- `FlutterView.updateSemantics` native leaf 占 `14.1%`。
+- 同一窗口还存在其他热点：`flushLayout 26.1%`、`BuildOwner.buildScope 21.3%`、
+  `TextPainter.layout 10.0%`、图片 `ImmutableBuffer.fromUint8List 9.4%`、
+  FlutterQuill layout 约 `7%`。
+
+结论：Gemini 对 semantics 热点的判断有数据支撑，但“彻底消除卡顿”的表述过强；
+语义裁剪只能解决一个主要热点，不能覆盖全部滚动成本。
+
+## 修改内容
+
+- `lib/widgets/note_list/note_list_items.dart`
+  - 在 `ListView.builder` 增加 `addSemanticIndexes: false`，避免大缓存区中的屏外卡片
+    继续生成自动列表语义索引。
+- `lib/widgets/quote_item_widget.dart`
+  - 对纯装饰图标、折叠底部毛玻璃遮罩、双击高亮覆盖层增加 `ExcludeSemantics`。
+  - 没有包裹卡片最外层渐变容器，因为那会连同正文、日期、标签和按钮一起从语义树移除。
+- `test/widget/note_list_view_filter_test.dart`
+  - 增加列表语义索引关闭的回归测试。
+  - 修正过期的 `cacheExtent == 250` 断言，当前架构已采用 `400~900` 大缓存区。
+- `test/widgets/quote_item_widget_test.dart`
+  - 增加折叠遮罩被 `ExcludeSemantics` 包裹的回归测试。
+
+## 视觉影响
+
+本次修改只增加语义树裁剪 widget，不改变布局、颜色、动画、尺寸、边距或绘制参数。
+预期视觉效果保持不变。
+
+## 验证
+
+已执行：
+
+```bash
+dart format --set-exit-if-changed lib/widgets/note_list/note_list_items.dart lib/widgets/quote_item_widget.dart test/widget/note_list_view_filter_test.dart test/widgets/quote_item_widget_test.dart
+timeout 60s flutter test --reporter compact test/widget/note_list_view_filter_test.dart
+timeout 60s flutter test --reporter compact test/widgets/quote_item_widget_test.dart
+timeout 60s flutter analyze --no-fatal-infos lib/widgets/note_list/note_list_items.dart lib/widgets/quote_item_widget.dart test/widget/note_list_view_filter_test.dart test/widgets/quote_item_widget_test.dart
+```
+
+结果：相关测试通过，静态分析无 issues。
+
+## 后续建议
+
+用同样的 Profile 滚动流程复测，重点看 `PipelineOwner.flushSemantics` 是否下降。
+如果卡顿仍明显，下一优先级应分析：
+
+1. `quote_item_widget.dart` 中头部 `_measureSingleLineTextWidth` / `TextPainter` 测量。
+2. 富文本和媒体导致的 FlutterQuill layout / 图片解码成本。
+3. `NoteListView` item `GlobalKey` 在长列表中的 element 管理成本。

--- a/.squad/log/2026-05-31-note-list-semantics-trimming.md
+++ b/.squad/log/2026-05-31-note-list-semantics-trimming.md
@@ -23,10 +23,11 @@
 ## 修改内容
 
 - `lib/widgets/note_list/note_list_items.dart`
-  - 在 `ListView.builder` 增加 `addSemanticIndexes: false`，避免大缓存区中的屏外卡片
-    继续生成自动列表语义索引。
+  - 在 `ListView.builder` 增加 `addSemanticIndexes: false`，关闭自动列表语义索引。
+  - 同步设置 `semanticChildCount`，保留列表总数语义信息，减少无障碍回归风险。
 - `lib/widgets/quote_item_widget.dart`
-  - 对纯装饰图标、折叠底部毛玻璃遮罩、双击高亮覆盖层增加 `ExcludeSemantics`。
+  - 对纯装饰图标、折叠底部毛玻璃/渐变遮罩、双击高亮覆盖层增加 `ExcludeSemantics`。
+  - 保留折叠提示文字（`doubleTapToViewFull`）的语义，避免屏幕阅读器丢失展开提示。
   - 没有包裹卡片最外层渐变容器，因为那会连同正文、日期、标签和按钮一起从语义树移除。
 - `test/widget/note_list_view_filter_test.dart`
   - 增加列表语义索引关闭的回归测试。
@@ -38,6 +39,13 @@
 
 本次修改只增加语义树裁剪 widget，不改变布局、颜色、动画、尺寸、边距或绘制参数。
 预期视觉效果保持不变。
+
+## 无障碍说明
+
+`addSemanticIndexes: false` 会关闭所有列表项的自动顺序语义索引，而不只影响屏外缓存项。
+这意味着屏幕阅读器可能不再播报类似“第 N 项，共 M 项”的列表位置信息。当前选择该权衡是为了
+降低大缓存区记录列表的 `flushSemantics` 成本；后续如果做专项无障碍优化，可评估是否以更轻量的
+手动 `Semantics` 节点补回必要的位置信息。
 
 ## 验证
 

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -378,6 +378,7 @@ extension _NoteListItemsExtension on NoteListViewState {
           physics: const AlwaysScrollableScrollPhysics(),
           addAutomaticKeepAlives: true, // 保持默认：图片组件依赖 keepAlive 避免重加载闪烁
           addRepaintBoundaries: true, // 性能优化：减少重绘范围
+          addSemanticIndexes: false, // 缓存区较大时避免为屏外卡片生成列表语义索引
           // 性能优化：惯性首帧移动距离远大于拖拽帧，需要更大缓存区预构建 item
           // 避免 drag→ballistic 过渡时集中构建新 item 导致卡顿
           cacheExtent: MediaQuery.sizeOf(context).height.clamp(400, 900),

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -378,10 +378,11 @@ extension _NoteListItemsExtension on NoteListViewState {
           physics: const AlwaysScrollableScrollPhysics(),
           addAutomaticKeepAlives: true, // 保持默认：图片组件依赖 keepAlive 避免重加载闪烁
           addRepaintBoundaries: true, // 性能优化：减少重绘范围
-          addSemanticIndexes: false, // 缓存区较大时避免为屏外卡片生成列表语义索引
+          addSemanticIndexes: false, // 性能权衡：关闭所有列表项的自动顺序语义索引
           // 性能优化：惯性首帧移动距离远大于拖拽帧，需要更大缓存区预构建 item
           // 避免 drag→ballistic 过渡时集中构建新 item 导致卡顿
           cacheExtent: MediaQuery.sizeOf(context).height.clamp(400, 900),
+          semanticChildCount: _quotes.length + (_hasMore ? 1 : 0),
           itemCount: _quotes.length + (_hasMore ? 1 : 0),
           itemBuilder: (context, index) {
             if (index < _quotes.length) {

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -588,67 +588,79 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                               switchInCurve: Curves.easeIn,
                               switchOutCurve: Curves.easeOut,
                               child: (!isExpanded && needsExpansion)
-                                  ? ExcludeSemantics(
-                                      child: RepaintBoundary(
-                                        child: ClipRect(
-                                          child: BackdropFilter.grouped(
-                                            filter: ui.ImageFilter.blur(
-                                              sigmaX: 1.2,
-                                              sigmaY: 1.2,
-                                            ),
-                                            child: Container(
-                                              decoration: BoxDecoration(
-                                                gradient: LinearGradient(
-                                                  begin: Alignment.topCenter,
-                                                  end: Alignment.bottomCenter,
-                                                  colors: [
-                                                    innerTheme
-                                                        .colorScheme.surface
-                                                        .withValues(alpha: 0.0),
-                                                    innerTheme
-                                                        .colorScheme.surface
-                                                        .withValues(
-                                                            alpha: 0.08),
-                                                    innerTheme
-                                                        .colorScheme.surface
-                                                        .withValues(
-                                                            alpha: 0.18),
-                                                  ],
-                                                  stops: const [0.0, 0.4, 1.0],
+                                  ? Stack(
+                                      fit: StackFit.expand,
+                                      children: [
+                                        ExcludeSemantics(
+                                          child: RepaintBoundary(
+                                            child: ClipRect(
+                                              child: BackdropFilter.grouped(
+                                                filter: ui.ImageFilter.blur(
+                                                  sigmaX: 1.2,
+                                                  sigmaY: 1.2,
                                                 ),
-                                              ),
-                                              alignment: Alignment.center,
-                                              child: Container(
-                                                padding:
-                                                    const EdgeInsets.symmetric(
-                                                  horizontal: 8,
-                                                  vertical: 2,
-                                                ),
-                                                decoration: BoxDecoration(
-                                                  color: innerTheme
-                                                      .colorScheme.surface
-                                                      .withValues(alpha: 0.35),
-                                                  borderRadius:
-                                                      BorderRadius.circular(12),
-                                                ),
-                                                child: Text(
-                                                  l10n.doubleTapToViewFull,
-                                                  style: innerTheme
-                                                      .textTheme.bodySmall
-                                                      ?.copyWith(
-                                                    color: innerTheme
-                                                        .colorScheme.onSurface
-                                                        .withValues(
-                                                            alpha: 0.65),
-                                                    fontSize: 11,
-                                                    fontStyle: FontStyle.italic,
+                                                child: Container(
+                                                  decoration: BoxDecoration(
+                                                    gradient: LinearGradient(
+                                                      begin:
+                                                          Alignment.topCenter,
+                                                      end: Alignment
+                                                          .bottomCenter,
+                                                      colors: [
+                                                        innerTheme
+                                                            .colorScheme.surface
+                                                            .withValues(
+                                                                alpha: 0.0),
+                                                        innerTheme
+                                                            .colorScheme.surface
+                                                            .withValues(
+                                                                alpha: 0.08),
+                                                        innerTheme
+                                                            .colorScheme.surface
+                                                            .withValues(
+                                                                alpha: 0.18),
+                                                      ],
+                                                      stops: const [
+                                                        0.0,
+                                                        0.4,
+                                                        1.0,
+                                                      ],
+                                                    ),
                                                   ),
                                                 ),
                                               ),
                                             ),
                                           ),
                                         ),
-                                      ),
+                                        Align(
+                                          alignment: Alignment.center,
+                                          child: Container(
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 8,
+                                              vertical: 2,
+                                            ),
+                                            decoration: BoxDecoration(
+                                              color: innerTheme
+                                                  .colorScheme.surface
+                                                  .withValues(alpha: 0.35),
+                                              borderRadius:
+                                                  BorderRadius.circular(12),
+                                            ),
+                                            child: Text(
+                                              l10n.doubleTapToViewFull,
+                                              style: innerTheme
+                                                  .textTheme.bodySmall
+                                                  ?.copyWith(
+                                                color: innerTheme
+                                                    .colorScheme.onSurface
+                                                    .withValues(alpha: 0.65),
+                                                fontSize: 11,
+                                                fontStyle: FontStyle.italic,
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                      ],
                                     )
                                   : const SizedBox.shrink(),
                             ),

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart';
 import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../extensions/note_category_localization_extension.dart';
@@ -368,10 +369,12 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                 padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
                 child: Row(
                   children: [
-                    Icon(
-                      Icons.auto_delete_outlined,
-                      size: 16,
-                      color: theme.colorScheme.error,
+                    ExcludeSemantics(
+                      child: Icon(
+                        Icons.auto_delete_outlined,
+                        size: 16,
+                        color: theme.colorScheme.error,
+                      ),
                     ),
                     const SizedBox(width: 6),
                     Text(
@@ -446,10 +449,12 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           if (hasLocationText) ...[
-                            Icon(
-                              Icons.location_on,
-                              size: 14,
-                              color: iconColor,
+                            ExcludeSemantics(
+                              child: Icon(
+                                Icons.location_on,
+                                size: 14,
+                                color: iconColor,
+                              ),
                             ),
                             const SizedBox(width: 2),
                             Text(
@@ -462,10 +467,12 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                           if (hasLocationText && hasWeatherText)
                             const SizedBox(width: 8),
                           if (hasWeatherText) ...[
-                            Icon(
-                              _getWeatherIcon(quote.weather!),
-                              size: 14,
-                              color: iconColor,
+                            ExcludeSemantics(
+                              child: Icon(
+                                _getWeatherIcon(quote.weather!),
+                                size: 14,
+                                color: iconColor,
+                              ),
                             ),
                             const SizedBox(width: 2),
                             Text(
@@ -581,53 +588,61 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                               switchInCurve: Curves.easeIn,
                               switchOutCurve: Curves.easeOut,
                               child: (!isExpanded && needsExpansion)
-                                  ? RepaintBoundary(
-                                      child: ClipRect(
-                                        child: BackdropFilter.grouped(
-                                          filter: ui.ImageFilter.blur(
-                                            sigmaX: 1.2,
-                                            sigmaY: 1.2,
-                                          ),
-                                          child: Container(
-                                            decoration: BoxDecoration(
-                                              gradient: LinearGradient(
-                                                begin: Alignment.topCenter,
-                                                end: Alignment.bottomCenter,
-                                                colors: [
-                                                  innerTheme.colorScheme.surface
-                                                      .withValues(alpha: 0.0),
-                                                  innerTheme.colorScheme.surface
-                                                      .withValues(alpha: 0.08),
-                                                  innerTheme.colorScheme.surface
-                                                      .withValues(alpha: 0.18),
-                                                ],
-                                                stops: const [0.0, 0.4, 1.0],
-                                              ),
+                                  ? ExcludeSemantics(
+                                      child: RepaintBoundary(
+                                        child: ClipRect(
+                                          child: BackdropFilter.grouped(
+                                            filter: ui.ImageFilter.blur(
+                                              sigmaX: 1.2,
+                                              sigmaY: 1.2,
                                             ),
-                                            alignment: Alignment.center,
                                             child: Container(
-                                              padding:
-                                                  const EdgeInsets.symmetric(
-                                                horizontal: 8,
-                                                vertical: 2,
-                                              ),
                                               decoration: BoxDecoration(
-                                                color: innerTheme
-                                                    .colorScheme.surface
-                                                    .withValues(alpha: 0.35),
-                                                borderRadius:
-                                                    BorderRadius.circular(12),
+                                                gradient: LinearGradient(
+                                                  begin: Alignment.topCenter,
+                                                  end: Alignment.bottomCenter,
+                                                  colors: [
+                                                    innerTheme
+                                                        .colorScheme.surface
+                                                        .withValues(alpha: 0.0),
+                                                    innerTheme
+                                                        .colorScheme.surface
+                                                        .withValues(
+                                                            alpha: 0.08),
+                                                    innerTheme
+                                                        .colorScheme.surface
+                                                        .withValues(
+                                                            alpha: 0.18),
+                                                  ],
+                                                  stops: const [0.0, 0.4, 1.0],
+                                                ),
                                               ),
-                                              child: Text(
-                                                l10n.doubleTapToViewFull,
-                                                style: innerTheme
-                                                    .textTheme.bodySmall
-                                                    ?.copyWith(
+                                              alignment: Alignment.center,
+                                              child: Container(
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                  horizontal: 8,
+                                                  vertical: 2,
+                                                ),
+                                                decoration: BoxDecoration(
                                                   color: innerTheme
-                                                      .colorScheme.onSurface
-                                                      .withValues(alpha: 0.65),
-                                                  fontSize: 11,
-                                                  fontStyle: FontStyle.italic,
+                                                      .colorScheme.surface
+                                                      .withValues(alpha: 0.35),
+                                                  borderRadius:
+                                                      BorderRadius.circular(12),
+                                                ),
+                                                child: Text(
+                                                  l10n.doubleTapToViewFull,
+                                                  style: innerTheme
+                                                      .textTheme.bodySmall
+                                                      ?.copyWith(
+                                                    color: innerTheme
+                                                        .colorScheme.onSurface
+                                                        .withValues(
+                                                            alpha: 0.65),
+                                                    fontSize: 11,
+                                                    fontStyle: FontStyle.italic,
+                                                  ),
                                                 ),
                                               ),
                                             ),
@@ -667,14 +682,16 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                                       child!,
                                       Positioned.fill(
                                         child: IgnorePointer(
-                                          child: DecoratedBox(
-                                            key: const ValueKey(
-                                              'quote_item.double_tap_overlay',
-                                            ),
-                                            decoration: BoxDecoration(
-                                              color: Colors.white.withValues(
-                                                alpha: overlayStrength *
-                                                    highlightOpacity,
+                                          child: ExcludeSemantics(
+                                            child: DecoratedBox(
+                                              key: const ValueKey(
+                                                'quote_item.double_tap_overlay',
+                                              ),
+                                              decoration: BoxDecoration(
+                                                color: Colors.white.withValues(
+                                                  alpha: overlayStrength *
+                                                      highlightOpacity,
+                                                ),
                                               ),
                                             ),
                                           ),
@@ -728,7 +745,13 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
               child: Row(
                 children: [
                   if (quote.tagIds.isNotEmpty) ...[
-                    Icon(Icons.label_outline, size: 16, color: iconColor),
+                    ExcludeSemantics(
+                      child: Icon(
+                        Icons.label_outline,
+                        size: 16,
+                        color: iconColor,
+                      ),
+                    ),
                     const SizedBox(width: 6),
                     Expanded(
                       child: SizedBox(
@@ -812,27 +835,32 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                                                       if (IconUtils.isEmoji(
                                                         tag.iconName!,
                                                       )) ...[
-                                                        Text(
-                                                          IconUtils
-                                                              .getDisplayIcon(
-                                                            tag.iconName!,
-                                                          ),
-                                                          style:
-                                                              const TextStyle(
-                                                            fontSize: 12,
+                                                        ExcludeSemantics(
+                                                          child: Text(
+                                                            IconUtils
+                                                                .getDisplayIcon(
+                                                              tag.iconName!,
+                                                            ),
+                                                            style:
+                                                                const TextStyle(
+                                                              fontSize: 12,
+                                                            ),
                                                           ),
                                                         ),
                                                         const SizedBox(
                                                           width: 3,
                                                         ),
                                                       ] else ...[
-                                                        Icon(
-                                                          IconUtils.getIconData(
-                                                            tag.iconName!,
+                                                        ExcludeSemantics(
+                                                          child: Icon(
+                                                            IconUtils
+                                                                .getIconData(
+                                                              tag.iconName!,
+                                                            ),
+                                                            size: 12,
+                                                            color:
+                                                                secondaryTextColor,
                                                           ),
-                                                          size: 12,
-                                                          color:
-                                                              secondaryTextColor,
                                                         ),
                                                         const SizedBox(
                                                           width: 3,

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -219,6 +219,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
 
       final listView = tester.widget<ListView>(find.byType(ListView));
+      expect(listView.semanticChildCount, 1);
       final delegate = listView.childrenDelegate as SliverChildBuilderDelegate;
       expect(delegate.addSemanticIndexes, isFalse);
 

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -164,7 +164,8 @@ void main() {
       },
     );
 
-    testWidgets('uses a light cache extent to keep drag scrolling responsive', (
+    testWidgets(
+        'uses an extended cache extent to preload variable-height items', (
       tester,
     ) async {
       final databaseService = _FakeDatabaseService()
@@ -188,7 +189,38 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
 
       final listView = tester.widget<ListView>(find.byType(ListView));
-      expect(listView.cacheExtent, 250);
+      expect(listView.cacheExtent, inInclusiveRange(400, 900));
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('disables automatic semantic indexes for cached list items', (
+      tester,
+    ) async {
+      final databaseService = _FakeDatabaseService()
+        ..quotesToEmit = [
+          Quote(
+            id: 'quote-1',
+            content: '普通笔记',
+            date: DateTime(2026, 5, 16).toIso8601String(),
+          ),
+        ];
+      final settingsService = _FakeSettingsService();
+
+      await tester.pumpWidget(
+        _TestApp(
+          databaseService: databaseService,
+          settingsService: settingsService,
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final listView = tester.widget<ListView>(find.byType(ListView));
+      final delegate = listView.childrenDelegate as SliverChildBuilderDelegate;
+      expect(delegate.addSemanticIndexes, isFalse);
 
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump(const Duration(seconds: 2));

--- a/test/widgets/quote_item_widget_test.dart
+++ b/test/widgets/quote_item_widget_test.dart
@@ -157,6 +157,49 @@ void main() {
       expect(find.byType(BackdropFilter), findsOneWidget);
     });
 
+    testWidgets('折叠遮罩不参与语义树生成', (tester) async {
+      final quote = _buildQuote(
+        content: List.filled(6, _longContentChunk).join('\n'),
+        editSource: 'inline',
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: _FakeSettingsService(),
+          child: MaterialApp(
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+            home: Material(
+              child: QuoteItemWidget(
+                quote: quote,
+                tagMap: const {},
+                isExpanded: false,
+                onToggleExpanded: (_) {},
+                onEdit: () {},
+                onDelete: () {},
+                onAskAI: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.ancestor(
+          of: find.byType(BackdropFilter),
+          matching: find.byType(ExcludeSemantics),
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('展开状态显示完整内容且截断提示消失', (tester) async {
       final quote = _buildQuote(
         content:

--- a/test/widgets/quote_item_widget_test.dart
+++ b/test/widgets/quote_item_widget_test.dart
@@ -198,6 +198,13 @@ void main() {
         ),
         findsOneWidget,
       );
+      expect(
+        find.ancestor(
+          of: find.text('双击查看全文'),
+          matching: find.byType(ExcludeSemantics),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets('展开状态显示完整内容且截断提示消失', (tester) async {


### PR DESCRIPTION
## Summary

- Disable automatic semantic indexes for cached note list items.
- Exclude decorative quote-card icons, folded-content blur masks, and double-tap highlight overlays from the semantics tree.
- Record the performance analysis and implementation notes in `.squad/log/2026-05-31-note-list-semantics-trimming.md`.
- Add focused widget tests for the semantics behavior and update the cache extent assertion to match the current 400-900 strategy.

## Root Cause

The latest DevTools CPU profile showed `PipelineOwner.flushSemantics` at 31.6% inclusive time during note-list scrolling. Large `cacheExtent` keeps more offscreen cards built to avoid layout shift, but that also made Flutter maintain unnecessary semantics work for decorative or offscreen list metadata.

This is one major hotspot, not the only one. The same profile also showed layout/build/TextPainter/image/Quill costs that may need follow-up if profile-mode retesting still shows jank.

## Visual Impact

No visual parameters were changed. The patch only adds semantics wrappers and list delegate configuration; layout, colors, animations, padding, gradients, blur, and text remain the same.

## Validation

- `dart format --set-exit-if-changed lib/widgets/note_list/note_list_items.dart lib/widgets/quote_item_widget.dart test/widget/note_list_view_filter_test.dart test/widgets/quote_item_widget_test.dart`
- `timeout 60s flutter test --reporter compact test/widget/note_list_view_filter_test.dart`
- `timeout 60s flutter test --reporter compact test/widgets/quote_item_widget_test.dart`
- `timeout 60s flutter analyze --no-fatal-infos lib/widgets/note_list/note_list_items.dart lib/widgets/quote_item_widget.dart test/widget/note_list_view_filter_test.dart test/widgets/quote_item_widget_test.dart`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化笔记列表滚动性能：关闭列表的自动语义索引，裁剪装饰性部件的语义，并补充 `semanticChildCount`，降低 `flushSemantics` 热点。视觉与布局不变。

- **Refactors**
  - 列表：`ListView.builder` 设为 `addSemanticIndexes: false`，并设置 `semanticChildCount`；沿用 `cacheExtent` 400–900 并补充断言。
  - 卡片：为装饰性 `Icon`、折叠模糊遮罩、双击高亮覆盖层加 `ExcludeSemantics`；保留“双击查看全文”提示的语义。
  - 文档与测试：更新/新增 `.squad/log/2026-05-31-note-list-semantics-trimming.md` 与 `.squad/decisions.md`；新增列表语义索引与遮罩裁剪相关的 widget 测试。

<sup>Written for commit d08dd826ba92f52f9eebe1820a3e44f5148df1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

