### PR TITLE
🌐 译者: 提取 WebDAV 同步冲突处理相关的硬编码字符串

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -33,3 +33,6 @@
 ## 2026-05-25 - [HitokotoWidget 提取硬编码]
 **发现:** HitokotoWidget 中存在 "每日一言" 和 "加载中..." 硬编码
 **规则:** 分别替换为 featureDailyQuote 和 loading。
+## YYYY-MM-DD - [提取 WebDAV 同步冲突处理相关的硬编码字符串]
+**发现:** WebDAV 同步页面冲突处理的提示：`"确认保留（移入默认分类）"`, `"已确认并移回默认笔记列表。"`, `"丢弃此冲突备份"`, `"已永久丢弃此冲突笔记。"`
+**规则:** 采用极简风格翻译，例如 `webdavConflictKeepTooltip`, `webdavConflictKeepSuccess`, `webdavConflictDiscardTooltip`, `webdavConflictDiscardSuccess`

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -33,5 +33,9 @@
   "dailyQuoteApiNinjasApiKeyInvalid": "Das Format des Dienstschlüssels scheint ungültig zu sein",
   "dailyQuoteApi": "Dienstanbieter für tägliche Zitate",
   "applyChanges": "Änderungen übernehmen",
-  "appendToOriginal": "An Original anhängen"
+  "appendToOriginal": "An Original anhängen",
+  "webdavConflictKeepTooltip": "Behalten und in Standardkategorie verschieben",
+  "webdavConflictKeepSuccess": "Bestätigt und in Standardliste verschoben.",
+  "webdavConflictDiscardTooltip": "Dieses Konflikt-Backup verwerfen",
+  "webdavConflictDiscardSuccess": "Diese Konfliktnotiz wurde dauerhaft verworfen."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3768,5 +3768,9 @@
   "customFeedbackEmailLabel": "Email (Optional)",
   "customFeedbackSubmit": "Submit Feedback",
   "customFeedbackSuccess": "Thanks for your feedback!",
-  "customFeedbackEmptyError": "Please enter feedback details"
+  "customFeedbackEmptyError": "Please enter feedback details",
+  "webdavConflictKeepTooltip": "Keep and move to default category",
+  "webdavConflictKeepSuccess": "Confirmed and moved to default list.",
+  "webdavConflictDiscardTooltip": "Discard this conflict backup",
+  "webdavConflictDiscardSuccess": "Permanently discarded this conflict note."
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -33,5 +33,9 @@
   "hitokotoTypeJoke": "Humor",
   "dailyQuoteApi": "Proveedor de cita diaria",
   "applyChanges": "Aplicar cambios",
-  "appendToOriginal": "Añadir al original"
+  "appendToOriginal": "Añadir al original",
+  "webdavConflictKeepTooltip": "Mantener y mover a categoría predeterminada",
+  "webdavConflictKeepSuccess": "Confirmado y movido a la lista predeterminada.",
+  "webdavConflictDiscardTooltip": "Descartar esta copia de seguridad de conflicto",
+  "webdavConflictDiscardSuccess": "Nota de conflicto descartada permanentemente."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3530,6 +3530,6 @@
   "appendToOriginal": "Ajouter à l'original",
   "webdavConflictKeepTooltip": "Conserver et déplacer vers la catégorie par défaut",
   "webdavConflictKeepSuccess": "Confirmé et déplacé vers la liste par défaut.",
-  "webdavConflictDiscardTooltip": "Ignorer cette sauvegarde de conflit",
+  "webdavConflictDiscardTooltip": "Jeter cette sauvegarde de conflit",
   "webdavConflictDiscardSuccess": "Note de conflit définitivement supprimée."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3527,5 +3527,9 @@
   "insertAudio": "Insérer un audio",
   "clipboardFoundHint": "Contenu du presse-papiers trouvé, appuyez pour ajouter comme note",
   "operationFailedSimple": "L'opération a échoué",
-  "appendToOriginal": "Ajouter à l'original"
+  "appendToOriginal": "Ajouter à l'original",
+  "webdavConflictKeepTooltip": "Conserver et déplacer vers la catégorie par défaut",
+  "webdavConflictKeepSuccess": "Confirmé et déplacé vers la liste par défaut.",
+  "webdavConflictDiscardTooltip": "Ignorer cette sauvegarde de conflit",
+  "webdavConflictDiscardSuccess": "Note de conflit définitivement supprimée."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3545,5 +3545,9 @@
   "offlineQuoteSourceDesc": "オフライン時やローカルのみ使用時にホーム画面に表示する内容",
   "offlineQuoteSourceTagOnly": "「今日の一言」タグのノートのみ表示",
   "offlineQuoteSourceAll": "すべてのノートをランダムに表示",
