### PR TITLE
🧹 移除 SVGTestHelper 中的 debug print，改用 AppLogger

### DIFF
--- a/lib/utils/svg_test_helper.dart
+++ b/lib/utils/svg_test_helper.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:thoughtecho/utils/app_logger.dart';
 
 /// SVG测试辅助工具
 class SVGTestHelper {
@@ -47,26 +47,26 @@ class SVGTestHelper {
   /// 验证SVG内容是否有效
   static bool validateSVG(String svgContent) {
     if (svgContent.trim().isEmpty) {
-      if (kDebugMode) print('SVG验证失败: 内容为空');
+      AppLogger.w('SVG验证失败: 内容为空', source: 'SVGTestHelper');
       return false;
     }
 
     if (!svgContent.contains('<svg')) {
-      if (kDebugMode) print('SVG验证失败: 缺少<svg>标签');
+      AppLogger.w('SVG验证失败: 缺少<svg>标签', source: 'SVGTestHelper');
       return false;
     }
 
     if (!svgContent.contains('</svg>')) {
-      if (kDebugMode) print('SVG验证失败: 缺少</svg>结束标签');
+      AppLogger.w('SVG验证失败: 缺少</svg>结束标签', source: 'SVGTestHelper');
       return false;
     }
 
     if (!svgContent.contains('xmlns="http://www.w3.org/2000/svg"')) {
-      if (kDebugMode) print('SVG验证警告: 缺少xmlns命名空间');
+      AppLogger.w('SVG验证警告: 缺少xmlns命名空间', source: 'SVGTestHelper');
     }
 
     if (!svgContent.contains('viewBox')) {
-      if (kDebugMode) print('SVG验证警告: 缺少viewBox属性');
+      AppLogger.w('SVG验证警告: 缺少viewBox属性', source: 'SVGTestHelper');
     }
 
     return true;


### PR DESCRIPTION
🎯 **What:** 将 `lib/utils/svg_test_helper.dart` 中的 5 处 `if (kDebugMode) print(...)` 替换为项目统一的日志工具 `AppLogger.w`，并移除了不再使用的 `package:flutter/foundation.dart` 引用。

💡 **Why:** 统一项目中的日志输出方式。标准 `print` 难以控制日志级别、格式及存储，改用 `AppLogger` 能够提高代码的规范性和可维护性，确保日志在不同环境（生产、测试）下的正确处理。

✅ **Verification:** 
- 运行 `dart format` 和 `flutter analyze`，确保代码格式和语法无误且未引入新的问题。
- 检查 `git diff`，确认所有更改都精确匹配要求，未产生不相关修改（已恢复因环境导致的 `pubspec.lock` 变更）。

✨ **Result:** 增强了 `SVGTestHelper` 的代码健康度，使其日志机制与项目规范完全对齐。

---
*PR created automatically by Jules for task [5026679754252125668](https://jules.google.com/task/5026679754252125668) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `lib/utils/svg_test_helper.dart` 中的 5 处 `if (kDebugMode) print(...)` 替换为 `AppLogger.w`，并移除未使用的 `package:flutter/foundation.dart` 引用。统一日志输出与级别，确保 SVG 校验的错误与警告在各环境下可控、可追踪。

<sup>Written for commit 657b4adc38527d06a69a093cd24e8b00bb8eeb41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

