### PR TITLE
🗃️ 黑匣: [完善 DatabaseService 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -31,3 +31,7 @@
 ## 2025-05-18 - 🗃️ 黑匣: [完善 WebDAVSyncPage 模块的结构化日志]
 **异常:** [WebDAVSyncPage 模块在 `_checkConflictNotes` 检查冲突笔记时，遇到数据库查询错误仅使用了 `catch (_) {}` 进行了空捕获。这会隐藏潜在的数据库或表结构问题，导致用户无法发现并处理同步冲突。]
 **拦截:** [已将该空捕获替换为 `AppLogger.e`，注入了描述信息、具体的错误对象 `error: e`、堆栈轨迹 `stackTrace: stackTrace`，并指定了明确的日志来源模块 `source: 'WebDAVSyncPage'`。确认记录内容不包含任何笔记实体数据。]
+
+## 2025-10-24 - 🗃️ 黑匣: [完善 DatabaseService 模块的结构化日志]
+**异常:** [DatabaseService 模块在数据库初始化失败、初始化新数据库失败、预加载笔记失败和数据库恢复失败时，仅使用了 logDebug 进行了粗糙的打印，丢失了关键的错误堆栈信息以及明确的模块来源信息，这使得排查数据库连接和读写故障十分困难。]
+**拦截:** [已将上述环节中的 catch (e) 替换为 catch (e, stackTrace)，并将 logDebug 替换为结构化的 AppLogger.e，注入了对应的报错描述、具体的异常对象 error: e、堆栈轨迹 stackTrace: stackTrace，并指定了来源模块 source: 'DatabaseService'。确认修改不超过 50 行，且未记录用户的任何隐私数据。]

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -629,8 +629,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
       SchedulerBinding.instance.addPostFrameCallback((_) {
         if (!_isDisposed) notifyListeners();
       });
-    } catch (e) {
-      logDebug('数据库初始化失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e('数据库初始化失败', error: e, stackTrace: stackTrace, source: 'DatabaseService');
       _isInitializing = false;
       if (_initCompleter != null && !_initCompleter!.isCompleted) {
         _initCompleter!.completeError(e);
@@ -733,8 +733,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
         if (!_isDisposed) notifyListeners();
       });
       logDebug('成功初始化新数据库');
-    } catch (e) {
-      logDebug('初始化新数据库失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e('初始化新数据库失败', error: e, stackTrace: stackTrace, source: 'DatabaseService');
       rethrow;
     }
   }
@@ -782,8 +782,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
         _safeNotifyQuotesStream();
         logDebug('预加载完成，获取到 ${quotes.length} 条笔记，已通知UI更新');
       }
-    } catch (e) {
-      logDebug('预加载笔记时出错: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e('预加载笔记时出错', error: e, stackTrace: stackTrace, source: 'DatabaseService');
       // 确保状态一致
       _currentQuotes = [];
       _currentQuoteIds.clear(); // 性能优化：同步清空 ID Set
@@ -925,8 +925,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
       _clearAllCache();
 
       logDebug('数据库恢复措施已执行');
-    } catch (e) {
-      logDebug('数据库恢复失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e('数据库恢复失败', error: e, stackTrace: stackTrace, source: 'DatabaseService');
       rethrow;
     }
   }

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -630,7 +630,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
         if (!_isDisposed) notifyListeners();
       });
     } catch (e, stackTrace) {
-      AppLogger.e('数据库初始化失败', error: e, stackTrace: stackTrace, source: 'DatabaseService');
+      AppLogger.e('数据库初始化失败',
+          error: e, stackTrace: stackTrace, source: 'DatabaseService');
       _isInitializing = false;
       if (_initCompleter != null && !_initCompleter!.isCompleted) {
         _initCompleter!.completeError(e);
@@ -734,7 +735,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
       });
       logDebug('成功初始化新数据库');
     } catch (e, stackTrace) {
-      AppLogger.e('初始化新数据库失败', error: e, stackTrace: stackTrace, source: 'DatabaseService');
+      AppLogger.e('初始化新数据库失败',
+          error: e, stackTrace: stackTrace, source: 'DatabaseService');
       rethrow;
     }
   }
@@ -783,7 +785,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
         logDebug('预加载完成，获取到 ${quotes.length} 条笔记，已通知UI更新');
       }
     } catch (e, stackTrace) {
-      AppLogger.e('预加载笔记时出错', error: e, stackTrace: stackTrace, source: 'DatabaseService');
+      AppLogger.e('预加载笔记时出错',
+          error: e, stackTrace: stackTrace, source: 'DatabaseService');
       // 确保状态一致
       _currentQuotes = [];
       _currentQuoteIds.clear(); // 性能优化：同步清空 ID Set
@@ -926,7 +929,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
 
       logDebug('数据库恢复措施已执行');
     } catch (e, stackTrace) {
-      AppLogger.e('数据库恢复失败', error: e, stackTrace: stackTrace, source: 'DatabaseService');
+      AppLogger.e('数据库恢复失败',
+          error: e, stackTrace: stackTrace, source: 'DatabaseService');
       rethrow;
     }
   }


### PR DESCRIPTION
展示封装前后的日志内容差异：
封装前: `logDebug('数据库初始化失败: $e');`
封装后: `AppLogger.e('数据库初始化失败', error: e, stackTrace: stackTrace, source: 'DatabaseService');`

明确声明：已确认修改未包含任何敏感数据（不包含用户的笔记数据，仅记录数据库初始化与状态同步的异常对象自身），符合《黑匣的哲学》的规范限制。

---
*PR created automatically by Jules for task [1505658255788606564](https://jules.google.com/task/1505658255788606564) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `DatabaseService` 引入结构化错误日志：将 `logDebug` 替换为 `AppLogger.e`，并传递 `stackTrace` 与 `source`，提升初始化、预加载和恢复失败时的可观测性；不记录用户数据。

- **Bug Fixes**
  - 在数据库初始化失败、初始化新库失败、预加载笔记失败、数据库恢复失败处，改为 `catch (e, stackTrace)` 并使用 `AppLogger.e(..., error: e, stackTrace: stackTrace, source: 'DatabaseService')`
  - 更新 `.jules/blackbox.md` 记录规则，确认日志不包含笔记内容或隐私数据

<sup>Written for commit 80717febe52f6e6cb96b54371bbe90ffd21d8cb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 增强了数据库服务模块的错误日志记录机制，采用更详细的结构化日志格式，提升问题诊断和追踪能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->