### PR TITLE
[codex] Sanitize Sentry performance spans

### DIFF
--- a/lib/utils/sentry_helper.dart
+++ b/lib/utils/sentry_helper.dart
@@ -61,7 +61,34 @@ String sanitizeSentryDatabaseDescription(String description) {
       return '$prefix main';
     }
   }
+  final normalized = description.trimLeft().toUpperCase();
+  if (description.contains('app_logs') ||
+      description.contains('log_database')) {
+    return 'Log database write';
+  }
+  if (normalized.startsWith('SELECT ') ||
+      normalized.startsWith('INSERT ') ||
+      normalized.startsWith('UPDATE ') ||
+      normalized.startsWith('DELETE ') ||
+      normalized.startsWith('CREATE ') ||
+      normalized.startsWith('ALTER ') ||
+      normalized.startsWith('DROP ') ||
+      normalized.startsWith('PRAGMA ')) {
+    return 'SQL query';
+  }
   return description;
+}
+
+String sanitizeSentrySpanDescription(String description) {
+  final parts = description.split(' ');
+  if (parts.length >= 2 && Uri.tryParse(parts[1])?.hasScheme == true) {
+    return [
+      parts.first,
+      sanitizeSentryUrl(parts[1]),
+      if (parts.length > 2) ...parts.skip(2),
+    ].join(' ');
+  }
+  return sanitizeSentryDatabaseDescription(description);
 }
 
 String? sanitizeSentryUrl(String? url) {
@@ -116,13 +143,13 @@ SentryTransaction? sanitizeSentryTransaction(
   for (final span in transaction.spans) {
     final url = span.data['url'];
     if (url is String) {
-      span.setData('url', sanitizeSentryUrl(url));
+      span.data['url'] = sanitizeSentryUrl(url);
     }
-    span.removeData('http.query');
-    span.removeData('http.fragment');
+    span.data.remove('http.query');
+    span.data.remove('http.fragment');
     final description = span.context.description;
     if (description != null) {
-      span.context.description = sanitizeSentryDatabaseDescription(description);
+      span.context.description = sanitizeSentrySpanDescription(description);
     }
   }
   return transaction;

--- a/lib/utils/sentry_helper.dart
+++ b/lib/utils/sentry_helper.dart
@@ -61,9 +61,10 @@ String sanitizeSentryDatabaseDescription(String description) {
       return '$prefix main';
     }
   }
+  final lowerDescription = description.toLowerCase();
   final normalized = description.trimLeft().toUpperCase();
-  if (description.contains('app_logs') ||
-      description.contains('log_database')) {
+  if (lowerDescription.contains('app_logs') ||
+      lowerDescription.contains('log_database')) {
     return 'Log database write';
   }
   if (normalized.startsWith('SELECT ') ||
@@ -80,7 +81,7 @@ String sanitizeSentryDatabaseDescription(String description) {
 }
 
 String sanitizeSentrySpanDescription(String description) {
-  final parts = description.split(' ');
+  final parts = description.trim().split(RegExp(r'\s+'));
   if (parts.length >= 2 && Uri.tryParse(parts[1])?.hasScheme == true) {
     return [
       parts.first,

--- a/test/unit/utils/sentry_helper_test.dart
+++ b/test/unit/utils/sentry_helper_test.dart
@@ -1,11 +1,16 @@
-// ignore_for_file: depend_on_referenced_packages, experimental_member_use, implementation_imports
+// ignore_for_file: experimental_member_use
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:thoughtecho/utils/sentry_helper.dart';
 
+import '../../test_setup.dart';
+
 void main() {
+  setUpAll(() async {
+    await setupTestEnvironment();
+  });
+
   group('Sentry minimal collection options', () {
     test('disables sensitive and high-overhead collection', () {
       final options = SentryFlutterOptions();
@@ -49,53 +54,82 @@ INSERT OR REPLACE INTO app_logs (timestamp, level, message, source, error, stack
         sanitizeSentryDatabaseDescription(longSql),
         'Log database write',
       );
+      expect(
+        sanitizeSentryDatabaseDescription('INSERT INTO APP_LOGS VALUES (?)'),
+        'Log database write',
+      );
+      expect(
+        sanitizeSentrySpanDescription(
+          'GET\t https://example.com/path?api_key=secret#private',
+        ),
+        'GET https://example.com/path',
+      );
     });
 
     test('removes sensitive and bulky transaction span data', () async {
-      final tracer = SentryTracer(
-        SentryTransactionContext(
-          'root /',
-          'ui.load',
-          samplingDecision: SentryTracesSamplingDecision(true),
-          transactionNameSource: SentryTransactionNameSource.component,
-        ),
-        Hub(SentryOptions(dsn: 'https://public@example.com/1')),
-      );
-      final httpSpan = tracer.startChild(
-        'http.client',
-        description: 'GET https://example.com/path?api_key=secret#private',
-      ) as SentrySpan;
-      httpSpan
-        ..setData('url', 'https://example.com/path?api_key=secret#private')
-        ..setData('http.query', 'api_key=secret')
-        ..setData('http.fragment', 'private');
-      await httpSpan.finish();
-      final sqlSpan = tracer.startChild(
-        'db.sql.query',
-        description: 'SELECT * FROM quotes WHERE content LIKE ?',
-      ) as SentrySpan;
-      await sqlSpan.finish();
-      final logSpan = tracer.startChild(
-        'db',
-        description: '''
+      final mockTransport = _MockSentryTransport();
+      await Sentry.init((options) {
+        options.dsn = 'https://public@example.com/1';
+        options.transport = mockTransport;
+        options.tracesSampleRate = 1.0;
+        options.beforeSendTransaction = sanitizeSentryTransaction;
+      });
+
+      try {
+        final transaction = Sentry.startTransaction('root /', 'ui.load');
+        final httpSpan = transaction.startChild(
+          'http.client',
+          description: 'GET https://example.com/path?api_key=secret#private',
+        );
+        httpSpan
+          ..setData('url', 'https://example.com/path?api_key=secret#private')
+          ..setData('http.query', 'api_key=secret')
+          ..setData('http.fragment', 'private');
+        await httpSpan.finish();
+        final sqlSpan = transaction.startChild(
+          'db.sql.query',
+          description: 'SELECT * FROM quotes WHERE content LIKE ?',
+        );
+        await sqlSpan.finish();
+        final logSpan = transaction.startChild(
+          'db',
+          description: '''
 INSERT OR REPLACE INTO app_logs (timestamp, level, message, source, error, stack_trace) VALUES (?, ?, ?, ?, NULL, NULL)
 INSERT OR REPLACE INTO app_logs (timestamp, level, message, source, error, stack_trace) VALUES (?, ?, ?, ?, NULL, NULL)
 ''',
-      ) as SentrySpan;
-      await logSpan.finish();
-      await tracer.finish();
+        );
+        await logSpan.finish();
+        await transaction.finish();
 
-      final transaction = SentryTransaction(tracer);
+        await Future<void>.delayed(const Duration(milliseconds: 200));
 
-      final sanitized = sanitizeSentryTransaction(transaction, Hint());
+        final sentryTransaction = mockTransport.envelopes
+            .expand((envelope) => envelope.items)
+            .map((item) => item.originalObject)
+            .whereType<SentryTransaction>()
+            .single;
+        final httpTransactionSpan = sentryTransaction.spans.singleWhere(
+          (span) => span.context.operation == 'http.client',
+        );
+        final sqlTransactionSpan = sentryTransaction.spans.singleWhere(
+          (span) => span.context.operation == 'db.sql.query',
+        );
+        final logTransactionSpan = sentryTransaction.spans.singleWhere(
+          (span) => span.context.operation == 'db',
+        );
 
-      expect(sanitized, same(transaction));
-      expect(httpSpan.context.description, 'GET https://example.com/path');
-      expect(httpSpan.data['url'], 'https://example.com/path');
-      expect(httpSpan.data, isNot(contains('http.query')));
-      expect(httpSpan.data, isNot(contains('http.fragment')));
-      expect(sqlSpan.context.description, 'SQL query');
-      expect(logSpan.context.description, 'Log database write');
+        expect(
+          httpTransactionSpan.context.description,
+          'GET https://example.com/path',
+        );
+        expect(httpTransactionSpan.data['url'], 'https://example.com/path');
+        expect(httpTransactionSpan.data, isNot(contains('http.query')));
+        expect(httpTransactionSpan.data, isNot(contains('http.fragment')));
+        expect(sqlTransactionSpan.context.description, 'SQL query');
+        expect(logTransactionSpan.context.description, 'Log database write');
+      } finally {
+        await Sentry.close();
+      }
     });
 
     test('removes local paths from database breadcrumbs', () {
@@ -147,4 +181,14 @@ INSERT OR REPLACE INTO app_logs (timestamp, level, message, source, error, stack
       expect(sanitized?.request?.headers, isEmpty);
     });
   });
+}
+
+class _MockSentryTransport implements Transport {
+  final envelopes = <SentryEnvelope>[];
+
+  @override
+  Future<SentryId?> send(SentryEnvelope envelope) async {
+    envelopes.add(envelope);
+    return SentryId.newId();
+  }
 }

--- a/test/unit/utils/sentry_helper_test.dart
+++ b/test/unit/utils/sentry_helper_test.dart
@@ -1,6 +1,7 @@
-// ignore_for_file: experimental_member_use
+// ignore_for_file: depend_on_referenced_packages, experimental_member_use, implementation_imports
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/src/sentry_tracer.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:thoughtecho/utils/sentry_helper.dart';
 
@@ -27,6 +28,10 @@ void main() {
   group('Sentry database privacy', () {
     test('removes local paths from database descriptions', () {
       const privatePath = '/Users/private/Documents/ThoughtEcho/quotes.db';
+      const longSql = '''
+INSERT OR REPLACE INTO app_logs (timestamp, level, message, source, error, stack_trace) VALUES (?, ?, ?, ?, NULL, NULL)
+INSERT OR REPLACE INTO app_logs (timestamp, level, message, source, error, stack_trace) VALUES (?, ?, ?, ?, NULL, NULL)
+''';
 
       expect(
         sanitizeSentryDatabaseDescription('Transaction DB: $privatePath'),
@@ -38,8 +43,59 @@ void main() {
       );
       expect(
         sanitizeSentryDatabaseDescription('SELECT * FROM quotes'),
-        'SELECT * FROM quotes',
+        'SQL query',
       );
+      expect(
+        sanitizeSentryDatabaseDescription(longSql),
+        'Log database write',
+      );
+    });
+
+    test('removes sensitive and bulky transaction span data', () async {
+      final tracer = SentryTracer(
+        SentryTransactionContext(
+          'root /',
+          'ui.load',
+          samplingDecision: SentryTracesSamplingDecision(true),
+          transactionNameSource: SentryTransactionNameSource.component,
+        ),
+        Hub(SentryOptions(dsn: 'https://public@example.com/1')),
+      );
+      final httpSpan = tracer.startChild(
+        'http.client',
+        description: 'GET https://example.com/path?api_key=secret#private',
+      ) as SentrySpan;
+      httpSpan
+        ..setData('url', 'https://example.com/path?api_key=secret#private')
+        ..setData('http.query', 'api_key=secret')
+        ..setData('http.fragment', 'private');
+      await httpSpan.finish();
+      final sqlSpan = tracer.startChild(
+        'db.sql.query',
+        description: 'SELECT * FROM quotes WHERE content LIKE ?',
+      ) as SentrySpan;
+      await sqlSpan.finish();
+      final logSpan = tracer.startChild(
+        'db',
+        description: '''
+INSERT OR REPLACE INTO app_logs (timestamp, level, message, source, error, stack_trace) VALUES (?, ?, ?, ?, NULL, NULL)
+INSERT OR REPLACE INTO app_logs (timestamp, level, message, source, error, stack_trace) VALUES (?, ?, ?, ?, NULL, NULL)
+''',
+      ) as SentrySpan;
+      await logSpan.finish();
+      await tracer.finish();
+
+      final transaction = SentryTransaction(tracer);
+
+      final sanitized = sanitizeSentryTransaction(transaction, Hint());
+
+      expect(sanitized, same(transaction));
+      expect(httpSpan.context.description, 'GET https://example.com/path');
+      expect(httpSpan.data['url'], 'https://example.com/path');
+      expect(httpSpan.data, isNot(contains('http.query')));
+      expect(httpSpan.data, isNot(contains('http.fragment')));
+      expect(sqlSpan.context.description, 'SQL query');
+      expect(logSpan.context.description, 'Log database write');
     });
 
     test('removes local paths from database breadcrumbs', () {


### PR DESCRIPTION
## Summary
- sanitize Sentry performance span descriptions for SQL/log database operations
- remove HTTP query/fragment data from finished transaction spans by mutating span data directly
- add unit coverage for bulky transaction span sanitization

## Why
Sentry ANR evidence showed a native zlib `deflate_slow` stack, while slow root traces contained large SQL/log span descriptions and HTTP query data. Reducing transaction payload size lowers privacy risk and may reduce envelope compression pressure.

## Validation
- `timeout 60s flutter test --reporter compact test/unit/utils/sentry_helper_test.dart`
- `flutter analyze --no-fatal-infos` (only pre-existing infos remain)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
统一并清理 Sentry 性能 spans。标准化 SQL/日志描述，移除 URL 查询/片段，并脱敏 span 描述里的 URL，降低负载与隐私风险。

- **Bug Fixes**
  - 新增 `sanitizeSentrySpanDescription`：脱敏 HTTP 描述中的 URL；SQL 统一为 "SQL query"，日志写入统一为 "Log database write"（匹配 `app_logs`/`log_database` 与常见 SQL 动词）。
  - 直接修改 span 数据：清理 `data.url`，删除 `http.query`、`http.fragment`。
  - 扩展测试：基于 mock transport 的端到端事务验证；新增 HTTP/SQL/日志描述场景与边界用例。

<sup>Written for commit eeb9e85b1cda9591aa2b471c08ffc77880970101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 增强了错误追踪系统中的数据脱敏能力，更有效地识别并清理数据库相关描述、SQL语句和HTTP请求中的敏感信息。

* **测试**
  * 扩展了敏感数据脱敏行为的测试覆盖，包括复杂事务场景的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->