### PR TITLE
feat: implement standard A4 PDF export with rich-text compilation, batch selection, and print preview

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3745,5 +3745,9 @@
   },
   "pleaseSelectAtLeastOneNote": "Please select at least one note first",
   "selectedNotesHaveNoCategories": "Selected notes have no category tags",
-  "pdfPreviewAndPrint": "PDF Preview & Print"
+  "pdfPreviewAndPrint": "PDF Preview & Print",
+  "webdavSyncOnCellular": "Sync over cellular data",
+  "webdavSyncOnCellularSubtitle": "Allow cloud backup and merge under mobile data networks",
+  "webdavSyncNotesOnlyOnCellular": "Sync notes only on cellular",
+  "webdavSyncNotesOnlyOnCellularSubtitle": "Only sync lightweight text notes and skip heavy media files to save data"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3725,5 +3725,25 @@
     }
   },
   "exportSuccess": "Export Successful",
-  "exportFailed": "Export Failed"
+  "exportFailed": "Export Failed",
+  "generatingPdf": "Generating PDF...",
+  "pdfExportFailed": "Failed to export PDF: {error}",
+  "@pdfExportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "batchPdfExportFailed": "Failed to batch export PDF: {error}",
+  "@batchPdfExportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "pleaseSelectAtLeastOneNote": "Please select at least one note first",
+  "selectedNotesHaveNoCategories": "Selected notes have no category tags",
+  "pdfPreviewAndPrint": "PDF Preview & Print"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3707,5 +3707,23 @@
       }
     }
   },
-  "webdavViewNow": "View Now"
+  "webdavViewNow": "View Now",
+  "exportFormatLabel": "Default Export Format",
+  "exportFormatCard": "Delicate Share Card",
+  "exportFormatPdf": "Standard A4 PDF",
+  "exportFormatDesc": "Configure the default format when exporting or sharing notes",
+  "exportToPdf": "Export to PDF",
+  "pdfExportSelectionMode": "Select Export Mode",
+  "selectSameMonth": "Select Same Month",
+  "selectSameCategory": "Select Same Category",
+  "exportSelected": "Export ({count})",
+  "@exportSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "exportSuccess": "Export Successful",
+  "exportFailed": "Export Failed"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3725,5 +3725,25 @@
     }
   },
   "exportSuccess": "导出成功",
-  "exportFailed": "导出失败"
+  "exportFailed": "导出失败",
+  "generatingPdf": "正在生成 PDF...",
+  "pdfExportFailed": "导出 PDF 失败: {error}",
+  "@pdfExportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "batchPdfExportFailed": "批量导出 PDF 失败: {error}",
+  "@batchPdfExportFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "pleaseSelectAtLeastOneNote": "请先选择至少一条笔记",
+  "selectedNotesHaveNoCategories": "所选笔记没有分类标签",
+  "pdfPreviewAndPrint": "PDF 预览 & 打印"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3745,5 +3745,9 @@
   },
   "pleaseSelectAtLeastOneNote": "请先选择至少一条笔记",
   "selectedNotesHaveNoCategories": "所选笔记没有分类标签",
-  "pdfPreviewAndPrint": "PDF 预览 & 打印"
+  "pdfPreviewAndPrint": "PDF 预览 & 打印",
+  "webdavSyncOnCellular": "允许数据流量下同步",
+  "webdavSyncOnCellularSubtitle": "允许在移动数据网络下进行云端备份和合并",
+  "webdavSyncNotesOnlyOnCellular": "数据流量下仅同步笔记",
+  "webdavSyncNotesOnlyOnCellularSubtitle": "启用后在移动网络下仅同步文本，跳过大型媒体文件以节省流量"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3707,5 +3707,23 @@
       }
     }
   },
-  "webdavViewNow": "立即查看"
+  "webdavViewNow": "立即查看",
+  "exportFormatLabel": "默认导出格式",
+  "exportFormatCard": "精致分享卡片",
+  "exportFormatPdf": "标准 A4 PDF",
+  "exportFormatDesc": "配置笔记一键导出或分享时的默认生成格式",
+  "exportToPdf": "导出为 PDF",
+  "pdfExportSelectionMode": "选择导出模式",
+  "selectSameMonth": "一键选同月",
+  "selectSameCategory": "一键选同分类",
+  "exportSelected": "导出 ({count})",
+  "@exportSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "exportSuccess": "导出成功",
+  "exportFailed": "导出失败"
 }

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -63,6 +63,7 @@ class AppSettings {
   final String? trashRetentionLastModified; // 回收站保留设置更新时间（UTC ISO）
   final bool skipNonFullscreenEditor; // 新增：跳过非全屏编辑器，直接进入全屏编辑器
   final String offlineQuoteSource;
+  final String exportFormat;
 
   AppSettings({
     this.hitokotoType = 'a,b,c,d,e,f,g,h,i,j,k', // 默认全选所有类型
@@ -98,6 +99,7 @@ class AppSettings {
     this.trashRetentionLastModified,
     this.skipNonFullscreenEditor = false, // 默认不跳过非全屏编辑器
     this.offlineQuoteSource = 'tagOnly', // 默认仅展示带每日一言标签的笔记
+    this.exportFormat = 'card', // 默认精致分享卡片
   }) : trashRetentionDays = normalizeTrashRetentionDays(trashRetentionDays);
 
   static int normalizeTrashRetentionDays(int? days) {
@@ -142,6 +144,7 @@ class AppSettings {
       'trashRetentionLastModified': trashRetentionLastModified,
       'skipNonFullscreenEditor': skipNonFullscreenEditor,
       'offlineQuoteSource': offlineQuoteSource,
+      'exportFormat': exportFormat,
     };
   }
 
@@ -217,6 +220,7 @@ class AppSettings {
       trashRetentionLastModified: map['trashRetentionLastModified'] as String?,
       skipNonFullscreenEditor: map['skipNonFullscreenEditor'] ?? false,
       offlineQuoteSource: _readString(map['offlineQuoteSource'], 'tagOnly'),
+      exportFormat: _readString(map['exportFormat'], 'card'),
     );
   }
 
@@ -254,6 +258,7 @@ class AppSettings {
         trashRetentionLastModified: null,
         skipNonFullscreenEditor: false, // 默认不跳过非全屏编辑器
         offlineQuoteSource: 'tagOnly',
+        exportFormat: 'card',
       );
 
   /// 使用特殊标记来区分"未指定"和"设置为null（跟随系统）"
@@ -295,6 +300,7 @@ class AppSettings {
     bool clearTrashRetentionLastModified = false,
     bool? skipNonFullscreenEditor,
     String? offlineQuoteSource,
+    String? exportFormat,
   }) {
     return AppSettings(
       hitokotoType: hitokotoType ?? this.hitokotoType,
@@ -346,6 +352,7 @@ class AppSettings {
       skipNonFullscreenEditor:
           skipNonFullscreenEditor ?? this.skipNonFullscreenEditor,
       offlineQuoteSource: offlineQuoteSource ?? this.offlineQuoteSource,
+      exportFormat: exportFormat ?? this.exportFormat,
     );
   }
 }

--- a/lib/pages/preferences_detail_page.dart
+++ b/lib/pages/preferences_detail_page.dart
@@ -228,6 +228,65 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
                   value: settings.skipNonFullscreenEditor,
                   onChanged: (v) => settings.setSkipNonFullscreenEditor(v),
                 ),
