### PR TITLE
🛡️ Sentinel: [HIGH] 修复遗留明文 API 密钥未彻底清除的安全漏洞

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -943,53 +943,85 @@ class SettingsService extends ChangeNotifier {
 
   /// 迁移遗留的明文API密钥到安全存储
   Future<void> _secureLegacyApiKey() async {
-    if (_aiSettings.apiKey.isEmpty) return;
+    if (_aiSettings.apiKey.isEmpty) {
+      // 安全起见，如果在 _prefs 中还残留包含 apiKey 的 json，也要清理
+      try {
+        final legacyJson = _prefs.getString(_aiSettingsKey);
+        if (legacyJson != null &&
+            legacyJson.contains('"apiKey":') &&
+            !legacyJson.contains('"apiKey":""') &&
+            !legacyJson.contains('"apiKey":" "')) {
+          final Map<String, dynamic> settingsMap = json.decode(legacyJson);
+          if (settingsMap['apiKey'] != null &&
+              settingsMap['apiKey'].toString().isNotEmpty) {
+            settingsMap['apiKey'] = '';
+            await _prefs.setString(_aiSettingsKey, json.encode(settingsMap));
+            logDebug('Cleared residual legacy API key from SharedPreferences.');
+          }
+        }
+      } catch (_) {}
+      return;
+    }
 
     bool shouldClear = false;
 
-    // 如果我们有当前选中的服务商
-    if (_multiAISettings.currentProviderId != null) {
-      final apiKeyManager = APIKeyManager();
-      final providerId = _multiAISettings.currentProviderId!;
-
-      try {
-        // 检查安全存储中是否已有密钥
-        final hasSecureKey = await apiKeyManager.hasValidProviderApiKey(
-          providerId,
-        );
-
-        if (hasSecureKey) {
-          // 安全存储中已有密钥，遗留的明文密钥是冗余的，可以直接清除
-          shouldClear = true;
-          logDebug(
-              'Found redundant plaintext API key in AISettings. Clearing.');
-        } else {
-          // 安全存储中没有密钥，尝试迁移
-          await apiKeyManager.saveProviderApiKey(
-            providerId,
-            _aiSettings.apiKey,
-          );
-          shouldClear = true;
-          logDebug(
-            'Migrated legacy plaintext API key to SecureStorage for provider: $providerId',
-          );
-        }
-      } catch (e) {
-        logDebug('Error securing legacy API key: $e');
-        // 出错时不清除，避免数据丢失
-      }
-    } else {
-      // 如果没有选中的服务商，暂时不清除，因为无法确定归属
-      // 但这种情况很少见，因为通常会有默认或已配置的服务商
+    // 确定要迁移到的服务商 ID，如果没有选中则回退到 openai 或 default
+    String? providerId = _multiAISettings.currentProviderId;
+    if (providerId == null) {
+      providerId = _multiAISettings.providers.isNotEmpty
+          ? _multiAISettings.providers.first.id
+          : 'openai';
       logDebug(
-        'Legacy API key found but no current provider selected. Skipping migration.',
+          'No current provider selected. Defaulting migration to provider: $providerId');
+    }
+
+    final apiKeyManager = APIKeyManager();
+
+    try {
+      // 检查安全存储中是否已有密钥
+      final hasSecureKey = await apiKeyManager.hasValidProviderApiKey(
+        providerId,
       );
+
+      if (hasSecureKey) {
+        // 安全存储中已有密钥，遗留的明文密钥是冗余的，可以直接清除
+        shouldClear = true;
+        logDebug('Found redundant plaintext API key in AISettings. Clearing.');
+      } else {
+        // 安全存储中没有密钥，尝试迁移
+        await apiKeyManager.saveProviderApiKey(
+          providerId,
+          _aiSettings.apiKey,
+        );
+        shouldClear = true;
+        logDebug(
+          'Migrated legacy plaintext API key to SecureStorage for provider: $providerId',
+        );
+      }
+    } catch (e) {
+      logDebug('Error securing legacy API key: $e');
+      // 即使出错，如果是格式错误等不可恢复的错误，为了安全也应该考虑清除，但这里暂保持保守，出错时不清除，避免数据丢失
+      // 除非我们能确定错误类型
     }
 
     if (shouldClear) {
+      // 从内存和 MMKV 中清除
       _aiSettings = _aiSettings.copyWith(apiKey: '');
-      await _mmkv.setString(_aiSettingsKey, json.encode(_aiSettings.toJson()));
-      logDebug('Legacy plaintext API key cleared from AISettings.');
+      final clearedJsonString = json.encode(_aiSettings.toJson());
+      await _mmkv.setString(_aiSettingsKey, clearedJsonString);
+
+      // 彻底：同时从 SharedPreferences 中彻底清除
+      try {
+        // 更新或删除 _prefs 中的 _aiSettingsKey 以彻底消灭明文密钥
+        await _prefs.setString(_aiSettingsKey, clearedJsonString);
+        logDebug(
+            'Legacy plaintext API key also cleared from SharedPreferences.');
+      } catch (e) {
+        logDebug('Failed to clear legacy API key from SharedPreferences: $e');
+      }
+
+      logDebug(
+          'Legacy plaintext API key completely cleared from AISettings storage layers.');
     }
   }
 }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -968,9 +968,14 @@ class SettingsService extends ChangeNotifier {
     // 确定要迁移到的服务商 ID，如果没有选中则回退到 openai 或 default
     String? providerId = _multiAISettings.currentProviderId;
     if (providerId == null) {
-      providerId = _multiAISettings.providers.isNotEmpty
-          ? _multiAISettings.providers.first.id
-          : 'openai';
+      // 优先寻找 openai，否则找第一个不是 default 的，如果都没有则回退到 openai
+      final providers = _multiAISettings.providers;
+      if (providers.any((p) => p.id == 'openai')) {
+        providerId = 'openai';
+      } else {
+        final nonDefault = providers.where((p) => p.id != 'default');
+        providerId = nonDefault.isNotEmpty ? nonDefault.first.id : 'openai';
+      }
       logDebug(
           'No current provider selected. Defaulting migration to provider: $providerId');
     }

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -383,7 +383,8 @@ void main() {
         );
         final targetQuoteId = initialQuoteItem.quote.id;
         final selectedNote = find.byWidgetPredicate(
-          (widget) => widget is QuoteItemWidget && widget.quote.id == targetQuoteId,
+          (widget) =>
+              widget is QuoteItemWidget && widget.quote.id == targetQuoteId,
         );
         final offsetBefore = listView.controller!.offset;
         final positionBefore = tester.getTopLeft(selectedNote).dy;


### PR DESCRIPTION
🎯 **What:** 
修复了在从遗留明文存储迁移 API Key 到安全存储（SecureStorage）时，旧的明文密钥未能被彻底从本地磁盘删除的漏洞。

⚠️ **Risk:** 
[HIGH] 在原有的迁移流程中，即使旧密钥成功复制到了安全存储，清理步骤也仅擦除了 MMKV 缓存层和内存变量中的对应字段，但忽略了持久化在 `SharedPreferences` (`_prefs`) 中的旧版 JSON 数据。这导致用户的明文 API 密钥仍然完整保留在本地磁盘文件中，存在被提取或恶意读取的风险，并在某些异常情况下可能导致密钥被恢复重建。此外，如果用户之前没有选中默认的 AI 提供商，迁移流程会被跳过，进而保留了这部分历史污点。

🛡️ **Solution:** 
1. **彻底擦除:** 在 `_secureLegacyApiKey` 中增加直接修改 `_prefs` 以写回清除后的 JSON 的逻辑。
2. **残余清理:** 即使 `_aiSettings.apiKey` 在当前内存中已经为空，仍会尝试解析并清除可能残留在 `_prefs` 磁盘文件中的 `apiKey` 字段。
3. **安全降级:** 在迁移时如果当前没有选中的 `providerId`，强制回退至 `openai` 或是可用的首个提供商，以确保迁移成功并彻底触发遗留数据的清理。

---
*PR created automatically by Jules for task [13698138281814652659](https://jules.google.com/task/13698138281814652659) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
彻底清除遗留明文 API 密钥，迁移到 `SecureStorage` 后不再在磁盘（`MMKV`/`SharedPreferences`）保留，消除高风险泄露点。

- **Bug Fixes**
  - 在 `_secureLegacyApiKey` 中将清空后的 JSON 同步写回 `MMKV` 与 `_prefs`，彻底移除明文 `apiKey`。
  - 即使 `_aiSettings.apiKey` 为空，也会扫描 `_prefs` 并清理残留密钥。
  - 无已选 `providerId` 时优先使用 `openai`，否则选首个非 `default` 的提供商，避免写入 `default` 桩并确保迁移与清理完成。
  - 运行 `dart format .` 通过 CI 格式检查。

<sup>Written for commit ce1e86080c4da9e33a7c08834218c84005139bda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

