### PR TITLE
🎨 Palette: 为关闭按钮补充无障碍提示 (Tooltip)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,6 @@
 ## 2025-02-28 - [完善引导弹窗遮罩层的无障碍支持]
 **Learning:** 自定义悬浮层（Overlay/Popover）中作为背景点击关闭的 GestureDetector 往往缺乏无障碍焦点和语意说明，屏幕阅读器用户无法感知这是一个可以用来关闭弹窗的可交互区域。
 **Action:** 确保这种非文字说明的交互背景元素（如全屏透明遮罩）被 Semantics 包装，提供 `button: true` 和 `label: MaterialLocalizations.of(context).closeButtonTooltip`，以此提升无障碍体验。
+## 2026-05-20 - [Fix Missing Tooltips for IconButton]
+**Learning:** `pdf_preview_dialog.dart` where `IconButton` with `Icons.close` was missing a `tooltip` property.
+**Action:** When adding close buttons inside standard dialogs and modals, always set `tooltip: MaterialLocalizations.of(context).closeButtonTooltip`.

--- a/lib/widgets/pdf_preview_dialog.dart
+++ b/lib/widgets/pdf_preview_dialog.dart
@@ -30,6 +30,7 @@ class PdfPreviewDialog extends StatelessWidget {
               title: Text(AppLocalizations.of(context).pdfPreviewAndPrint),
               leading: IconButton(
                 icon: const Icon(Icons.close),
+                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
                 onPressed: () => Navigator.pop(context),
               ),
               elevation: 0,


### PR DESCRIPTION
💡 What: 在 `pdf_preview_dialog.dart` 的 `IconButton(Icons.close)` 添加了 `tooltip`
🎯 Why: 提高应用的无障碍支持，让使用屏幕阅读器的用户能够知道这个图标按钮是用来关闭弹窗的。
♿ Accessibility: 使用 `MaterialLocalizations.of(context).closeButtonTooltip` 提供了无障碍焦点以及悬浮提示。

---
*PR created automatically by Jules for task [12592487567038295115](https://jules.google.com/task/12592487567038295115) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 PDF 预览弹窗的关闭按钮补充本地化 tooltip，提升无障碍与可用性。在 `pdf_preview_dialog.dart` 的 `IconButton(Icons.close)` 上添加 `tooltip: MaterialLocalizations.of(context).closeButtonTooltip`，便于屏幕阅读器识别并为鼠标悬停提供提示。

<sup>Written for commit 8bb5510ccb3bae12d56923967f622fdda134e436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 增强PDF预览对话框关闭按钮的无障碍性，现已提供本地化的提示文本，帮助用户更清晰地理解按钮功能，提升整体使用体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->