### PR TITLE
🧪 补充 OnboardingModels 的单元测试

### DIFF
--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -10,6 +10,7 @@ import 'unit/models/note_category_test.dart' as note_category_test;
 import 'unit/models/note_tag_test.dart' as note_tag_test;
 import 'unit/models/weather_data_test.dart' as weather_data_test;
 import 'unit/models/app_settings_test.dart' as app_settings_test;
+import 'unit/models/onboarding_models_test.dart' as onboarding_models_test;
 
 // Import service tests
 import 'unit/services/database_service_test.dart' as database_service_test;
@@ -95,6 +96,7 @@ void main() {
       note_tag_test.main();
       weather_data_test.main();
       app_settings_test.main();
+      onboarding_models_test.main();
     });
 
     group('Service Tests', () {

--- a/test/unit/models/onboarding_models_test.dart
+++ b/test/unit/models/onboarding_models_test.dart
@@ -2,7 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/models/onboarding_models.dart';
 
+import '../../test_setup.dart';
+
 void main() {
+  setUp(() async {
+    await setupTestEnvironment();
+  });
+
   group('Onboarding Models Test', () {
     group('OnboardingPageData', () {
       test('should correctly assign all required properties', () {

--- a/test/unit/models/onboarding_models_test.dart
+++ b/test/unit/models/onboarding_models_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/models/onboarding_models.dart';
+
+void main() {
+  group('Onboarding Models Test', () {
+    group('OnboardingPageData', () {
+      test('should correctly assign all required properties', () {
+        const pageData = OnboardingPageData(
+          title: 'Welcome',
+          subtitle: 'Subtitle',
+          type: OnboardingPageType.welcome,
+        );
+
+        expect(pageData.title, 'Welcome');
+        expect(pageData.subtitle, 'Subtitle');
+        expect(pageData.description, isNull);
+        expect(pageData.features, isNull);
+        expect(pageData.type, OnboardingPageType.welcome);
+      });
+
+      test('should correctly assign all optional properties', () {
+        const feature = OnboardingFeature(
+          title: 'Feature',
+          description: 'Desc',
+          icon: Icons.star,
+        );
+        const pageData = OnboardingPageData(
+          title: 'Features',
+          subtitle: 'Features Subtitle',
+          description: 'Description',
+          features: [feature],
+          type: OnboardingPageType.features,
+        );
+
+        expect(pageData.title, 'Features');
+        expect(pageData.subtitle, 'Features Subtitle');
+        expect(pageData.description, 'Description');
+        expect(pageData.features, isNotNull);
+        expect(pageData.features!.length, 1);
+        expect(pageData.features!.first, feature);
+        expect(pageData.type, OnboardingPageType.features);
+      });
+    });
+
+    group('OnboardingFeature', () {
+      test('should correctly assign all properties with default values', () {
+        const feature = OnboardingFeature(
+          title: 'Feature',
+          description: 'Desc',
+          icon: Icons.star,
+        );
+
+        expect(feature.title, 'Feature');
+        expect(feature.description, 'Desc');
+        expect(feature.icon, Icons.star);
+        expect(feature.isHighlight, isFalse);
+      });
+
+      test('should correctly override default value', () {
+        const feature = OnboardingFeature(
+          title: 'Feature',
+          description: 'Desc',
+          icon: Icons.star,
+          isHighlight: true,
+        );
+
+        expect(feature.isHighlight, isTrue);
+      });
+    });
+
+    group('OnboardingPreference', () {
+      test('should correctly assign properties properly', () {
+        const pref = OnboardingPreference<bool>(
+          key: 'sync_enabled',
+          title: 'Sync',
+          description: 'Enable Sync',
+          defaultValue: true,
+          type: OnboardingPreferenceType.toggle,
+        );
+
+        expect(pref.key, 'sync_enabled');
+        expect(pref.title, 'Sync');
+        expect(pref.description, 'Enable Sync');
+        expect(pref.defaultValue, isTrue);
+        expect(pref.options, isNull);
+        expect(pref.type, OnboardingPreferenceType.toggle);
+      });
+    });
+
+    group('OnboardingPreferenceOption', () {
+      test('should correctly assign value, label, and description', () {
+        const option = OnboardingPreferenceOption<String>(
+          value: 'dark',
+          label: 'Dark Mode',
+          description: 'Uses dark colors',
+        );
+
+        expect(option.value, 'dark');
+        expect(option.label, 'Dark Mode');
+        expect(option.description, 'Uses dark colors');
+      });
+    });
+
+    group('OnboardingState', () {
+      test('should have correct default values', () {
+        const state = OnboardingState();
+
+        expect(state.currentPageIndex, 0);
+        expect(state.isCompleting, isFalse);
+        expect(state.preferences, isEmpty);
+        expect(state.canGoNext, isTrue);
+        expect(state.canGoPrevious, isFalse);
+      });
+
+      test('copyWith should update specific fields or use existing', () {
+        const initialState = OnboardingState();
+        final updatedState = initialState.copyWith(
+          currentPageIndex: 1,
+          isCompleting: true,
+          canGoNext: false,
+          canGoPrevious: true,
+          preferences: {'theme': 'dark'},
+        );
+
+        expect(updatedState.currentPageIndex, 1);
+        expect(updatedState.isCompleting, isTrue);
+        expect(updatedState.canGoNext, isFalse);
+        expect(updatedState.canGoPrevious, isTrue);
+        expect(updatedState.preferences['theme'], 'dark');
+
+        final partialUpdate = updatedState.copyWith(currentPageIndex: 2);
+        expect(partialUpdate.currentPageIndex, 2);
+        expect(partialUpdate.isCompleting, isTrue);
+        expect(partialUpdate.canGoNext, isFalse);
+        expect(partialUpdate.canGoPrevious, isTrue);
+        expect(partialUpdate.preferences['theme'], 'dark');
+      });
+
+      test('updatePreference should return new state and keep original intact',
+          () {
+        const initialState = OnboardingState(preferences: {'theme': 'light'});
+        final updatedState = initialState.updatePreference('theme', 'dark');
+
+        expect(initialState.preferences['theme'], 'light');
+        expect(updatedState.preferences['theme'], 'dark');
+        expect(updatedState.currentPageIndex, initialState.currentPageIndex);
+      });
+
+      test('getPreference should retrieve casted value or null', () {
+        const state = OnboardingState(preferences: {
+          'theme': 'dark',
+          'sync_enabled': true,
+        });
+
+        expect(state.getPreference<String>('theme'), 'dark');
+        expect(state.getPreference<bool>('sync_enabled'), isTrue);
+        expect(state.getPreference<int>('missing_key'), isNull);
+      });
+    });
+  });
+}

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -383,7 +383,8 @@ void main() {
         );
         final targetQuoteId = initialQuoteItem.quote.id;
         final selectedNote = find.byWidgetPredicate(
-          (widget) => widget is QuoteItemWidget && widget.quote.id == targetQuoteId,
+          (widget) =>
+              widget is QuoteItemWidget && widget.quote.id == targetQuoteId,
         );
         final offsetBefore = listView.controller!.offset;
         final positionBefore = tester.getTopLeft(selectedNote).dy;


### PR DESCRIPTION
🎯 **What:** 针对 `lib/models/onboarding_models.dart` 补充缺失的单元测试。
📊 **Coverage:** 覆盖了 `OnboardingPageData`、`OnboardingFeature`、`OnboardingPreference`、`OnboardingPreferenceOption` 以及 `OnboardingState` 的属性赋值、默认值校验及诸如 `copyWith`、`getPreference`、`updatePreference` 等核心方法的行为。
✨ **Result:** 将引导页面模型的测试覆盖率提升，防范重构过程中的回归问题，提高了应用的可靠性。

---
*PR created automatically by Jules for task [13952310051049351584](https://jules.google.com/task/13952310051049351584) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `lib/models/onboarding_models.dart` 补充单元测试，覆盖 `OnboardingPageData`、`OnboardingFeature`、`OnboardingPreference`、`OnboardingPreferenceOption`、`OnboardingState` 的属性与默认值，以及 `copyWith`、`getPreference`、`updatePreference` 等核心行为。
在 `test/all_tests.dart` 注册测试集，初始化测试环境以避免依赖缺失，并对 `test/widget/note_list_view_filter_test.dart` 做了轻微格式化。

<sup>Written for commit dbce5f5d90263c000b37babec4ac679cefd6dc9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 将登机流程模型单元测试纳入全量测试运行，提升整体覆盖度与回归保障。
  * 新增登机流程模型测试，覆盖数据字段赋值、默认值行为、状态 `copyWith`/偏好更新、以及按键获取偏好结果。
  * 调整笔记列表筛选相关断言写法（不改变测试逻辑）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->