### PR TITLE
[codex] Format database health cache change

### DIFF
--- a/lib/services/database_health_service.dart
+++ b/lib/services/database_health_service.dart
@@ -175,8 +175,7 @@ class DatabaseHealthService {
       );
 
       // Cache the full column set for this table.
-      final columns =
-          result.map((row) => row['name'] as String).toSet();
+      final columns = result.map((row) => row['name'] as String).toSet();
       _tableColumnCache[tableName] = columns;
 
       return columns.contains(columnName);


### PR DESCRIPTION
## Summary

- Format the cached pragma_table_info column-set assignment in DatabaseHealthService.

## Validation
- dart format --set-exit-if-changed lib/services/database_health_service.dart






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 DatabaseHealthService 中缓存列集合（来自 pragma_table_info）的赋值从多行合并为单行，统一代码风格。无逻辑或行为变更。

<sup>Written for commit fc8e857f3f3af2356f348b3ae96eda2b5eff13ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