+                _buildDivider(),
+                ListTile(
+                  contentPadding:
+                      const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+                  leading: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: settings.exportFormat == 'pdf'
+                          ? theme.colorScheme.primaryContainer
+                          : theme.colorScheme.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Icon(
+                      Icons.output_outlined,
+                      color: settings.exportFormat == 'pdf'
+                          ? theme.colorScheme.onPrimaryContainer
+                          : theme.colorScheme.onSurfaceVariant,
+                      size: 20,
+                    ),
+                  ),
+                  title: Text(
+                    l10n.exportFormatLabel,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  subtitle: Text(
+                    l10n.exportFormatDesc,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                  ),
+                  trailing: DropdownButtonHideUnderline(
+                    child: DropdownButton<String>(
+                      value: settings.exportFormat,
+                      dropdownColor: theme.colorScheme.surfaceContainerHigh,
+                      borderRadius: BorderRadius.circular(12),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurface,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      onChanged: (String? newValue) {
+                        if (newValue != null) {
+                          settings.setExportFormat(newValue);
+                        }
+                      },
+                      items: [
+                        DropdownMenuItem(
+                          value: 'card',
+                          child: Text(l10n.exportFormatCard),
+                        ),
+                        DropdownMenuItem(
+                          value: 'pdf',
+                          child: Text(l10n.exportFormatPdf),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
               ],
             ),
 

--- a/lib/pages/preferences_detail_page.dart
+++ b/lib/pages/preferences_detail_page.dart
@@ -235,16 +235,24 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
                   leading: Container(
                     padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color: settings.exportFormat == 'pdf'
-                          ? theme.colorScheme.primaryContainer
-                          : theme.colorScheme.surfaceContainerHighest,
+                      color:
+                          (const ['card', 'pdf'].contains(settings.exportFormat)
+                                      ? settings.exportFormat
+                                      : 'card') ==
+                                  'pdf'
+                              ? theme.colorScheme.primaryContainer
+                              : theme.colorScheme.surfaceContainerHighest,
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Icon(
                       Icons.output_outlined,
-                      color: settings.exportFormat == 'pdf'
-                          ? theme.colorScheme.onPrimaryContainer
-                          : theme.colorScheme.onSurfaceVariant,
+                      color:
+                          (const ['card', 'pdf'].contains(settings.exportFormat)
+                                      ? settings.exportFormat
+                                      : 'card') ==
+                                  'pdf'
+                              ? theme.colorScheme.onPrimaryContainer
+                              : theme.colorScheme.onSurfaceVariant,
                       size: 20,
                     ),
                   ),
@@ -262,7 +270,10 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
                   ),
                   trailing: DropdownButtonHideUnderline(
                     child: DropdownButton<String>(
-                      value: settings.exportFormat,
+                      value:
+                          const ['card', 'pdf'].contains(settings.exportFormat)
+                              ? settings.exportFormat
+                              : 'card',
                       dropdownColor: theme.colorScheme.surfaceContainerHigh,
                       borderRadius: BorderRadius.circular(12),
                       style: theme.textTheme.bodyMedium?.copyWith(

--- a/lib/services/delta_to_pdf_parser.dart
+++ b/lib/services/delta_to_pdf_parser.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/utils/app_logger.dart';
+
+class DeltaToPdfParser {
+  /// 将富文本的 Delta JSON 解析编译为适合 pdf 渲染的 Widget 列表
+  static List<pw.Widget> parse(Quote quote, pw.Font font) {
+    final List<pw.Widget> widgets = [];
+    final deltaStr = quote.deltaContent;
+
+    // 如果没有富文本格式，退回到普通纯文本段落渲染
+    if (deltaStr == null || deltaStr.isEmpty) {
+      widgets.add(
+        pw.Paragraph(
+          text: quote.content,
+          style: pw.TextStyle(
+            font: font,
+            fontSize: 12,
+            lineSpacing: 4,
+          ),
+        ),
+      );
+      return widgets;
+    }
+
+    try {
+      final List<dynamic> ops = json.decode(deltaStr);
+      List<pw.InlineSpan> currentSpans = [];
+
+      for (final op in ops) {
+        if (op is! Map<String, dynamic>) continue;
+        final insert = op['insert'];
+        if (insert == null) continue;
+
+        final attributes = op['attributes'] as Map<String, dynamic>? ?? {};
+
+        // 1. 处理内联或独立图片
+        if (insert is Map<String, dynamic> && insert.containsKey('image')) {
+          if (currentSpans.isNotEmpty) {
+            widgets.add(pw.RichText(text: pw.TextSpan(children: currentSpans)));
+            currentSpans = [];
+          }
+
+          final imagePath = insert['image'] as String;
+          final imageWidget = _buildPdfImage(imagePath);
+          if (imageWidget != null) {
+            widgets.add(pw.Padding(
+              padding: const pw.EdgeInsets.symmetric(vertical: 8),
+              child: imageWidget,
+            ));
+          }
+          continue;
+        }
+
+        // 2. 处理普通样式文本段落
+        if (insert is String) {
+          if (insert == '\n') {
+            if (currentSpans.isNotEmpty) {
+              widgets.add(pw.Container(
+                margin: const pw.EdgeInsets.only(bottom: 6),
+                child: pw.RichText(text: pw.TextSpan(children: currentSpans)),
+              ));
+              currentSpans = [];
+            } else {
+              widgets.add(pw.SizedBox(height: 8));
+            }
+            continue;
+          }
+
+          final lines = insert.split('\n');
+          for (int i = 0; i < lines.length; i++) {
+            final lineText = lines[i];
+            if (lineText.isNotEmpty) {
+              final span = _buildTextSpan(lineText, attributes, font);
+              currentSpans.add(span);
+            }
+
+            if (i < lines.length - 1) {
+              if (currentSpans.isNotEmpty) {
+                widgets.add(pw.Container(
+                  margin: const pw.EdgeInsets.only(bottom: 6),
+                  child: pw.RichText(text: pw.TextSpan(children: currentSpans)),
+                ));
+                currentSpans = [];
+              } else {
+                widgets.add(pw.SizedBox(height: 8));
+              }
+            }
+          }
+        }
+      }
+
+      if (currentSpans.isNotEmpty) {
+        widgets.add(pw.Container(
+          margin: const pw.EdgeInsets.only(bottom: 6),
+          child: pw.RichText(text: pw.TextSpan(children: currentSpans)),
+        ));
+      }
+    } catch (e, stack) {
+      logError("DeltaToPdfParser 解析异常", error: e, stackTrace: stack);
+      // 异常兜底：返回纯文本段落
+      widgets.add(
+        pw.Paragraph(
+          text: quote.content,
+          style: pw.TextStyle(
+            font: font,
+            fontSize: 12,
+            lineSpacing: 4,
+          ),
+        ),
+      );
+    }
+
+    return widgets;
+  }
+
+  static pw.InlineSpan _buildTextSpan(
+    String text,
+    Map<String, dynamic> attrs,
+    pw.Font font,
+  ) {
+    final isBold = attrs['bold'] == true;
+    final isItalic = attrs['italic'] == true;
+    final isUnderline = attrs['underline'] == true;
+    final colorHex = attrs['color'] as String?;
+
+    PdfColor? fontColor;
+    if (colorHex != null) {
+      try {
+        final hexStr = colorHex.replaceFirst('#', '');
+        fontColor = PdfColor.fromHex(hexStr);
+      } catch (_) {}
+    }
+
+    return pw.TextSpan(
+      text: text,
+      style: pw.TextStyle(
+        font: font,
+        fontWeight: isBold ? pw.FontWeight.bold : pw.FontWeight.normal,
+        fontStyle: isItalic ? pw.FontStyle.italic : pw.FontStyle.normal,
+        decoration:
+            isUnderline ? pw.TextDecoration.underline : pw.TextDecoration.none,
+        color: fontColor,
+      ),
+    );
+  }
+
+  static pw.Widget? _buildPdfImage(String path) {
+    try {
+      final file = File(path);
+      if (file.existsSync()) {
+        final bytes = file.readAsBytesSync();
+        if (bytes.isNotEmpty) {
+          final image = pw.MemoryImage(bytes);
+          return pw.Container(
+            alignment: pw.Alignment.centerLeft,
+            constraints: const pw.BoxConstraints(
+              maxHeight: 200,
+              maxWidth: 440, // 适应 A4 页面最大内边距限制
+            ),
+            child: pw.Image(image, fit: pw.BoxFit.contain),
+          );
+        }
+      }
+    } catch (e) {
+      logDebug("DeltaToPdfParser 加载内联图片失败: $e", source: "DeltaToPdfParser");
+    }
+    return null;
+  }
+}

--- a/lib/services/pdf_export_service.dart
+++ b/lib/services/pdf_export_service.dart
@@ -1,0 +1,217 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart' show BuildContext;
+import 'package:provider/provider.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/models/note_category.dart';
+import 'package:thoughtecho/services/database_service.dart';
+import 'package:thoughtecho/services/delta_to_pdf_parser.dart';
+import 'package:thoughtecho/utils/app_logger.dart';
+
+class PdfExportService {
+  /// 将一组笔记编译组装成一个符合 A4 标准、排版精致的 PDF 文件字节流
+  static Future<Uint8List> exportNotesToPdf(
+    List<Quote> quotes,
+    pw.Font font,
+    BuildContext context,
+  ) async {
+    final pdf = pw.Document(
+      title: "ThoughtEcho Notes Export",
+      author: "ThoughtEcho",
+    );
+
+    // 1. 获取全局标签分类映射，用来还原标签名字
+    Map<String, NoteCategory> tagMap = {};
+    try {
+      final db = Provider.of<DatabaseService>(context, listen: false);
+      final categories = await db.getCategories();
+      tagMap = {for (var c in categories) c.id: c};
+    } catch (e) {
+      logDebug("PdfExportService 获取标签映射失败: $e", source: "PdfExportService");
+    }
+
+    // 2. 组装 PDF 页面布局
+    pdf.addPage(
+      pw.MultiPage(
+        pageFormat: PdfPageFormat.a4,
+        margin: const pw.EdgeInsets.all(36), // 0.5 英寸边距
+        header: (pw.Context context) {
+          return pw.Container(
+            alignment: pw.Alignment.centerRight,
+            margin: const pw.EdgeInsets.only(bottom: 12),
+            padding: const pw.EdgeInsets.only(bottom: 4),
+            decoration: const pw.BoxDecoration(
+              border: pw.Border(
+                bottom: pw.BorderSide(color: PdfColors.grey300, width: 0.5),
+              ),
+            ),
+            child: pw.Row(
+              mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+              children: [
+                pw.Text(
+                  "ThoughtEcho (心迹) — 专属思想摘录本",
+                  style: pw.TextStyle(
+                    font: font,
+                    fontSize: 8,
+                    color: PdfColors.grey600,
+                  ),
+                ),
+                pw.Text(
+                  "导出日期: ${DateTime.now().toString().substring(0, 10)}",
+                  style: pw.TextStyle(
+                    font: font,
+                    fontSize: 8,
+                    color: PdfColors.grey600,
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+        footer: (pw.Context context) {
+          return pw.Container(
+            alignment: pw.Alignment.center,
+            margin: const pw.EdgeInsets.only(top: 16),
+            child: pw.Text(
+              "第 ${context.pageNumber} 页 / 共 ${context.pagesCount} 页",
+              style: pw.TextStyle(
+                font: font,
+                fontSize: 9,
+                color: PdfColors.grey500,
+              ),
+            ),
+          );
+        },
+        build: (pw.Context context) {
+          final List<pw.Widget> content = [];
+
+          for (int i = 0; i < quotes.length; i++) {
+            final quote = quotes[i];
+
+            // 每一个笔记卡片以容器封装，配有细虚线或实线边框
+            content.add(
+              pw.Container(
+                margin: const pw.EdgeInsets.only(bottom: 16),
+                padding: const pw.EdgeInsets.all(12),
+                decoration: pw.BoxDecoration(
+                  color: PdfColors.white,
+                  borderRadius:
+                      const pw.BorderRadius.all(pw.Radius.circular(8)),
+                  border: pw.Border.all(
+                      color: PdfColor.fromHex("E2E8F0"), width: 0.8),
+                ),
+                child: pw.Column(
+                  crossAxisAlignment: pw.CrossAxisAlignment.start,
+                  children: [
+                    // --- 元数据头部 ---
+                    pw.Row(
+                      mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+                      children: [
+                        // 日期与时间段
+                        pw.Text(
+                          "📅 ${quote.date.substring(0, 10)} ${quote.dayPeriod ?? ''}",
+                          style: pw.TextStyle(
+                            font: font,
+                            fontSize: 10,
+                            fontWeight: pw.FontWeight.bold,
+                            color: PdfColor.fromHex("4A5568"),
+                          ),
+                        ),
+                        // 天气与位置
+                        pw.Row(
+                          children: [
+                            if (quote.weather != null) ...[
+                              pw.Text(
+                                "☀️ ${quote.weather!} ${quote.temperature ?? ''}",
+                                style: pw.TextStyle(
+                                  font: font,
+                                  fontSize: 8,
+                                  color: PdfColor.fromHex("718096"),
+                                ),
+                              ),
+                              pw.SizedBox(width: 8),
+                            ],
+                            if (quote.location != null &&
+                                quote.location!.isNotEmpty)
+                              pw.Text(
+                                "📍 ${quote.location}",
+                                style: pw.TextStyle(
+                                  font: font,
+                                  fontSize: 8,
+                                  color: PdfColor.fromHex("718096"),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    pw.Divider(
+                        color: PdfColor.fromHex("EDF2F7"),
+                        thickness: 0.6,
+                        height: 12),
+
+                    // --- 富文本解析出的主体内容段落 ---
+                    ...DeltaToPdfParser.parse(quote, font),
+
+                    // --- 出处作者 ---
+                    if (quote.source != null && quote.source!.isNotEmpty) ...[
+                      pw.SizedBox(height: 8),
+                      pw.Align(
+                        alignment: pw.Alignment.centerRight,
+                        child: pw.Text(
+                          "—— ${quote.source}",
+                          style: pw.TextStyle(
+                            font: font,
+                            fontSize: 10,
+                            fontStyle: pw.FontStyle.italic,
+                            color: PdfColor.fromHex("4A5568"),
+                          ),
+                        ),
+                      ),
+                    ],
+
+                    // --- 标签列表 ---
+                    if (quote.tagIds.isNotEmpty) ...[
+                      pw.SizedBox(height: 10),
+                      pw.Wrap(
+                        spacing: 6,
+                        runSpacing: 4,
+                        children: quote.tagIds.map((tagId) {
+                          final tag = tagMap[tagId];
+                          final tagName = tag != null ? tag.name : "未知标签";
+                          return pw.Container(
+                            padding: const pw.EdgeInsets.symmetric(
+                                horizontal: 6, vertical: 2),
+                            decoration: pw.BoxDecoration(
+                              color: PdfColor.fromHex("EDF2F7"),
+                              borderRadius: const pw.BorderRadius.all(
+                                  pw.Radius.circular(4)),
+                            ),
+                            child: pw.Text(
+                              "🏷️ $tagName",
+                              style: pw.TextStyle(
+                                font: font,
+                                fontSize: 8,
+                                color: PdfColor.fromHex("4A5568"),
+                              ),
+                            ),
+                          );
+                        }).toList(),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            );
+          }
+
+          return content;
+        },
+      ),
+    );
+
+    // 3. 编译并生成 PDF 字节数据
+    return await pdf.save();
+  }
+}

--- a/lib/services/pdf_font_service.dart
+++ b/lib/services/pdf_font_service.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:path_provider/path_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:thoughtecho/utils/app_logger.dart';
+
+class PdfFontService {
+  static pw.Font? _cachedFont;
+
+  /// 加载最合适的中文字体，检索本地或动态下载缓存，保障 PDF 正确呈现中文字符
+  static Future<pw.Font> loadFont() async {
+    if (_cachedFont != null) {
+      return _cachedFont!;
+    }
+
+    try {
+      // 1. 尝试检索 Windows/Android 本地系统自带的中文字体（无网络/极速加载）
+      final systemFontData = await _tryLoadLocalSystemFont();
+      if (systemFontData != null) {
+        _cachedFont = pw.Font.ttf(systemFontData);
+        logDebug("成功从系统本地路径加载中文字体", source: "PdfFontService");
+        return _cachedFont!;
+      }
+
+      // 2. 尝试从应用文档目录中读取已下载并缓存的字体
+      final cachedFontData = await _tryLoadCachedFont();
+      if (cachedFontData != null) {
+        _cachedFont = pw.Font.ttf(cachedFontData);
+        logDebug("成功从应用缓存路径加载中文字体", source: "PdfFontService");
+        return _cachedFont!;
+      }
+
+      // 3. 动态下载中文字体并写入缓存
+      final downloadedFontData = await _downloadAndCacheFont();
+      if (downloadedFontData != null) {
+        _cachedFont = pw.Font.ttf(downloadedFontData);
+        logDebug("成功动态下载并加载中文字体", source: "PdfFontService");
+        return _cachedFont!;
+      }
+    } catch (e, stack) {
+      logError("loadFont 失败，将回退到 PDF 默认系统英文字体", error: e, stackTrace: stack);
+    }
+
+    // 4. 兜底回退，避免应用崩溃
+    return pw.Font.helvetica();
+  }
+
+  /// 检索 Windows/Android 本地中文字体
+  static Future<ByteData?> _tryLoadLocalSystemFont() async {
+    try {
+      if (Platform.isWindows) {
+        final paths = [
+          "C:\\Windows\\Fonts\\msyh.ttc",
+          "C:\\Windows\\Fonts\\msyh.ttf",
+          "C:\\Windows\\Fonts\\simsun.ttc",
+          "C:\\Windows\\Fonts\\simsun.ttf",
+        ];
+        for (final p in paths) {
+          final f = File(p);
+          if (await f.exists()) {
+            final bytes = await f.readAsBytes();
+            if (bytes.isNotEmpty) {
+              return ByteData.view(bytes.buffer);
+            }
+          }
+        }
+      } else if (Platform.isAndroid) {
+        final paths = [
+          "/system/fonts/NotoSansSC-Regular.otf",
+          "/system/fonts/DroidSansFallback.ttf",
+          "/system/fonts/NotoSansCJK-Regular.ttc",
+        ];
+        for (final p in paths) {
+          final f = File(p);
+          if (await f.exists()) {
+            final bytes = await f.readAsBytes();
+            if (bytes.isNotEmpty) {
+              return ByteData.view(bytes.buffer);
+            }
+          }
+        }
+      }
+    } catch (e) {
+      logDebug("本地系统中文字体检索异常: $e", source: "PdfFontService");
+    }
+    return null;
+  }
+
+  /// 读取已下载缓存的字体
+  static Future<ByteData?> _tryLoadCachedFont() async {
+    try {
+      final docDir = await getApplicationDocumentsDirectory();
+      final fontFile = File("${docDir.path}/cached_chinese_font.ttf");
+      if (await fontFile.exists()) {
+        final bytes = await fontFile.readAsBytes();
+        if (bytes.isNotEmpty) {
+          return ByteData.view(bytes.buffer);
+        }
+      }
+    } catch (e) {
+      logDebug("读取本地缓存字体异常: $e", source: "PdfFontService");
+    }
+    return null;
+  }
+
+  /// 从公共 CDN 动态下载小巧精美且支持中文的 TrueType 字体（站酷小薇，约 2.0MB）
+  static Future<ByteData?> _downloadAndCacheFont() async {
+    final url =
+        "https://fonts.gstatic.com/s/zcoolxiaowei/v13/q5uD35KLXuK6LALR-3uPA4vS0D2d2tL5.ttf";
+    try {
+      logDebug("开始网络下载中文字体: $url", source: "PdfFontService");
+      final dio = Dio();
+      final response = await dio.get<List<int>>(
+        url,
+        options: Options(responseType: ResponseType.bytes),
+      );
+      if (response.data != null && response.data!.isNotEmpty) {
+        final bytes = Uint8List.fromList(response.data!);
+        final docDir = await getApplicationDocumentsDirectory();
+        final fontFile = File("${docDir.path}/cached_chinese_font.ttf");
+        await fontFile.writeAsBytes(bytes);
+        logDebug("中文字体下载成功，并已缓存至: ${fontFile.path}", source: "PdfFontService");
+        return ByteData.view(bytes.buffer);
+      }
+    } catch (e) {
+      logDebug("网络下载字体失败: $e", source: "PdfFontService");
+    }
+    return null;
+  }
+}

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -391,6 +391,14 @@ class SettingsService extends ChangeNotifier {
     notifyListeners();
   }
 
+  // 默认导出格式配置
+  String get exportFormat => _appSettings.exportFormat;
+  Future<void> setExportFormat(String format) async {
+    _appSettings = _appSettings.copyWith(exportFormat: format);
+    await _mmkv.setString(_appSettingsKey, json.encode(_appSettings.toJson()));
+    notifyListeners();
+  }
+
   SettingsService(this._prefs);
 
   /// 创建SettingsService实例的静态工厂方法

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -394,7 +394,9 @@ class SettingsService extends ChangeNotifier {
   // 默认导出格式配置
   String get exportFormat => _appSettings.exportFormat;
   Future<void> setExportFormat(String format) async {
-    _appSettings = _appSettings.copyWith(exportFormat: format);
+    final validatedFormat =
+        const ['card', 'pdf'].contains(format) ? format : 'card';
+    _appSettings = _appSettings.copyWith(exportFormat: validatedFormat);
     await _mmkv.setString(_appSettingsKey, json.encode(_appSettings.toJson()));
     notifyListeners();
   }

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -11,6 +11,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
 
+import '../services/connectivity_service.dart';
 import '../services/database_service.dart';
 import '../services/media_reference_service.dart';
 import '../services/mmkv_service.dart';
@@ -50,12 +51,17 @@ class WebDAVSyncService extends ChangeNotifier {
   bool _syncOnLaunch = true;
   bool _syncOnChange = true;
 
+  bool _syncOnCellular = false;
+  bool _syncNotesOnlyOnCellular = false;
+
   bool get enabled => _enabled;
   String get provider => _provider;
   String get url => _url;
   String get username => _username;
   bool get syncOnLaunch => _syncOnLaunch;
   bool get syncOnChange => _syncOnChange;
+  bool get syncOnCellular => _syncOnCellular;
+  bool get syncNotesOnlyOnCellular => _syncNotesOnlyOnCellular;
 
   // 定时器用于防抖
   Timer? _debounceTimer;
@@ -71,6 +77,8 @@ class WebDAVSyncService extends ChangeNotifier {
     _username = _mmkv.getString('webdav_username') ?? '';
     _syncOnLaunch = _mmkv.getBool('webdav_sync_on_launch') ?? true;
     _syncOnChange = _mmkv.getBool('webdav_sync_on_change') ?? true;
+    _syncOnCellular = _mmkv.getBool('webdav_sync_on_cellular') ?? false;
+    _syncNotesOnlyOnCellular = _mmkv.getBool('webdav_sync_notes_only_on_cellular') ?? false;
     _lastSyncTime = _mmkv.getString('webdav_last_sync_time') ?? '';
 
     // 如果是首次使用，且预设是坚果云，自动填入坚果云的地址
@@ -98,6 +106,8 @@ class WebDAVSyncService extends ChangeNotifier {
     String? password,
     required bool syncOnLaunch,
     required bool syncOnChange,
+    required bool syncOnCellular,
+    required bool syncNotesOnlyOnCellular,
   }) async {
     _enabled = enabled;
     _provider = provider;
@@ -111,6 +121,8 @@ class WebDAVSyncService extends ChangeNotifier {
     _username = username.trim();
     _syncOnLaunch = syncOnLaunch;
     _syncOnChange = syncOnChange;
+    _syncOnCellular = syncOnCellular;
+    _syncNotesOnlyOnCellular = syncNotesOnlyOnCellular;
 
     await _mmkv.setBool('webdav_enabled', _enabled);
     await _mmkv.setString('webdav_provider', _provider);
@@ -118,6 +130,8 @@ class WebDAVSyncService extends ChangeNotifier {
     await _mmkv.setString('webdav_username', _username);
     await _mmkv.setBool('webdav_sync_on_launch', _syncOnLaunch);
     await _mmkv.setBool('webdav_sync_on_change', _syncOnChange);
+    await _mmkv.setBool('webdav_sync_on_cellular', _syncOnCellular);
+    await _mmkv.setBool('webdav_sync_notes_only_on_cellular', _syncNotesOnlyOnCellular);
 
     if (password != null) {
       await _secureStorage.write(
@@ -284,6 +298,21 @@ class WebDAVSyncService extends ChangeNotifier {
       return;
     }
 
+    // 移动数据网络检测与过滤策略
+    final isCellular = await ConnectivityService().isCellularConnection();
+    bool skipMedia = false;
+    if (isCellular) {
+      if (!_syncOnCellular) {
+        if (_syncNotesOnlyOnCellular) {
+          logInfo('当前处于移动数据网络下且启用“仅同步笔记”，将跳过大媒体文件同步');
+          skipMedia = true;
+        } else {
+          logInfo('当前处于移动数据网络下且未允许流量同步，跳过 WebDAV 同步');
+          return;
+        }
+      }
+    }
+
     _syncStatus = WebDAVSyncStatus.syncing;
     _lastConflictCount = 0;
     notifyListeners();
@@ -360,8 +389,12 @@ class WebDAVSyncService extends ChangeNotifier {
       }
 
       // 5. 增量比对并同步大媒体附件 (Images, Videos, Audios)
-      logDebug('开始同步本地与云端媒体文件...');
-      await _syncMediaFiles(dio);
+      if (skipMedia) {
+        logDebug('数据流量下跳过大媒体文件同步');
+      } else {
+        logDebug('开始同步本地与云端媒体文件...');
+        await _syncMediaFiles(dio);
+      }
 
       // 6. 流式写入本地数据到临时文件并上传（避免全量数据入内存）
       logDebug('打包本地最新数据上传云端...');

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -78,7 +78,8 @@ class WebDAVSyncService extends ChangeNotifier {
     _syncOnLaunch = _mmkv.getBool('webdav_sync_on_launch') ?? true;
     _syncOnChange = _mmkv.getBool('webdav_sync_on_change') ?? true;
     _syncOnCellular = _mmkv.getBool('webdav_sync_on_cellular') ?? false;
-    _syncNotesOnlyOnCellular = _mmkv.getBool('webdav_sync_notes_only_on_cellular') ?? false;
+    _syncNotesOnlyOnCellular =
+        _mmkv.getBool('webdav_sync_notes_only_on_cellular') ?? false;
     _lastSyncTime = _mmkv.getString('webdav_last_sync_time') ?? '';
 
     // 如果是首次使用，且预设是坚果云，自动填入坚果云的地址
@@ -131,7 +132,8 @@ class WebDAVSyncService extends ChangeNotifier {
     await _mmkv.setBool('webdav_sync_on_launch', _syncOnLaunch);
     await _mmkv.setBool('webdav_sync_on_change', _syncOnChange);
     await _mmkv.setBool('webdav_sync_on_cellular', _syncOnCellular);
-    await _mmkv.setBool('webdav_sync_notes_only_on_cellular', _syncNotesOnlyOnCellular);
+    await _mmkv.setBool(
+        'webdav_sync_notes_only_on_cellular', _syncNotesOnlyOnCellular);
 
     if (password != null) {
       await _secureStorage.write(

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -304,14 +304,12 @@ class WebDAVSyncService extends ChangeNotifier {
     final isCellular = await ConnectivityService().isCellularConnection();
     bool skipMedia = false;
     if (isCellular) {
-      if (!_syncOnCellular) {
-        if (_syncNotesOnlyOnCellular) {
-          logInfo('当前处于移动数据网络下且启用“仅同步笔记”，将跳过大媒体文件同步');
-          skipMedia = true;
-        } else {
-          logInfo('当前处于移动数据网络下且未允许流量同步，跳过 WebDAV 同步');
-          return;
-        }
+      if (_syncNotesOnlyOnCellular) {
+        logInfo('当前处于移动数据网络下且启用“仅同步笔记”，将跳过大媒体文件同步');
+        skipMedia = true;
+      } else if (!_syncOnCellular) {
+        logInfo('当前处于移动数据网络下且未允许流量同步，跳过 WebDAV 同步');
+        return;
       }
     }
 

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -720,7 +720,8 @@ class WebDAVSyncService extends ChangeNotifier {
               deleteUrl,
               options: Options(
                 method: 'DELETE',
-                validateStatus: (status) => status == 200 || status == 204 || status == 404,
+                validateStatus: (status) =>
+                    status == 200 || status == 204 || status == 404,
               ),
             );
           } catch (e) {

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -825,8 +825,8 @@ extension _NoteListItemsExtension on NoteListViewState {
     }
     final selectedMonths = <String>{};
     for (final id in _selectedExportNoteIds) {
-      final quote = _quotes.firstWhere((q) => q.id == id);
-      if (quote.date.length >= 7) {
+      final quote = _quotes.firstWhereOrNull((q) => q.id == id);
+      if (quote != null && quote.date.length >= 7) {
         selectedMonths.add(quote.date.substring(0, 7));
       }
     }
@@ -850,8 +850,10 @@ extension _NoteListItemsExtension on NoteListViewState {
     }
     final selectedTags = <String>{};
     for (final id in _selectedExportNoteIds) {
-      final quote = _quotes.firstWhere((q) => q.id == id);
-      selectedTags.addAll(quote.tagIds);
+      final quote = _quotes.firstWhereOrNull((q) => q.id == id);
+      if (quote != null) {
+        selectedTags.addAll(quote.tagIds);
+      }
     }
     if (selectedTags.isEmpty) {
       _showInfoSnackBar(l10n.selectedNotesHaveNoCategories);

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -818,8 +818,9 @@ extension _NoteListItemsExtension on NoteListViewState {
   }
 
   void _selectSameMonthNotes() {
+    final l10n = AppLocalizations.of(context);
     if (_selectedExportNoteIds.isEmpty) {
-      _showInfoSnackBar("请先选择至少一条笔记");
+      _showInfoSnackBar(l10n.pleaseSelectAtLeastOneNote);
       return;
     }
     final selectedMonths = <String>{};
@@ -842,8 +843,9 @@ extension _NoteListItemsExtension on NoteListViewState {
   }
 
   void _selectSameCategoryNotes() {
+    final l10n = AppLocalizations.of(context);
     if (_selectedExportNoteIds.isEmpty) {
-      _showInfoSnackBar("请先选择至少一条笔记");
+      _showInfoSnackBar(l10n.pleaseSelectAtLeastOneNote);
       return;
     }
     final selectedTags = <String>{};
@@ -852,7 +854,7 @@ extension _NoteListItemsExtension on NoteListViewState {
       selectedTags.addAll(quote.tagIds);
     }
     if (selectedTags.isEmpty) {
-      _showInfoSnackBar("所选笔记没有分类标签");
+      _showInfoSnackBar(l10n.selectedNotesHaveNoCategories);
       return;
     }
     _updateState(() {
@@ -875,8 +877,9 @@ extension _NoteListItemsExtension on NoteListViewState {
   }
 
   Future<void> _exportSingleNoteToPdf(Quote quote) async {
+    final l10n = AppLocalizations.of(context);
     try {
-      _showLoadingDialog("正在生成 PDF...");
+      _showLoadingDialog(l10n.generatingPdf);
       final font = await PdfFontService.loadFont();
       if (!mounted) return;
       final pdfBytes =
@@ -894,14 +897,15 @@ extension _NoteListItemsExtension on NoteListViewState {
     } catch (e, stack) {
       logError("ExportSingleNoteToPdf", error: e, stackTrace: stack);
       if (mounted) Navigator.pop(context);
-      _showInfoSnackBar("导出 PDF 失败: $e");
+      _showInfoSnackBar(l10n.pdfExportFailed(e.toString()));
     }
   }
 
   Future<void> _exportSelectedNotesToPdf() async {
     if (_selectedExportNoteIds.isEmpty) return;
+    final l10n = AppLocalizations.of(context);
     try {
-      _showLoadingDialog("正在生成 PDF...");
+      _showLoadingDialog(l10n.generatingPdf);
       final selectedQuotes = _quotes
           .where((q) => q.id != null && _selectedExportNoteIds.contains(q.id))
           .toList();
@@ -927,7 +931,7 @@ extension _NoteListItemsExtension on NoteListViewState {
     } catch (e, stack) {
       logError("ExportSelectedNotesToPdf", error: e, stackTrace: stack);
       if (mounted) Navigator.pop(context);
-      _showInfoSnackBar("批量导出 PDF 失败: $e");
+      _showInfoSnackBar(l10n.batchPdfExportFailed(e.toString()));
     }
   }
 

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -37,13 +37,12 @@ extension _NoteListItemsExtension on NoteListViewState {
           theme.brightness,
         );
 
-        return Container(
-          color: backgroundColor,
-          child: Center(
-            child: ConstrainedBox(
-              constraints: BoxConstraints(maxWidth: maxWidth),
-              child: Column(
-                children: [
+        Widget mainContent = Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: maxWidth),
+            child: Column(
+              children: [
+                if (!_isExportMode)
                   // 搜索框 - 现代圆角样式，筛选按钮内嵌到右侧
                   Container(
                     padding: EdgeInsets.fromLTRB(
@@ -112,6 +111,17 @@ extension _NoteListItemsExtension on NoteListViewState {
                                   );
                                 }
                                 return const SizedBox.shrink();
+                              },
+                            ),
+                            // PDF 导出选择模式入口按钮
+                            IconButton(
+                              icon: const Icon(Icons.picture_as_pdf_outlined),
+                              tooltip: l10n.pdfExportSelectionMode,
+                              onPressed: () {
+                                _updateState(() {
+                                  _isExportMode = true;
+                                  _selectedExportNoteIds.clear();
+                                });
                               },
                             ),
                             // 筛选按钮
@@ -200,34 +210,177 @@ extension _NoteListItemsExtension on NoteListViewState {
                       ),
                     ),
                   ),
+                if (_isExportMode)
+                  // 占位符，腾出顶部悬浮栏的位置
+                  SizedBox(height: MediaQuery.of(context).padding.top + 72.0),
 
-                  // 筛选条件展示区域
-                  _buildFilterDisplay(theme, horizontalPadding),
+                // 筛选条件展示区域
+                _buildFilterDisplay(theme, horizontalPadding),
 
-                  // 笔记列表 - 添加平滑过渡动画
-                  Expanded(
-                    child: Padding(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: horizontalPadding,
-                      ),
-                      child: AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 150),
-                        switchInCurve: Curves.easeOut,
-                        switchOutCurve: Curves.easeOut,
-                        transitionBuilder: (child, animation) {
-                          return FadeTransition(
-                            opacity: animation,
-                            child: child,
-                          );
-                        },
-                        child: _buildNoteList(theme),
-                      ),
+                // 笔记列表 - 添加平滑过渡动画
+                Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: horizontalPadding,
+                    ),
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 150),
+                      switchInCurve: Curves.easeOut,
+                      switchOutCurve: Curves.easeOut,
+                      transitionBuilder: (child, animation) {
+                        return FadeTransition(
+                          opacity: animation,
+                          child: child,
+                        );
+                      },
+                      child: _buildNoteList(theme),
                     ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
+        );
+
+        if (_isExportMode) {
+          mainContent = Stack(
+            children: [
+              mainContent,
+              // 顶部悬浮控制栏
+              Positioned(
+                top: MediaQuery.of(context).padding.top + 8.0,
+                left: horizontalPadding,
+                right: horizontalPadding,
+                child: Container(
+                  height: 56,
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surfaceContainerHighest
+                        .withValues(alpha: 0.95),
+                    borderRadius: BorderRadius.circular(20),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.08),
+                        blurRadius: 8,
+                        offset: const Offset(0, 3),
+                      ),
+                    ],
+                  ),
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      TextButton(
+                        onPressed: () {
+                          _updateState(() {
+                            _isExportMode = false;
+                            _selectedExportNoteIds.clear();
+                          });
+                        },
+                        child: Text(l10n.cancel),
+                      ),
+                      const Spacer(),
+                      Text(
+                        "${l10n.pdfExportSelectionMode} (${_selectedExportNoteIds.length})",
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const Spacer(),
+                      TextButton(
+                        onPressed: _selectAllVisibleNotes,
+                        child: Text(
+                          _selectedExportNoteIds.containsAll(
+                                  _quotes.map((q) => q.id).whereType<String>())
+                              ? l10n.prefClearAll
+                              : l10n.prefSelectAll,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              // 底部悬浮控制栏
+              Positioned(
+                bottom: 16.0,
+                left: horizontalPadding,
+                right: horizontalPadding,
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surfaceContainerHighest
+                        .withValues(alpha: 0.95),
+                    borderRadius: BorderRadius.circular(24),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.12),
+                        blurRadius: 16,
+                        offset: const Offset(0, 4),
+                      ),
+                    ],
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          onPressed: _selectSameMonthNotes,
+                          icon: const Icon(Icons.calendar_month_outlined,
+                              size: 18),
+                          label: Text(l10n.selectSameMonth,
+                              style: const TextStyle(fontSize: 11)),
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 12),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          onPressed: _selectSameCategoryNotes,
+                          icon: const Icon(Icons.label_outline, size: 18),
+                          label: Text(l10n.selectSameCategory,
+                              style: const TextStyle(fontSize: 11)),
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 12),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: FilledButton.icon(
+                          onPressed: _selectedExportNoteIds.isEmpty
+                              ? null
+                              : _exportSelectedNotesToPdf,
+                          icon: const Icon(Icons.picture_as_pdf, size: 18),
+                          label: Text(
+                            l10n.exportSelected(_selectedExportNoteIds.length),
+                            style: const TextStyle(
+                                fontSize: 11, fontWeight: FontWeight.bold),
+                          ),
+                          style: FilledButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 12),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          );
+        }
+
+        return Container(
+          color: backgroundColor,
+          child: mainContent,
         );
       },
     );
@@ -430,7 +583,7 @@ extension _NoteListItemsExtension on NoteListViewState {
               _expandedItems.putIfAbsent(
                   quoteId, () => expansionNotifier.value);
 
-              return KeyedSubtree(
+              Widget itemWidget = KeyedSubtree(
                 key: _itemKeys[quoteId],
                 child: ValueListenableBuilder<bool>(
                   valueListenable: expansionNotifier,
@@ -467,6 +620,7 @@ extension _NoteListItemsExtension on NoteListViewState {
                     onGenerateCard: widget.onGenerateCard != null
                         ? () => widget.onGenerateCard!(quote)
                         : null,
+                    onExportPdf: () => _exportSingleNoteToPdf(quote),
                     onFavorite: widget.onFavorite != null
                         ? () => widget.onFavorite!(quote)
                         : null,
@@ -480,11 +634,57 @@ extension _NoteListItemsExtension on NoteListViewState {
                         attachMoreGuideKey ? widget.moreButtonGuideKey : null,
                     foldToggleGuideKey:
                         attachFoldGuideKey ? widget.foldToggleGuideKey : null,
-                    // 不使用自定义 tagBuilder，让 QuoteItemWidget 使用内部的标签渲染逻辑
-                    // 这样可以支持筛选标签的优先显示和高亮效果
                   ),
                 ),
               );
+
+              if (_isExportMode) {
+                final isSelected = _selectedExportNoteIds.contains(quoteId);
+                itemWidget = InkWell(
+                  onTap: () => _toggleExportSelection(quoteId),
+                  borderRadius: BorderRadius.circular(16),
+                  child: Row(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(left: 12.0),
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 150),
+                          curve: Curves.easeInOut,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: isSelected
+                                ? theme.colorScheme.primary
+                                : Colors.transparent,
+                            border: Border.all(
+                              color: isSelected
+                                  ? theme.colorScheme.primary
+                                  : theme.colorScheme.outline,
+                              width: 2,
+                            ),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(2.0),
+                            child: Icon(
+                              Icons.check,
+                              size: 16,
+                              color: isSelected
+                                  ? theme.colorScheme.onPrimary
+                                  : Colors.transparent,
+                            ),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: IgnorePointer(
+                          child: itemWidget,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }
+
+              return itemWidget;
             }
             // 底部加载指示器
             return const Padding(
@@ -594,5 +794,159 @@ extension _NoteListItemsExtension on NoteListViewState {
         }
       });
     }
+  }
+
+  void _toggleExportSelection(String quoteId) {
+    _updateState(() {
+      if (_selectedExportNoteIds.contains(quoteId)) {
+        _selectedExportNoteIds.remove(quoteId);
+      } else {
+        _selectedExportNoteIds.add(quoteId);
+      }
+    });
+  }
+
+  void _selectAllVisibleNotes() {
+    _updateState(() {
+      final allIds = _quotes.map((q) => q.id).whereType<String>().toSet();
+      if (_selectedExportNoteIds.containsAll(allIds)) {
+        _selectedExportNoteIds.removeAll(allIds);
+      } else {
+        _selectedExportNoteIds.addAll(allIds);
+      }
+    });
+  }
+
+  void _selectSameMonthNotes() {
+    if (_selectedExportNoteIds.isEmpty) {
+      _showInfoSnackBar("请先选择至少一条笔记");
+      return;
+    }
+    final selectedMonths = <String>{};
+    for (final id in _selectedExportNoteIds) {
+      final quote = _quotes.firstWhere((q) => q.id == id);
+      if (quote.date.length >= 7) {
+        selectedMonths.add(quote.date.substring(0, 7));
+      }
+    }
+    _updateState(() {
+      for (final q in _quotes) {
+        if (q.id != null && q.date.length >= 7) {
+          final m = q.date.substring(0, 7);
+          if (selectedMonths.contains(m)) {
+            _selectedExportNoteIds.add(q.id!);
+          }
+        }
+      }
+    });
+  }
+
+  void _selectSameCategoryNotes() {
+    if (_selectedExportNoteIds.isEmpty) {
+      _showInfoSnackBar("请先选择至少一条笔记");
+      return;
+    }
+    final selectedTags = <String>{};
+    for (final id in _selectedExportNoteIds) {
+      final quote = _quotes.firstWhere((q) => q.id == id);
+      selectedTags.addAll(quote.tagIds);
+    }
+    if (selectedTags.isEmpty) {
+      _showInfoSnackBar("所选笔记没有分类标签");
+      return;
+    }
+    _updateState(() {
+      for (final q in _quotes) {
+        if (q.id != null && q.tagIds.any(selectedTags.contains)) {
+          _selectedExportNoteIds.add(q.id!);
+        }
+      }
+    });
+  }
+
+  void _showInfoSnackBar(String msg) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(msg),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  Future<void> _exportSingleNoteToPdf(Quote quote) async {
+    try {
+      _showLoadingDialog("正在生成 PDF...");
+      final font = await PdfFontService.loadFont();
+      if (!mounted) return;
+      final pdfBytes =
+          await PdfExportService.exportNotesToPdf([quote], font, context);
+      if (!mounted) return;
+      Navigator.pop(context);
+
+      showDialog(
+        context: context,
+        builder: (context) => PdfPreviewDialog(
+          pdfBytes: pdfBytes,
+          fileName: "thoughtecho_note_${quote.id ?? 'single'}.pdf",
+        ),
+      );
+    } catch (e, stack) {
+      logError("ExportSingleNoteToPdf", error: e, stackTrace: stack);
+      if (mounted) Navigator.pop(context);
+      _showInfoSnackBar("导出 PDF 失败: $e");
+    }
+  }
+
+  Future<void> _exportSelectedNotesToPdf() async {
+    if (_selectedExportNoteIds.isEmpty) return;
+    try {
+      _showLoadingDialog("正在生成 PDF...");
+      final selectedQuotes = _quotes
+          .where((q) => q.id != null && _selectedExportNoteIds.contains(q.id))
+          .toList();
+      final font = await PdfFontService.loadFont();
+      if (!mounted) return;
+      final pdfBytes = await PdfExportService.exportNotesToPdf(
+          selectedQuotes, font, context);
+      if (!mounted) return;
+      Navigator.pop(context);
+
+      _updateState(() {
+        _isExportMode = false;
+        _selectedExportNoteIds.clear();
+      });
+
+      showDialog(
+        context: context,
+        builder: (context) => PdfPreviewDialog(
+          pdfBytes: pdfBytes,
+          fileName: "thoughtecho_notes_batch.pdf",
+        ),
+      );
+    } catch (e, stack) {
+      logError("ExportSelectedNotesToPdf", error: e, stackTrace: stack);
+      if (mounted) Navigator.pop(context);
+      _showInfoSnackBar("批量导出 PDF 失败: $e");
+    }
+  }
+
+  void _showLoadingDialog(String message) {
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => PopScope(
+        canPop: false,
+        child: AlertDialog(
+          content: Row(
+            children: [
+              const CircularProgressIndicator(),
+              const SizedBox(width: 16),
+              Expanded(child: Text(message)),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -27,6 +27,9 @@ import '../controllers/search_controller.dart';
 import '../constants/app_constants.dart'; // 导入应用常量
 import '../utils/quill_editor_extensions.dart' show isListScrolling;
 import '../services/settings_service.dart'; // 导入设置服务
+import '../services/pdf_export_service.dart';
+import '../services/pdf_font_service.dart';
+import '../widgets/pdf_preview_dialog.dart';
 import 'note_list/scroll_alignment.dart';
 
 part 'note_list/note_list_scroll.dart';
@@ -103,6 +106,10 @@ class NoteListViewState extends State<NoteListView> {
 
   // AI搜索模式标志
   bool _isAISearchMode = false;
+
+  // PDF 导出选择模式状态
+  bool _isExportMode = false;
+  final Set<String> _selectedExportNoteIds = {};
 
   // 分页和懒加载状态
   final List<Quote> _quotes = [];

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui' show FrameTiming;
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/lib/widgets/pdf_preview_dialog.dart
+++ b/lib/widgets/pdf_preview_dialog.dart
@@ -1,0 +1,52 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:printing/printing.dart';
+import 'package:pdf/pdf.dart';
+
+class PdfPreviewDialog extends StatelessWidget {
+  final Uint8List pdfBytes;
+  final String fileName;
+
+  const PdfPreviewDialog({
+    super.key,
+    required this.pdfBytes,
+    required this.fileName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: SizedBox(
+          width: double.infinity,
+          height: double.infinity,
+          child: Scaffold(
+            appBar: AppBar(
+              title: const Text("PDF 预览 & 打印"),
+              leading: IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context),
+              ),
+              elevation: 0,
+              backgroundColor: theme.colorScheme.surfaceContainerHighest,
+            ),
+            body: PdfPreview(
+              build: (format) => pdfBytes,
+              pdfFileName: fileName,
+              allowPrinting: true,
+              allowSharing: true,
+              canChangePageFormat: false,
+              canChangeOrientation: false,
+              canDebug: false,
+              initialPageFormat: PdfPageFormat.a4,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/pdf_preview_dialog.dart
+++ b/lib/widgets/pdf_preview_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:printing/printing.dart';
 import 'package:pdf/pdf.dart';
+import 'package:thoughtecho/gen_l10n/app_localizations.dart';
 
 class PdfPreviewDialog extends StatelessWidget {
   final Uint8List pdfBytes;
@@ -26,7 +27,7 @@ class PdfPreviewDialog extends StatelessWidget {
           height: double.infinity,
           child: Scaffold(
             appBar: AppBar(
-              title: const Text("PDF 预览 & 打印"),
+              title: Text(AppLocalizations.of(context).pdfPreviewAndPrint),
               leading: IconButton(
                 icon: const Icon(Icons.close),
                 onPressed: () => Navigator.pop(context),

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -27,6 +27,7 @@ class QuoteItemWidget extends StatefulWidget {
   final Function() onDelete;
   final Function() onAskAI;
   final Function()? onGenerateCard;
+  final Function()? onExportPdf; // PDF导出回调
   final Function()? onFavorite; // 心形按钮点击回调
   final Function()? onLongPressFavorite; // 心形按钮长按回调（清除收藏）
   final String? searchQuery;
@@ -56,6 +57,7 @@ class QuoteItemWidget extends StatefulWidget {
     required this.onDelete,
     required this.onAskAI,
     this.onGenerateCard,
+    this.onExportPdf,
     this.onFavorite, // 心形按钮点击回调
     this.onLongPressFavorite, // 心形按钮长按回调（清除收藏）
     this.tagBuilder,
@@ -288,6 +290,9 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
     );
     final showNoteEditTime = context.select<SettingsService, bool>(
       (s) => s.showNoteEditTime,
+    );
+    final exportFormat = context.select<SettingsService, String>(
+      (s) => s.exportFormat,
     );
     final String formattedDate = TimeUtils.formatQuoteDateLocalized(
       context,
@@ -1027,6 +1032,8 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                           widget.onEdit();
                         } else if (value == 'generate_card') {
                           widget.onGenerateCard?.call();
+                        } else if (value == 'export_pdf') {
+                          widget.onExportPdf?.call();
                         } else if (value == 'delete') {
                           widget.onDelete();
                         }
@@ -1056,7 +1063,21 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                             ],
                           ),
                         ),
-                        if (widget.onGenerateCard != null)
+                        if (exportFormat == 'pdf' && widget.onExportPdf != null)
+                          PopupMenuItem<String>(
+                            value: 'export_pdf',
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.picture_as_pdf,
+                                  color: theme.colorScheme.primary,
+                                ),
+                                const SizedBox(width: 8),
+                                Text(l10n.exportToPdf),
+                              ],
+                            ),
+                          )
+                        else if (widget.onGenerateCard != null)
                           PopupMenuItem<String>(
                             value: 'generate_card',
                             child: Row(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.1"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      sha256: "7b6729c37e3b7f34233e2318d866e8c48ddb46c1f7ad01ff7bb2a8de1da2b9f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.9"
   basic_utils:
     dependency: "direct main"
     description:
@@ -113,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.8.2"
+  bidi:
+    dependency: transitive
+    description:
+      name: bidi
+      sha256: "77f475165e94b261745cf1032c751e2032b8ed92ccb2bf5716036db79320637d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.13"
   bluez:
     dependency: transitive
     description:
@@ -1612,6 +1628,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdf:
+    dependency: "direct main"
+    description:
+      name: pdf
+      sha256: e47a275b267873d5944ad5f5ff0dcc7ac2e36c02b3046a0ffac9b72fd362c44b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.12.0"
+  pdf_widget_wrapper:
+    dependency: transitive
+    description:
+      name: pdf_widget_wrapper
+      sha256: c930860d987213a3d58c7ec3b7ecf8085c3897f773e8dc23da9cae60a5d6d0f5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   permission_handler:
     dependency: "direct main"
     description:
@@ -1716,6 +1748,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  printing:
+    dependency: "direct main"
+    description:
+      name: printing
+      sha256: "689170c9ddb1bda85826466ba80378aa8993486d3c959a71cd7d2d80cb606692"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.14.3"
   process:
     dependency: transitive
     description:
@@ -1756,6 +1796,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   quill_native_bridge:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -289,6 +289,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   console:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,6 +86,7 @@ dependencies:
   flutter_blue_plus: ^1.32.0 # BLE 蓝牙通信，用于向树莓派 Pico 发送数据
   pdf: ^3.12.0
   printing: ^5.14.3
+  connectivity_plus: ^7.1.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,6 +84,8 @@ dependencies:
   timezone: ^0.10.0
   workmanager: ^0.9.0+3
   flutter_blue_plus: ^1.32.0 # BLE 蓝牙通信，用于向树莓派 Pico 发送数据
+  pdf: ^3.12.0
+  printing: ^5.14.3
 
 dev_dependencies:
   flutter_test:

--- a/test/pdf_export_test.dart
+++ b/test/pdf_export_test.dart
@@ -21,7 +21,8 @@ void main() {
     });
 
     test('DeltaToPdfParser parses structured deltaContent rich text', () {
-      final deltaJson = '[{"insert": "Rich Text Body "}, {"insert": "bold text", "attributes": {"bold": true}}, {"insert": "\\n"}]';
+      final deltaJson =
+          '[{"insert": "Rich Text Body "}, {"insert": "bold text", "attributes": {"bold": true}}, {"insert": "\\n"}]';
       final quote = Quote(
         content: 'Rich Text Body bold text\n',
         date: '2026-05-31',
@@ -34,7 +35,9 @@ void main() {
       expect(widgets.first, isA<pw.Container>());
     });
 
-    test('PdfFontService returns default system font if local and network fonts fail', () async {
+    test(
+        'PdfFontService returns default system font if local and network fonts fail',
+        () async {
       final font = await PdfFontService.loadFont();
       expect(font, isNotNull);
     });

--- a/test/pdf_export_test.dart
+++ b/test/pdf_export_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/services/delta_to_pdf_parser.dart';
+import 'package:thoughtecho/services/pdf_font_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PDF Export and Parser Tests', () {
+    test('DeltaToPdfParser parses empty deltaContent successfully', () {
+      final quote = Quote(
+        content: 'Hello, this is a plain text note.',
+        date: '2026-05-31',
+      );
+      final font = pw.Font.helvetica();
+      final widgets = DeltaToPdfParser.parse(quote, font);
+
+      expect(widgets, isNotEmpty);
+      expect(widgets.first, isA<pw.Paragraph>());
+    });
+
+    test('DeltaToPdfParser parses structured deltaContent rich text', () {
+      final deltaJson = '[{"insert": "Rich Text Body "}, {"insert": "bold text", "attributes": {"bold": true}}, {"insert": "\\n"}]';
+      final quote = Quote(
+        content: 'Rich Text Body bold text\n',
+        date: '2026-05-31',
+        deltaContent: deltaJson,
+      );
+      final font = pw.Font.helvetica();
+      final widgets = DeltaToPdfParser.parse(quote, font);
+
+      expect(widgets, isNotEmpty);
+      expect(widgets.first, isA<pw.Container>());
+    });
+
+    test('PdfFontService returns default system font if local and network fonts fail', () async {
+      final font = await PdfFontService.loadFont();
+      expect(font, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description
This Pull Request implements a comprehensive PDF export feature for ThoughtEcho (Windows, Android, and iOS).

### Implemented Features:
1. **Preferences & Settings Details**:
   - Added `exportFormat` field to `AppSettings` and exposed it in `SettingsService`.
   - Integrated dropdown selector ("精致分享卡片" / "标准 A4 PDF") in the "常用偏好" section of `PreferencesDetailPage` with safe boundary normalization.

2. **Note Export Integration**:
   - Updated `QuoteItemWidget` to display "导出为 PDF" in the popup menu when PDF is the default format.
   - Refactored `NoteListView` to support an interactive "PDF Export Selection Mode" featuring a top bar for multi-select utilities (Select All, Same Month, Same Category) and a bottom action bar to compile and export the selected notes.

3. **Core PDF Compilation Services**:
   - `PdfFontService`: Dynamically loads local system fonts (Windows / Android) or retrieves a ZCOOL XiaoWei font from the network with reliable file caching.
   - `DeltaToPdfParser`: Compiles Quill Delta JSON formatted notes into inline styled PDF texts, paragraphs, page numbers, and inline images.
   - `PdfExportService`: Assembles pages, metadata, headers, footers, and margins.

4. **Print Preview & Accessibility**:
   - `PdfPreviewDialog`: Directly bridges generated PDF byte streams into native print/share overlays.
   - Fixed all hardcoded texts in UI/Snackbars to fetch values directly from localized `AppLocalizations` (source ARB translation files regenerated successfully).

### Verification:
- Code formatted with `dart format .`
- Executed static analysis: `No issues found!` (0 warnings/errors)
- Unit tests: `test/pdf_export_test.dart` completed with 100% green pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
实现标准 A4 PDF 导出，支持富文本编译、单条与批量选择，以及原生打印/分享预览；完善 WebDAV 蜂窝网络同步策略，可在移动网络下仅同步笔记或禁用流量同步以跳过大媒体。

- **新功能**
  - 偏好与列表：新增 `exportFormat`；在 `PreferencesDetailPage` 下拉选择“精致分享卡片/标准 A4 PDF”；列表加入“PDF 导出选择模式”（全选/同月/同分类，顶部/底部悬浮栏与一键导出）；默认格式为 PDF 时，单条菜单显示“导出为 PDF”，并对同月/同分类选择做安全检查。
  - 富文本与排版：`DeltaToPdfParser` 将 Quill Delta 转 PDF（粗体/斜体/下划线/颜色/内联图片）；`PdfExportService` 输出 A4 多页，含页眉/页脚、日期、天气/位置与标签；`PdfPreviewDialog` 支持原生打印/分享。
  - 字体与本地化：`PdfFontService` 优先系统中文字体，失败则下载并缓存站酷小薇；新增/更新导出与蜂窝网络相关文案（经 `AppLocalizations` 管理）。
  - WebDAV 同步：接入蜂窝网络识别与限制，可“允许流量同步/数据流量下仅同步笔记”；在移动网络下跳过大媒体文件同步。

- **依赖**
  - 新增 `pdf`, `printing`, `connectivity_plus`。

<sup>Written for commit 7f63265a1415da2ab0a6c22d105271d0dcda66cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加笔记导出与分享：支持分享卡片与 A4 PDF、单条与批量导出、按同月/同分类一键选中并导出
  * 内置 PDF 预览与打印功能

* **设置**
  * 新增默认导出格式选项
  * 新增移动网络同步相关开关与提示（可在设置中控制仅在蜂窝网络同步/仅同步文本）

* **本地化**
  * 补齐导出/分享与移动同步相关界面文案与提示

* **测试**
  * 新增 PDF 导出与解析相关测试用例
<!-- end of auto-generated comment: release notes by coderabbit.ai -->