### PR TITLE
🛡️ Sentinel: [MEDIUM] 修复日志中的数据泄漏问题

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -43,3 +43,7 @@
 **Vulnerability:** The `LocalSendServer` (`lib/services/localsend/localsend_server.dart`), which binds to the local network interface (`InternetAddress.anyIPv4`), explicitly added permissive CORS headers (`Access-Control-Allow-Origin: *`) and handled `OPTIONS` preflight requests. This allowed any external malicious website the user visits to bypass the browser's Same-Origin Policy and make direct HTTP requests to the local server via the browser (e.g., DNS rebinding).
 **Learning:** Local network servers must be extremely strict about cross-origin requests. Adding wildcard CORS headers to a local server completely negates the security boundary provided by the browser's Same-Origin Policy.
 **Prevention:** Do not add `Access-Control-Allow-Origin: *` to local servers. Rely on standard Same-Origin Policy to block unauthorized cross-origin access from web browsers.
+## 2024-05-18 - 避免通过日志记录敏感数据库查询参数
+**Vulnerability:** 数据库查询参数（`$finalArgs`，可能包含用户标签、分类等敏感筛选条件）在 `logDebug` 中以明文形式记录，有数据泄漏风险。
+**Learning:** 在拼接或调用日志工具（如 `logDebug`、`AppLogger.e`）输出带参的 SQL 执行或排查信息时，极易忽略敏感信息脱敏，导致 PII 等数据泄漏。
+**Prevention:** 在日志中记录数据库操作时，永远不要将 `$args` 列表明文打印，必须使用 `[REDACTED]` 或其他脱敏手段隐藏参数内容。

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -104,19 +104,22 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
     // 时间段筛选
     if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-      final dayPeriodPlaceholders =
-          selectedDayPeriods.map((_) => '?').join(',');
+      final dayPeriodPlaceholders = selectedDayPeriods
+          .map((_) => '?')
+          .join(',');
       conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
       args.addAll(selectedDayPeriods);
     }
 
-    final whereClause =
-        conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
+    final whereClause = conditions.isNotEmpty
+        ? 'WHERE ${conditions.join(' AND ')}'
+        : '';
 
     // ⚡ Bolt: 使用标量子查询替代 LEFT JOIN 和 GROUP BY，避免在 LIMIT 分页前全表聚合的性能瓶颈
 
     final sanitizedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
-    final query = '''
+    final query =
+        '''
       SELECT 
         q.*
       FROM quotes q
@@ -236,12 +239,14 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
       if (!includeDeleted) {
         conditions.add('(q.is_deleted = 0 OR q.is_deleted IS NULL)');
       }
-      final where =
-          conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
+      final where = conditions.isNotEmpty
+          ? 'WHERE ${conditions.join(' AND ')}'
+          : '';
 
       // 只取必要列，不取 delta_content/ai_analysis/summary/keywords
       final sanitizedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
-      final query = '''
+      final query =
+          '''
         SELECT q.id, q.content, q.date, q.source, q.source_author, q.source_work,
                q.category_id, q.color_hex, q.location, q.latitude, q.longitude,
                q.weather, q.temperature, q.edit_source, q.day_period,
@@ -380,8 +385,9 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
       // 时间段筛选
       if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-        final dayPeriodPlaceholders =
-            selectedDayPeriods.map((_) => '?').join(',');
+        final dayPeriodPlaceholders = selectedDayPeriods
+            .map((_) => '?')
+            .join(',');
         conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
         args.addAll(selectedDayPeriods);
       }
@@ -400,19 +406,21 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
         finalArgs.insertAll(0, tagIds);
 
-        final whereClause =
-            conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
+        final whereClause = conditions.isNotEmpty
+            ? 'WHERE ${conditions.join(' AND ')}'
+            : '';
 
         query =
             'SELECT COUNT(DISTINCT q.id) as count FROM quotes q$joins $whereClause';
       } else {
         // 没有标签筛选，使用简单的 COUNT
-        final whereClause =
-            conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
+        final whereClause = conditions.isNotEmpty
+            ? 'WHERE ${conditions.join(' AND ')}'
+            : '';
         query = 'SELECT COUNT(*) as count FROM quotes q $whereClause';
       }
 
