### PR TITLE
⚡ Bolt: 优化 ContentSanitizer 中的正则表达式编译性能

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,8 @@
 ## 2024-05-30 - 优化 database_backup_service 中的降级插入性能
 **Learning:** The fallback block for database record insertion was incorrectly using sequential `await txn.insert()` for every tag of every quote. Although the initial quote array batch failed forcing this fallback, making another N+1 sequential request inside the fallback loop compounded the performance issue significantly.
 **Action:** Removed the sequential `txn.insert` call inside the tag resolution loop. Appended the records to `tagRelations` which is eventually processed by an existing, outer batched `txn.batch()` execution.
+## 2024-05-30 - 优化 ContentSanitizer 正则表达式编译性能
+**Learning:**
+在处理基于字符串分析的操作时（如 `injectCsp` 等方法），如果内联声明 `RegExp(...)`，Dart 会在每次调用方法时重新解析和编译正则表达式对象。尽管内部有一定缓存，但对于存在多次替换操作（如连续调用 `replaceAll` 和 `replaceFirstMapped`），频繁的对象分配和匹配查找依然会构成性能开销。
+**Action:**
+将 `injectCsp` 方法体内的所有用于 CSP 标签过滤、 `<script>` 标签清除以及 `<head>` 和 `<html>` 标签查找的正则表达式提取为类的 `static final RegExp` 字段。这种模式确保它们只会在类第一次被加载时进行编译（单次分配），避免了每次执行清理操作时重复实例化对象的问题，并更新了受影响的单元测试。

