### PR TITLE
🗃️ 黑匣: [完善 WebDAVSyncPage 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -27,3 +27,7 @@
 ## 2025-10-24 - 🗃️ 黑匣: [完善 InsightHistoryService 模块的结构化日志]
 **异常:** [InsightHistoryService 模块在解析和存储周期洞察（AI分析报告）历史时，如果遇到 JSON 解析错误或其他隐蔽异常，当前仅使用 catch (e) 进行了粗糙拦截，并依赖 debugPrint 输出，这会导致丢失关键的错误堆栈信息，且缺乏统一的模块标识。]
 **拦截:** [已将该模块中的异常捕获统一升级为 catch (e, stack)，并使用 AppLogger.e('...', error: e, stackTrace: stack, source: 'InsightHistoryService')。同时规范了 getInsightBySignature 中的控制流，避免使用 try...catch 进行预期内的查找。]
+
+## 2025-05-18 - 🗃️ 黑匣: [完善 WebDAVSyncPage 模块的结构化日志]
+**异常:** [WebDAVSyncPage 模块在 `_checkConflictNotes` 检查冲突笔记时，遇到数据库查询错误仅使用了 `catch (_) {}` 进行了空捕获。这会隐藏潜在的数据库或表结构问题，导致用户无法发现并处理同步冲突。]
+**拦截:** [已将该空捕获替换为 `AppLogger.e`，注入了描述信息、具体的错误对象 `error: e`、堆栈轨迹 `stackTrace: stackTrace`，并指定了明确的日志来源模块 `source: 'WebDAVSyncPage'`。确认记录内容不包含任何笔记实体数据。]

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -8,6 +8,7 @@ import '../services/database_service.dart';
 import '../services/mmkv_service.dart';
 import '../services/webdav_sync_service.dart';
 import '../utils/lww_utils.dart';
+import '../utils/app_logger.dart';
 
 class WebDAVSyncPage extends StatefulWidget {
   const WebDAVSyncPage({super.key});
@@ -127,7 +128,14 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
           _hasConflicts = result.isNotEmpty;
         });
       }
-    } catch (_) {}
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '检查冲突笔记失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'WebDAVSyncPage',
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
### 🎯 What
在 `WebDAVSyncPage` 模块检查冲突笔记的方法 `_checkConflictNotes` 中，将原先隐藏异常的 `catch (_) {}` 空捕获替换为了结构化的 `AppLogger.e`。

### 💡 Why
当数据库出现读取异常（例如表结构损坏或字段缺失）时，空捕获会掩盖错误，导致用户无法察觉且无法恢复同步冲突的笔记，后续极难排查。结构化日志记录了完整的错误与堆栈，并携带 `source: 'WebDAVSyncPage'` 标签，方便后续追踪。

### 🔒 Security Check
- 确认修改：仅在 catch 中传递系统错误堆栈。
- 敏感数据：不包含任何笔记实体正文或用户授权凭证，完全符合安全红线。

### 📊 Verification
- 运行了 `flutter analyze lib/pages/webdav_sync_page.dart`，无语法错误。
- 确保相关测试通过。

---
*PR created automatically by Jules for task [2856818192824750556](https://jules.google.com/task/2856818192824750556) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
完善 `WebDAVSyncPage` 的冲突检查日志：将 `_checkConflictNotes` 的空 `catch` 改为结构化 `AppLogger.e`，记录错误与堆栈并标注 `source: 'WebDAVSyncPage'`，避免吞错并提升可追踪性。同步更新黑匣文档记录此次变更，未包含任何用户敏感数据。

<sup>Written for commit 41855fb43bc1f89abc4a75d85ebd68e2d80b2f9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Bug Fixes**
  * 改进了WebDAV同步过程中的异常处理，原先的数据库查询错误不再被隐藏，现已添加详细的错误日志记录，便于诊断同步问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->