### PR TITLE
🧹 统一日志服务移除 print 语句改进代码健康度

### DIFF
--- a/lib/services/unified_log_service.dart
+++ b/lib/services/unified_log_service.dart
@@ -326,7 +326,7 @@ class UnifiedLogService with ChangeNotifier, WidgetsBindingObserver {
             (_currentLevel == UnifiedLogLevel.verbose ||
                 _currentLevel == UnifiedLogLevel.debug)) {
           if (kDebugMode) {
-            print(
+            debugPrint(
               'UnifiedLogService: 检测到日志级别为${_currentLevel.name}，用户未手动设置，重置为info',
             );
           }
@@ -437,8 +437,7 @@ class UnifiedLogService with ChangeNotifier, WidgetsBindingObserver {
         // 使用 debugPrint 输出到控制台，避免递归
         if (kDebugMode) {
           // 在调试模式下输出到控制台
-          // ignore: avoid_print
-          print(logOutput);
+          debugPrint(logOutput);
         }
       }
 
@@ -941,70 +940,65 @@ class UnifiedLogService with ChangeNotifier, WidgetsBindingObserver {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) =>
-      log(
-        UnifiedLogLevel.verbose,
-        message,
-        source: source,
-        error: error,
-        stackTrace: stackTrace,
-      );
+  }) => log(
+    UnifiedLogLevel.verbose,
+    message,
+    source: source,
+    error: error,
+    stackTrace: stackTrace,
+  );
 
   void debug(
     String message, {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) =>
-      log(
-        UnifiedLogLevel.debug,
-        message,
-        source: source,
-        error: error,
-        stackTrace: stackTrace,
-      );
+  }) => log(
+    UnifiedLogLevel.debug,
+    message,
+    source: source,
+    error: error,
+    stackTrace: stackTrace,
+  );
 
   void info(
     String message, {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) =>
-      log(
-        UnifiedLogLevel.info,
-        message,
-        source: source,
-        error: error,
-        stackTrace: stackTrace,
-      );
+  }) => log(
+    UnifiedLogLevel.info,
+    message,
+    source: source,
+    error: error,
+    stackTrace: stackTrace,
+  );
 
   void warning(
     String message, {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) =>
-      log(
-        UnifiedLogLevel.warning,
-        message,
-        source: source,
-        error: error,
-        stackTrace: stackTrace,
-      );
+  }) => log(
+    UnifiedLogLevel.warning,
+    message,
+    source: source,
+    error: error,
+    stackTrace: stackTrace,
+  );
 
   void error(
     String message, {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) =>
-      log(
-        UnifiedLogLevel.error,
-        message,
-        source: source,
-        error: error,
-        stackTrace: stackTrace,
-      );
+  }) => log(
+    UnifiedLogLevel.error,
+    message,
+    source: source,
+    error: error,
+    stackTrace: stackTrace,
+  );
 
   /// 获取日志统计摘要
   Map<String, dynamic> getLogSummary() {

--- a/lib/services/unified_log_service.dart
+++ b/lib/services/unified_log_service.dart
@@ -940,65 +940,70 @@ class UnifiedLogService with ChangeNotifier, WidgetsBindingObserver {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) => log(
-    UnifiedLogLevel.verbose,
-    message,
-    source: source,
-    error: error,
-    stackTrace: stackTrace,
-  );
+  }) =>
+      log(
+        UnifiedLogLevel.verbose,
+        message,
+        source: source,
+        error: error,
+        stackTrace: stackTrace,
+      );
 
   void debug(
     String message, {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) => log(
-    UnifiedLogLevel.debug,
-    message,
-    source: source,
-    error: error,
-    stackTrace: stackTrace,
-  );
+  }) =>
+      log(
+        UnifiedLogLevel.debug,
+        message,
+        source: source,
+        error: error,
+        stackTrace: stackTrace,
+      );
 
   void info(
     String message, {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) => log(
-    UnifiedLogLevel.info,
-    message,
-    source: source,
-    error: error,
-    stackTrace: stackTrace,
-  );
+  }) =>
+      log(
+        UnifiedLogLevel.info,
+        message,
+        source: source,
+        error: error,
+        stackTrace: stackTrace,
+      );
 
   void warning(
     String message, {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) => log(
-    UnifiedLogLevel.warning,
-    message,
-    source: source,
-    error: error,
-    stackTrace: stackTrace,
-  );
+  }) =>
+      log(
+        UnifiedLogLevel.warning,
+        message,
+        source: source,
+        error: error,
+        stackTrace: stackTrace,
+      );
 
   void error(
     String message, {
     String? source,
     Object? error,
     StackTrace? stackTrace,
-  }) => log(
-    UnifiedLogLevel.error,
-    message,
-    source: source,
-    error: error,
-    stackTrace: stackTrace,
-  );
+  }) =>
+      log(
+        UnifiedLogLevel.error,
+        message,
+        source: source,
+        error: error,
+        stackTrace: stackTrace,
+      );
 
   /// 获取日志统计摘要
   Map<String, dynamic> getLogSummary() {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the use of `print` statements in `lib/services/unified_log_service.dart`. These were replaced with `debugPrint` and the associated `// ignore: avoid_print` comment was removed.

💡 **Why:** This improves maintainability by ensuring logging consistency and avoiding the linter warnings associated with using plain `print` statements in production code.

✅ **Verification:** Verified by checking `git diff` for accurate replacements, ensuring `flutter analyze` and `dart format` pass, and running test suite successfully to ensure no functionality is broken. Also, reverted accidental modifications to unrelated files (`pubspec.lock`, `lib/widgets/add_note_dialog_parts.dart` and `lib/widgets/note_list/note_list_items.dart`).

✨ **Result:** A cleaner and more consistent `UnifiedLogService` that complies with Flutter logging best practices.

---
*PR created automatically by Jules for task [16424145938601025138](https://jules.google.com/task/16424145938601025138) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
在 `lib/services/unified_log_service.dart` 中将所有 `print` 替换为 `debugPrint`，移除 `// ignore: avoid_print`，并修复 `dart format`，统一日志输出并消除 linter 警告。仅做格式化与输出方式调整，行为不变，更符合 Flutter 日志最佳实践。

<sup>Written for commit ce0a0961e059e0f1f9fa192dc856ef16a206009c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