-  "appendToOriginal": "原文に追加"
+  "appendToOriginal": "原文に追加",
+  "webdavConflictKeepTooltip": "保持してデフォルトカテゴリに移動",
+  "webdavConflictKeepSuccess": "確認してデフォルトリストに移動しました。",
+  "webdavConflictDiscardTooltip": "この競合バックアップを破棄",
+  "webdavConflictDiscardSuccess": "この競合メモを完全に破棄しました。"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -3540,5 +3540,9 @@
   "insertVideo": "동영상 삽입",
   "insertAudio": "오디오 삽입",
   "clipboardFoundHint": "클립보드 내용 발견, 탭하여 노트로 추가",
-  "appendToOriginal": "원본에 추가"
+  "appendToOriginal": "원본에 추가",
+  "webdavConflictKeepTooltip": "유지 및 기본 카테고리로 이동",
+  "webdavConflictKeepSuccess": "확인 후 기본 목록으로 이동되었습니다.",
+  "webdavConflictDiscardTooltip": "이 충돌 백업 취소",
+  "webdavConflictDiscardSuccess": "이 충돌 메모를 영구적으로 삭제했습니다."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3717,6 +3717,10 @@
     }
   },
   "webdavViewNow": "立即查看",
+  "webdavConflictKeepTooltip": "确认保留（移入默认分类）",
+  "webdavConflictKeepSuccess": "已确认并移回默认笔记列表。",
+  "webdavConflictDiscardTooltip": "丢弃此冲突备份",
+  "webdavConflictDiscardSuccess": "已永久丢弃此冲突笔记。",
   "exportFormatLabel": "默认导出格式",
   "exportFormatCard": "精致分享卡片",
   "exportFormatPdf": "标准 A4 PDF",

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -920,7 +920,8 @@ class QuoteListViewByConflict extends StatelessWidget {
                     // 一键恢复/移动：改分类至默认，使其移出冲突
                     IconButton(
                       icon: const Icon(Icons.check, color: Colors.green),
-                      tooltip: '确认保留（移入默认分类）',
+                      tooltip: AppLocalizations.of(context)
+                          .webdavConflictKeepTooltip,
                       onPressed: () async {
                         // 更新分类为默认（空）
                         final updated = quote.copyWith(
@@ -934,8 +935,9 @@ class QuoteListViewByConflict extends StatelessWidget {
 
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('已确认并移回默认笔记列表。'),
+                            SnackBar(
+                              content: Text(AppLocalizations.of(context)
+                                  .webdavConflictKeepSuccess),
                               behavior: SnackBarBehavior.floating,
                             ),
                           );
@@ -945,7 +947,8 @@ class QuoteListViewByConflict extends StatelessWidget {
                     // 一键丢弃/删除
                     IconButton(
                       icon: const Icon(Icons.delete_outline, color: Colors.red),
-                      tooltip: '丢弃此冲突备份',
+                      tooltip: AppLocalizations.of(context)
+                          .webdavConflictDiscardTooltip,
                       onPressed: () async {
                         // 永久删除该笔记
                         await dbService.permanentlyDeleteQuote(quote.id!);
@@ -953,8 +956,9 @@ class QuoteListViewByConflict extends StatelessWidget {
 
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('已永久丢弃此冲突笔记。'),
+                            SnackBar(
+                              content: Text(AppLocalizations.of(context)
+                                  .webdavConflictDiscardSuccess),
                               behavior: SnackBarBehavior.floating,
                             ),
                           );


### PR DESCRIPTION
提取 `lib/pages/webdav_sync_page.dart` 中的中文硬编码并将其国际化。

提取的词条与中英对照：
- 确认保留（移入默认分类） -> Keep and move to default category
- 已确认并移回默认笔记列表。 -> Confirmed and moved to default list.
- 丢弃此冲突备份 -> Discard this conflict backup
- 已永久丢弃此冲突笔记。 -> Permanently discarded this conflict note.

涉及文件：
- `lib/pages/webdav_sync_page.dart`
- 各语言的 `app_*.arb` 文件
- 更新了 `.jules/translator.md` 记录翻译策略。

---
*PR created automatically by Jules for task [2649081908369368370](https://jules.google.com/task/2649081908369368370) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 WebDAV 同步冲突处理相关的中文硬编码移入多语言资源，统一使用 i18n key，提升可翻译性与一致性。功能行为不变，仅更新文案来源。

- **Refactors**
  - 新增 `webdavConflictKeepTooltip/webdavConflictKeepSuccess/webdavConflictDiscardTooltip/webdavConflictDiscardSuccess` 到各语言 `app_*.arb`（含法语补齐）
  - `lib/pages/webdav_sync_page.dart` 改为通过 `AppLocalizations` 获取 tooltip 与 SnackBar 文案
  - 更新 `.jules/translator.md`，记录对应翻译规则

<sup>Written for commit a674b94a08e478df5fca0e52a0130a146381ed25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为 WebDAV 同步冲突处理新增完整多语言文案：提供“保留并移回默认分类”和“丢弃冲突备份”的操作提示与成功反馈，覆盖英、中文、日、韩、法、德、西班牙语等。
  * 将冲突处理相关的提示与成功消息改为使用本地化文案，统一显示与风格。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->