### PR TITLE
🔒 安全修复：隐藏调试日志中可能包含敏感信息的数据库查询参数

### DIFF
--- a/lib/services/database/database_query_mixin.dart
+++ b/lib/services/database/database_query_mixin.dart
@@ -179,22 +179,24 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
         });
 
         // 异步执行查询
-        query().then((result) {
-          timeoutTimer?.cancel();
-          if (!completer.isCompleted) {
-            completer.complete(result);
-          }
-        }).catchError((error) {
-          timeoutTimer?.cancel();
-          if (!completer.isCompleted) {
-            logError(
-              '数据库查询失败: $error',
-              error: error,
-              source: 'DatabaseService',
-            );
-            completer.completeError(error);
-          }
-        });
+        query()
+            .then((result) {
+              timeoutTimer?.cancel();
+              if (!completer.isCompleted) {
+                completer.complete(result);
+              }
+            })
+            .catchError((error) {
+              timeoutTimer?.cancel();
+              if (!completer.isCompleted) {
+                logError(
+                  '数据库查询失败: $error',
+                  error: error,
+                  source: 'DatabaseService',
+                );
+                completer.completeError(error);
+              }
+            });
 
         final result = await completer.future;
         timeoutTimer.cancel();
@@ -296,8 +298,9 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
 
     // 时间段筛选
     if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-      final dayPeriodPlaceholders =
-          selectedDayPeriods.map((_) => '?').join(',');
+      final dayPeriodPlaceholders = selectedDayPeriods
+          .map((_) => '?')
+          .join(',');
       conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
       args.addAll(selectedDayPeriods);
     }
@@ -335,8 +338,9 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     joinClause = '';
     groupByClause = '';
 
-    final where =
-        conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
+    final where = conditions.isNotEmpty
+        ? 'WHERE ${conditions.join(' AND ')}'
+        : '';
 
     final correctedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
 
@@ -344,7 +348,8 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     // 优化：指定查询列，排除大文本字段(ai_analysis, summary等)以提升列表加载性能
     // 注意：delta_content 必须保留！列表卡片通过 QuoteContent 组件渲染富文本（加粗、图片等）
     // 性能提升：(SELECT GROUP_CONCAT(tag_id) ...) 仅对 LIMIT 返回的数据执行
-    final query = '''
+    final query =
+        '''
       SELECT
         q.id, q.content, q.date, q.source, q.source_author, q.source_work,
         q.category_id, q.color_hex, q.location, q.latitude, q.longitude,
@@ -362,7 +367,7 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     args.addAll([limit, offset]);
 
     if (kDebugMode) {
-      logDebug('执行优化查询: $query\n参数: $args');
+      logDebug('执行优化查询: $query\n参数: [REDACTED]');
     }
 
     /// 修复：增强查询性能监控和慢查询检测
@@ -380,13 +385,13 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
       final level = queryTime > 1000
           ? '🔴 严重慢查询'
           : queryTime > 500
-              ? '⚠️ 慢查询警告'
-              : 'ℹ️ 性能提示';
+          ? '⚠️ 慢查询警告'
+          : 'ℹ️ 性能提示';
       logDebug('$level: 查询耗时 ${queryTime}ms');
 
       if (queryTime > 500) {
         logDebug('慢查询SQL: $query');
-        logDebug('查询参数: $args');
+        logDebug('查询参数: [REDACTED]');
       }
     }
 

--- a/lib/services/database/database_query_mixin.dart
+++ b/lib/services/database/database_query_mixin.dart
@@ -179,24 +179,22 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
         });
 
         // 异步执行查询
-        query()
-            .then((result) {
-              timeoutTimer?.cancel();
-              if (!completer.isCompleted) {
-                completer.complete(result);
-              }
-            })
-            .catchError((error) {
-              timeoutTimer?.cancel();
-              if (!completer.isCompleted) {
-                logError(
-                  '数据库查询失败: $error',
-                  error: error,
-                  source: 'DatabaseService',
-                );
-                completer.completeError(error);
-              }
-            });
+        query().then((result) {
+          timeoutTimer?.cancel();
+          if (!completer.isCompleted) {
+            completer.complete(result);
+          }
+        }).catchError((error) {
+          timeoutTimer?.cancel();
+          if (!completer.isCompleted) {
+            logError(
+              '数据库查询失败: $error',
+              error: error,
+              source: 'DatabaseService',
+            );
+            completer.completeError(error);
+          }
+        });
 
         final result = await completer.future;
         timeoutTimer.cancel();
@@ -298,9 +296,8 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
 
     // 时间段筛选
     if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-      final dayPeriodPlaceholders = selectedDayPeriods
-          .map((_) => '?')
-          .join(',');
+      final dayPeriodPlaceholders =
+          selectedDayPeriods.map((_) => '?').join(',');
       conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
       args.addAll(selectedDayPeriods);
     }
@@ -338,9 +335,8 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     joinClause = '';
     groupByClause = '';
 
-    final where = conditions.isNotEmpty
-        ? 'WHERE ${conditions.join(' AND ')}'
-        : '';
+    final where =
+        conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
 
     final correctedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
 
@@ -348,8 +344,7 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     // 优化：指定查询列，排除大文本字段(ai_analysis, summary等)以提升列表加载性能
     // 注意：delta_content 必须保留！列表卡片通过 QuoteContent 组件渲染富文本（加粗、图片等）
     // 性能提升：(SELECT GROUP_CONCAT(tag_id) ...) 仅对 LIMIT 返回的数据执行
-    final query =
-        '''
+    final query = '''
       SELECT
         q.id, q.content, q.date, q.source, q.source_author, q.source_work,
         q.category_id, q.color_hex, q.location, q.latitude, q.longitude,
@@ -385,8 +380,8 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
       final level = queryTime > 1000
           ? '🔴 严重慢查询'
           : queryTime > 500
-          ? '⚠️ 慢查询警告'
-          : 'ℹ️ 性能提示';
+              ? '⚠️ 慢查询警告'
+              : 'ℹ️ 性能提示';
       logDebug('$level: 查询耗时 ${queryTime}ms');
 
       if (queryTime > 500) {


### PR DESCRIPTION
🎯 **What:** 修复了在慢查询监控和调试模式下以明文形式记录数据库查询参数的漏洞。
⚠️ **Risk:** 数据库查询参数可能包含敏感的用户数据，将这些参数直接记录在系统日志中可能导致数据泄露或合规性违规。
🛡️ **Solution:** 在 `database_query_mixin.dart` 文件中，将 `logDebug` 中可能包含敏感信息的 `$args` 替换为了 `[REDACTED]`。


---
*PR created automatically by Jules for task [3419360599162674849](https://jules.google.com/task/3419360599162674849) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
在调试与慢查询日志中隐藏数据库查询参数，避免敏感数据以明文记录。保留 SQL 与耗时信息，不影响查询与错误处理。

- **Bug Fixes**
  - 在 `lib/services/database/database_query_mixin.dart` 中，`kDebugMode` 与慢查询路径的参数日志统一替换为 `[REDACTED]`。
  - 不改动查询绑定与执行，仅更新日志内容。

<sup>Written for commit 7398325c61430ed3ec0e7fa52b971470874cf3b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

