### PR TITLE
🌐 译者: [提取硬编码 / 补全多语言词条] 提取滑动卡片提示

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -36,3 +36,6 @@
 ## YYYY-MM-DD - [提取 WebDAV 同步冲突处理相关的硬编码字符串]
 **发现:** WebDAV 同步页面冲突处理的提示：`"确认保留（移入默认分类）"`, `"已确认并移回默认笔记列表。"`, `"丢弃此冲突备份"`, `"已永久丢弃此冲突笔记。"`
 **规则:** 采用极简风格翻译，例如 `webdavConflictKeepTooltip`, `webdavConflictKeepSuccess`, `webdavConflictDiscardTooltip`, `webdavConflictDiscardSuccess`
+## 2024-05-18 - [滑动卡片添加笔记提示的国际化]
+**发现:** `← 左滑添加到笔记` 这个提示语被硬编码在了 `lib/widgets/sliding_card.dart` 中。这是一个通用的卡片滑动交互提示。
+**规则:** 遵循 Material Design 的极简交互文本风格。英文翻译为 `← Swipe left to add note`，日文为 `← 左にスワイプしてノートに追加`，其他语言类似处理。

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -37,5 +37,6 @@
   "webdavConflictKeepTooltip": "Behalten und in Standardkategorie verschieben",
   "webdavConflictKeepSuccess": "Bestätigt und in Standardliste verschoben.",
   "webdavConflictDiscardTooltip": "Dieses Konflikt-Backup verwerfen",
-  "webdavConflictDiscardSuccess": "Diese Konfliktnotiz wurde dauerhaft verworfen."
+  "webdavConflictDiscardSuccess": "Diese Konfliktnotiz wurde dauerhaft verworfen.",
+  "slideLeftToAddNote": "← Nach links wischen, um eine Notiz hinzuzufügen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3778,5 +3778,6 @@
   "webdavConflictKeepTooltip": "Keep and move to default category",
   "webdavConflictKeepSuccess": "Confirmed and moved to default list.",
   "webdavConflictDiscardTooltip": "Discard this conflict backup",
-  "webdavConflictDiscardSuccess": "Permanently discarded this conflict note."
+  "webdavConflictDiscardSuccess": "Permanently discarded this conflict note.",
+  "slideLeftToAddNote": "← Swipe left to add note"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -37,5 +37,6 @@
   "webdavConflictKeepTooltip": "Mantener y mover a categoría predeterminada",
   "webdavConflictKeepSuccess": "Confirmado y movido a la lista predeterminada.",
   "webdavConflictDiscardTooltip": "Descartar esta copia de seguridad de conflicto",
-  "webdavConflictDiscardSuccess": "Nota de conflicto descartada permanentemente."
+  "webdavConflictDiscardSuccess": "Nota de conflicto descartada permanentemente.",
+  "slideLeftToAddNote": "← Deslizar a la izquierda para añadir nota"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3531,5 +3531,6 @@
   "webdavConflictKeepTooltip": "Conserver et déplacer vers la catégorie par défaut",
   "webdavConflictKeepSuccess": "Confirmé et déplacé vers la liste par défaut.",
   "webdavConflictDiscardTooltip": "Jeter cette sauvegarde de conflit",
-  "webdavConflictDiscardSuccess": "Note de conflit définitivement supprimée."
+  "webdavConflictDiscardSuccess": "Note de conflit définitivement supprimée.",
+  "slideLeftToAddNote": "← Glisser vers la gauche pour ajouter une note"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3549,5 +3549,6 @@
   "webdavConflictKeepTooltip": "保持してデフォルトカテゴリに移動",
   "webdavConflictKeepSuccess": "確認してデフォルトリストに移動しました。",
   "webdavConflictDiscardTooltip": "この競合バックアップを破棄",
-  "webdavConflictDiscardSuccess": "この競合メモを完全に破棄しました。"
+  "webdavConflictDiscardSuccess": "この競合メモを完全に破棄しました。",
+  "slideLeftToAddNote": "← 左にスワイプしてノートに追加"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -3544,5 +3544,6 @@
   "webdavConflictKeepTooltip": "유지 및 기본 카테고리로 이동",
   "webdavConflictKeepSuccess": "확인 후 기본 목록으로 이동되었습니다.",
   "webdavConflictDiscardTooltip": "이 충돌 백업 취소",
-  "webdavConflictDiscardSuccess": "이 충돌 메모를 영구적으로 삭제했습니다."
+  "webdavConflictDiscardSuccess": "이 충돌 메모를 영구적으로 삭제했습니다.",
+  "slideLeftToAddNote": "← 왼쪽으로 스와이프하여 노트 추가"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3778,5 +3778,6 @@
   "customFeedbackEmailLabel": "联系邮箱 (可选)",
   "customFeedbackSubmit": "发送反馈",
   "customFeedbackSuccess": "感谢您的反馈！",
-  "customFeedbackEmptyError": "请输入反馈内容"
+  "customFeedbackEmptyError": "请输入反馈内容",
+  "slideLeftToAddNote": "← 左滑添加到笔记"
 }

--- a/lib/widgets/sliding_card.dart
+++ b/lib/widgets/sliding_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
 import '../utils/color_utils.dart';
+import '../gen_l10n/app_localizations.dart';
 
 class SlidingCard extends StatefulWidget {
   final Widget child;
@@ -229,7 +230,7 @@ class _SlidingCardState extends State<SlidingCard>
                                   duration: const Duration(milliseconds: 200),
                                   opacity: _isHovered ? 0.8 : 0.5,
                                   child: Text(
-                                    '← 左滑添加到笔记',
+                                    AppLocalizations.of(context).slideLeftToAddNote,
                                     style: TextStyle(
                                       fontSize: 12,
                                       color: theme.colorScheme.onSurface

--- a/lib/widgets/sliding_card.dart
+++ b/lib/widgets/sliding_card.dart
@@ -230,7 +230,8 @@ class _SlidingCardState extends State<SlidingCard>
                                   duration: const Duration(milliseconds: 200),
                                   opacity: _isHovered ? 0.8 : 0.5,
                                   child: Text(
-                                    AppLocalizations.of(context).slideLeftToAddNote,
+                                    AppLocalizations.of(context)
+                                        .slideLeftToAddNote,
                                     style: TextStyle(
                                       fontSize: 12,
                                       color: theme.colorScheme.onSurface


### PR DESCRIPTION
将 lib/widgets/sliding_card.dart 中的硬编码字符串 '← 左滑添加到笔记' 提取为翻译键 slideLeftToAddNote，并在各语言的 app_*.arb 文件中补全了翻译。

---
*PR created automatically by Jules for task [17468231395377297475](https://jules.google.com/task/17468231395377297475) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将滑动卡片提示“← 左滑添加到笔记”从硬编码提取为本地化键 `slideLeftToAddNote`，并补齐多语言翻译。提升多语言一致性与可维护性。

- **Refactors**
  - 在 `lib/widgets/sliding_card.dart` 使用 `AppLocalizations.of(context).slideLeftToAddNote` 替代硬编码
  - 为 de/en/es/fr/ja/ko/zh 添加 `slideLeftToAddNote` 词条
  - 更新 `.jules/translator.md`，补充该提示的翻译规范

<sup>Written for commit f67e57e5b6528947511f3cdd41aecece105337d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **国际化支持**
  * 为"左滑添加到笔记"交互提示新增多语言支持，现已涵盖英文、日文、德文、法文、西班牙文和韩文，确保全球用户获得本地化体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->