--- a/lib/utils/content_sanitizer.dart
+++ b/lib/utils/content_sanitizer.dart
@@ -16,10 +16,35 @@ class ContentSanitizer {
       "img-src data: https:; font-src data: https:; connect-src 'none'; "
       "media-src 'none'; frame-src 'none'; child-src 'none';";
 
+  // Optimization: Extract RegExp to static final fields to avoid repeated parsing
+  // and compilation overhead on every invocation of injectCsp.
+  static final RegExp _cspMetaRegex = RegExp(
+    r'<meta[^>]*http-equiv=["'
+    "'"
+    r']?Content-Security-Policy["'
+    "'"
+    r']?[^>]*>',
+    caseSensitive: false,
+  );
+
+  static final RegExp _scriptRegex = RegExp(
+    r'<script\b[^>]*>[\s\S]*?</script>',
+    caseSensitive: false,
+  );
+
+  static final RegExp _headRegex =
+      RegExp(r'(<head[^>]*>)', caseSensitive: false);
+
+  static final RegExp _htmlRegex =
+      RegExp(r'(<html[^>]*>)', caseSensitive: false);
+
+  static final RegExp _doctypeRegex =
+      RegExp(r'(<!doctype[^>]*>)', caseSensitive: false);
+
   /// Injects a Content Security Policy (CSP) meta tag into the HTML content.
   ///
-  /// If the HTML already contains a CSP meta tag, it returns the content unchanged.
-  /// Otherwise, it injects the tag into the `<head>` section.
+  /// If the HTML already contains a CSP meta tag, it removes it first to prevent
+  /// attacker bypass, then injects the safe CSP tag into the `<head>` section.
   static String injectCsp(String html) {
     if (html.isEmpty) return html;
 
@@ -29,39 +54,27 @@ class ContentSanitizer {
     String sanitized = html;
 
     // 1. Remove any existing CSP meta tags to prevent attacker bypass
-    sanitized = sanitized.replaceAll(
-        RegExp(
-            r'<meta[^>]*http-equiv=["'
-            "'"
-            r']?Content-Security-Policy["'
-            "'"
-            r']?[^>]*>',
-            caseSensitive: false),
-        '');
+    sanitized = sanitized.replaceAll(_cspMetaRegex, '');
 
     // 2. Strip <script> tags as an additional layer of defense
-    sanitized = sanitized.replaceAll(
-        RegExp(r'<script\b[^>]*>[\s\S]*?</script>', caseSensitive: false), '');
+    sanitized = sanitized.replaceAll(_scriptRegex, '');
 
     // Try to find <head> tag (case-insensitive), preserving attributes
-    final headRegex = RegExp(r'(<head[^>]*>)', caseSensitive: false);
-    if (headRegex.hasMatch(sanitized)) {
+    if (_headRegex.hasMatch(sanitized)) {
       return sanitized.replaceFirstMapped(
-          headRegex, (match) => '${match.group(0)}\n    $cspTag');
+          _headRegex, (match) => '${match.group(0)}\n    $cspTag');
     }
 
     // Try to find <html> tag, preserving attributes
-    final htmlRegex = RegExp(r'(<html[^>]*>)', caseSensitive: false);
-    if (htmlRegex.hasMatch(sanitized)) {
-      return sanitized.replaceFirstMapped(htmlRegex,
+    if (_htmlRegex.hasMatch(sanitized)) {
+      return sanitized.replaceFirstMapped(_htmlRegex,
           (match) => '${match.group(0)}\n<head>\n    $cspTag\n</head>');
     }
 
     // Try to find doctype tag, preserving attributes
-    final doctypeRegex = RegExp(r'(<!doctype[^>]*>)', caseSensitive: false);
-    if (doctypeRegex.hasMatch(sanitized)) {
+    if (_doctypeRegex.hasMatch(sanitized)) {
       return sanitized.replaceFirstMapped(
-          doctypeRegex, (match) => '${match.group(0)}\n$cspTag');
+          _doctypeRegex, (match) => '${match.group(0)}\n$cspTag');
     }
 
     // If no structure, just prepend it

--- a/test/unit/utils/content_sanitizer_test.dart
+++ b/test/unit/utils/content_sanitizer_test.dart
@@ -7,7 +7,7 @@ void main() {
     const expectedCspTag =
         '<meta http-equiv="Content-Security-Policy" content="$expectedCspContent">';
 
-    test('injectCsp returns unchanged HTML if CSP already exists', () {
+    test('injectCsp replaces existing CSP to prevent attacker bypass', () {
       const html = '''
 <!DOCTYPE html>
 <html>
@@ -18,7 +18,18 @@ void main() {
 <body>Hello</body>
 </html>
 ''';
-      expect(ContentSanitizer.injectCsp(html), html);
+      final expectedHtml = '''
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'none'; object-src 'none'; style-src 'unsafe-inline'; img-src data: https:; font-src data: https:; connect-src 'none'; media-src 'none'; frame-src 'none'; child-src 'none';">
+
+    <title>Test</title>
+</head>
+<body>Hello</body>
+</html>
+''';
+      expect(ContentSanitizer.injectCsp(html), expectedHtml);
     });
 
     test('injectCsp injects CSP into existing <head>', () {


### PR DESCRIPTION
💡 What: 将 `ContentSanitizer.injectCsp` 方法内部用于移除 CSP 以及替换关键标签（`<script>`, `<head>`, `<html>`, `<!doctype>`）的多个字面量 `RegExp` 提取为 `ContentSanitizer` 的 `static final` 私有静态字段。添加了专门的注释解释，并顺带修复了旧测试的断言以及该方法的 docstring 注释。

🎯 Why: 原本的写法会在每次调用 `injectCsp` 时反复解析和实例化正则表达式对象，虽然存在一定缓存机制，但这对于高频字符串处理方法来说仍然是多余的性能开销。

📊 Impact: 减少 `injectCsp` 方法执行时的对象重新分配内存和 CPU 执行时间，并且保持功能的完全一致性。

🔬 Measurement: 单元测试 `flutter test test/unit/utils/content_sanitizer_test.dart` 全部通过，功能未发生退化，静态分析 `flutter analyze` 无警告。

---
*PR created automatically by Jules for task [9508168905620429118](https://jules.google.com/task/9508168905620429118) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化 `ContentSanitizer` 中正则编译：将多处内联 `RegExp` 提取为类的 `static final`，减少 `injectCsp` 的 CPU 与内存开销；同时完善注释并修正测试以对齐预期逻辑。

- **性能与维护性**
  - 提取正则为私有静态字段：`_cspMetaRegex`、`_scriptRegex`、`_headRegex`、`_htmlRegex`、`_doctypeRegex`，避免重复解析与编译。
  - 明确并验证预期行为：若检测到现有 CSP，先移除再注入安全 CSP；更新了 docstring 与单测断言。

<sup>Written for commit 19e67fb0ac8a193246f6ef6e2efd7e1a9723a3d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **性能优化**
  * 优化了内容清理器的正则表达式编译性能。

* **改进**
  * 改进内容安全策略(CSP)注入行为，现将替换已有的CSP元标签而非保留原有内容，增强安全性。

* **测试**
  * 更新了相关单元测试以验证CSP替换行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->