-      logDebug('执行计数查询: $query\n参数: $finalArgs');
+      logDebug('执行计数查询: $query\n参数: [REDACTED]');
       final result = await db.rawQuery(query, finalArgs);
       return Sqflite.firstIntValue(result) ?? 0;
     } catch (e) {

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -104,22 +104,19 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
     // 时间段筛选
     if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-      final dayPeriodPlaceholders = selectedDayPeriods
-          .map((_) => '?')
-          .join(',');
+      final dayPeriodPlaceholders =
+          selectedDayPeriods.map((_) => '?').join(',');
       conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
       args.addAll(selectedDayPeriods);
     }
 
-    final whereClause = conditions.isNotEmpty
-        ? 'WHERE ${conditions.join(' AND ')}'
-        : '';
+    final whereClause =
+        conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
 
     // ⚡ Bolt: 使用标量子查询替代 LEFT JOIN 和 GROUP BY，避免在 LIMIT 分页前全表聚合的性能瓶颈
 
     final sanitizedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
-    final query =
-        '''
+    final query = '''
       SELECT 
         q.*
       FROM quotes q
@@ -239,14 +236,12 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
       if (!includeDeleted) {
         conditions.add('(q.is_deleted = 0 OR q.is_deleted IS NULL)');
       }
-      final where = conditions.isNotEmpty
-          ? 'WHERE ${conditions.join(' AND ')}'
-          : '';
+      final where =
+          conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
 
       // 只取必要列，不取 delta_content/ai_analysis/summary/keywords
       final sanitizedOrderBy = sanitizeOrderBy(orderBy, prefix: 'q');
-      final query =
-          '''
+      final query = '''
         SELECT q.id, q.content, q.date, q.source, q.source_author, q.source_work,
                q.category_id, q.color_hex, q.location, q.latitude, q.longitude,
                q.weather, q.temperature, q.edit_source, q.day_period,
@@ -385,9 +380,8 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
       // 时间段筛选
       if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-        final dayPeriodPlaceholders = selectedDayPeriods
-            .map((_) => '?')
-            .join(',');
+        final dayPeriodPlaceholders =
+            selectedDayPeriods.map((_) => '?').join(',');
         conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
         args.addAll(selectedDayPeriods);
       }
@@ -406,17 +400,15 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
         finalArgs.insertAll(0, tagIds);
 
-        final whereClause = conditions.isNotEmpty
-            ? 'WHERE ${conditions.join(' AND ')}'
-            : '';
+        final whereClause =
+            conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
 
         query =
             'SELECT COUNT(DISTINCT q.id) as count FROM quotes q$joins $whereClause';
       } else {
         // 没有标签筛选，使用简单的 COUNT
-        final whereClause = conditions.isNotEmpty
-            ? 'WHERE ${conditions.join(' AND ')}'
-            : '';
+        final whereClause =
+            conditions.isNotEmpty ? 'WHERE ${conditions.join(' AND ')}' : '';
         query = 'SELECT COUNT(*) as count FROM quotes q $whereClause';
       }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: 在 `lib/services/database/database_query_helpers_mixin.dart` 文件中，`logDebug` 函数以明文形式记录了数据库查询参数 `$finalArgs`。这可能导致敏感数据（例如用户标签、分类等）泄漏到日志中。
🎯 Impact: 如果有恶意人员访问了这些日志，敏感数据将会遭到泄漏。
🔧 Fix: 将 `logDebug` 中的 `$finalArgs` 替换为 `[REDACTED]` 以避免数据泄漏。
✅ Verification: 检查 `lib/services/database/database_query_helpers_mixin.dart` 中原本打印查询参数的地方是否已经被正确替换。执行 `flutter test` 和 `flutter analyze` 确保所有检查都通过。

---
*PR created automatically by Jules for task [13032409117463169243](https://jules.google.com/task/13032409117463169243) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复数据库查询日志中的敏感参数泄漏。将计数查询的 `logDebug` 参数输出改为 `[REDACTED]`，避免标签、分类等数据写入日志。

- **Bug Fixes**
  - 在计数查询日志中用 `[REDACTED]` 替代 `$finalArgs`（`lib/services/database/database_query_helpers_mixin.dart`）。
  - 在 `.jules/sentinel.md` 增补本次问题记录与预防指引。

<sup>Written for commit 4004c19d47077433a271abd30e96b6b23763dfe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **安全修复**
  * 增强日志安全性，敏感数据库查询参数在调试日志中将使用脱敏占位符替代明文显示，防止敏感信息泄露。

* **代码优化**
  * 改进代码可读性，优化数据库查询语句的组织结构。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->