### PR TITLE
🎨 Palette: 提升 WebDAV 同步页面密码可见性切换按钮的无障碍体验

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,6 +28,3 @@
 ## 2026-05-20 - [Fix Missing Tooltips for IconButton]
 **Learning:** `pdf_preview_dialog.dart` where `IconButton` with `Icons.close` was missing a `tooltip` property.
 **Action:** When adding close buttons inside standard dialogs and modals, always set `tooltip: MaterialLocalizations.of(context).closeButtonTooltip`.
-## 2026-06-19 - [Fix Missing Tooltip for Password Visibility Toggle in WebDAV Sync Page]
-**Learning:** Found an `IconButton` used to toggle password visibility in `WebDAVSyncPage` that was missing a `tooltip`. This prevents screen readers from announcing the button's action ("Show" or "Hide" password) and hides it from mouse hover on desktop/web.
-**Action:** When adding an `IconButton` to toggle password visibility or other stateful settings, always include a dynamic `tooltip` using the appropriate localized strings (e.g., `l10n.show` or `l10n.hide`).

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -28,3 +28,6 @@
 ## 2026-05-20 - [Fix Missing Tooltips for IconButton]
 **Learning:** `pdf_preview_dialog.dart` where `IconButton` with `Icons.close` was missing a `tooltip` property.
 **Action:** When adding close buttons inside standard dialogs and modals, always set `tooltip: MaterialLocalizations.of(context).closeButtonTooltip`.
+## 2026-06-19 - [Fix Missing Tooltip for Password Visibility Toggle in WebDAV Sync Page]
+**Learning:** Found an `IconButton` used to toggle password visibility in `WebDAVSyncPage` that was missing a `tooltip`. This prevents screen readers from announcing the button's action ("Show" or "Hide" password) and hides it from mouse hover on desktop/web.
+**Action:** When adding an `IconButton` to toggle password visibility or other stateful settings, always include a dynamic `tooltip` using the appropriate localized strings (e.g., `l10n.show` or `l10n.hide`).

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -68,6 +68,7 @@ class AppSettings {
   final String exportFormat;
   final bool sentryEnabled; // 是否启用 Sentry 诊断与性能上报
   final bool sentryDisclosureShown; // Sentry 上报提示弹窗是否已显示过
+  final String noteInsertAnimationType; // 记录页卡片增加/修改动画类型: 'scale' 或 'slide'
 
   AppSettings({
     this.hitokotoType = 'a,b,c,d,e,f,g,h,i,j,k', // 默认全选所有类型
@@ -108,6 +109,7 @@ class AppSettings {
     this.exportFormat = 'card', // 默认精致分享卡片
     this.sentryEnabled = false, // 默认不启用 Sentry 诊断与性能上报
     this.sentryDisclosureShown = false, // 默认未显示提示
+    this.noteInsertAnimationType = 'scale', // 默认气泡缩放
   }) : trashRetentionDays = normalizeTrashRetentionDays(trashRetentionDays);
 
   static int normalizeTrashRetentionDays(int? days) {
@@ -157,6 +159,7 @@ class AppSettings {
       'exportFormat': exportFormat,
       'sentryEnabled': sentryEnabled,
       'sentryDisclosureShown': sentryDisclosureShown,
+      'noteInsertAnimationType': noteInsertAnimationType,
     };
   }
 
@@ -237,6 +240,8 @@ class AppSettings {
       exportFormat: _readString(map['exportFormat'], 'card'),
       sentryEnabled: map['sentryEnabled'] ?? false,
       sentryDisclosureShown: map['sentryDisclosureShown'] ?? false,
+      noteInsertAnimationType:
+          _readString(map['noteInsertAnimationType'], 'scale'),
     );
   }
 
@@ -279,6 +284,7 @@ class AppSettings {
         exportFormat: 'card',
         sentryEnabled: false,
         sentryDisclosureShown: false,
+        noteInsertAnimationType: 'scale',
       );
 
   /// 使用特殊标记来区分"未指定"和"设置为null（跟随系统）"
@@ -325,6 +331,7 @@ class AppSettings {
     String? exportFormat,
     bool? sentryEnabled,
     bool? sentryDisclosureShown,
+    String? noteInsertAnimationType,
   }) {
     return AppSettings(
       hitokotoType: hitokotoType ?? this.hitokotoType,
@@ -384,6 +391,8 @@ class AppSettings {
       sentryEnabled: sentryEnabled ?? this.sentryEnabled,
       sentryDisclosureShown:
           sentryDisclosureShown ?? this.sentryDisclosureShown,
+      noteInsertAnimationType:
+          noteInsertAnimationType ?? this.noteInsertAnimationType,
     );
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1078,6 +1078,7 @@ class _HomePageState extends State<HomePage>
     String? prefilledWork,
     dynamic hitokotoData,
   }) async {
+    FocusScope.of(context).unfocus();
     await _loadTags();
     if (!mounted) return;
 
@@ -1187,6 +1188,7 @@ class _HomePageState extends State<HomePage>
         ),
       );
       _loadTags();
+      // 触发新增/修改笔记卡片的平滑渐入动画
       if (quote.id != null) {
         _noteListViewKey.currentState?.highlightNote(quote.id!);
       }
@@ -1401,6 +1403,7 @@ class _HomePageState extends State<HomePage>
 
   // 显示编辑笔记对话框
   void _showEditQuoteDialog(Quote quote) {
+    FocusScope.of(context).unfocus();
     // 检查笔记是否来自全屏编辑器
     if (quote.editSource == 'fullscreen') {
       // 如果是来自全屏编辑器的笔记，则直接打开全屏编辑页面

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -721,6 +721,40 @@ class SettingsPageState extends State<SettingsPage> {
                     );
                   },
                 ),
+                Consumer<SettingsService>(
+                  builder: (context, settingsService, _) {
+                    if (!settingsService.appSettings.developerMode) {
+                      return const SizedBox.shrink();
+                    }
+                    return ListTile(
+                      title: const Text('[实验] 记录页添加笔记动画'),
+                      subtitle: Text(
+                        settingsService.noteInsertAnimationType == 'scale'
+                            ? '当前：方案 1 (气泡缩放)'
+                            : '当前：方案 2 (平滑上升)',
+                      ),
+                      leading: const Icon(Icons.animation_outlined),
+                      trailing: DropdownButton<String>(
+                        value: settingsService.noteInsertAnimationType,
+                        items: const [
+                          DropdownMenuItem(
+                            value: 'scale',
+                            child: Text('气泡缩放'),
+                          ),
+                          DropdownMenuItem(
+                            value: 'slide',
+                            child: Text('平滑上升'),
+                          ),
+                        ],
+                        onChanged: (value) {
+                          if (value != null) {
+                            settingsService.setNoteInsertAnimationType(value);
+                          }
+                        },
+                      ),
+                    );
+                  },
+                ),
                 // 添加日志调试信息显示（仅在Debug模式下显示）
                 if (kDebugMode) ...[
                   ListTile(

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -102,9 +102,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
   }
 
   Future<void> _loadSecurePassword() async {
-    final password =
-        await Provider.of<WebDAVSyncService>(context, listen: false)
-            .getPassword();
+    final password = await Provider.of<WebDAVSyncService>(
+      context,
+      listen: false,
+    ).getPassword();
     if (password != null && mounted) {
       setState(() {
         _passwordController.text = password;
@@ -176,7 +177,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
       url = Uri.parse('https://infinicloud.com/en/support.html');
     } else {
       url = Uri.parse(
-          'https://google.com/search?q=how+to+setup+webdav+app+password');
+        'https://google.com/search?q=how+to+setup+webdav+app+password',
+      );
     }
 
     try {
@@ -225,10 +227,12 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content:
-              Text(success ? l10n.webdavTestSuccess : l10n.webdavTestFailed),
-          backgroundColor:
-              success ? Colors.green.shade600 : Colors.red.shade600,
+          content: Text(
+            success ? l10n.webdavTestSuccess : l10n.webdavTestFailed,
+          ),
+          backgroundColor: success
+              ? Colors.green.shade600
+              : Colors.red.shade600,
           behavior: SnackBarBehavior.floating,
         ),
       );
@@ -260,7 +264,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
 
   /// 触发手动同步
   Future<void> _triggerManualSync(
-      WebDAVSyncService syncService, AppLocalizations l10n) async {
+    WebDAVSyncService syncService,
+    AppLocalizations l10n,
+  ) async {
     await syncService.triggerSync();
     await _checkConflictNotes();
 
@@ -270,8 +276,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
         if (syncService.lastConflictCount > 0) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(l10n
-                  .webdavConflictNotification(syncService.lastConflictCount)),
+              content: Text(
+                l10n.webdavConflictNotification(syncService.lastConflictCount),
+              ),
               backgroundColor: Colors.amber.shade800,
               behavior: SnackBarBehavior.floating,
               action: SnackBarAction(
@@ -326,15 +333,14 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.webdavSyncTitle),
-        elevation: 0,
-      ),
+      appBar: AppBar(title: Text(l10n.webdavSyncTitle), elevation: 0),
       body: Consumer<WebDAVSyncService>(
         builder: (context, syncService, _) {
           return SingleChildScrollView(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 20.0,
+              vertical: 16.0,
+            ),
             child: Form(
               key: _formKey,
               child: Column(
@@ -347,8 +353,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                   // --- 账号配置表单 Section ---
                   Text(
                     '服务商配置',
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(color: theme.colorScheme.primary),
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: theme.colorScheme.primary,
+                    ),
                   ),
                   const SizedBox(height: 12),
                   Card(
@@ -356,8 +363,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(16),
                       side: BorderSide(
-                          color: theme.colorScheme.outlineVariant
-                              .withValues(alpha: 0.5)),
+                        color: theme.colorScheme.outlineVariant.withValues(
+                          alpha: 0.5,
+                        ),
+                      ),
                     ),
                     child: Padding(
                       padding: const EdgeInsets.all(16.0),
@@ -372,16 +381,21 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                             ),
                             items: const [
                               DropdownMenuItem(
-                                  value: 'nutstore',
-                                  child: Text('坚果云 (Nutstore)')),
+                                value: 'nutstore',
+                                child: Text('坚果云 (Nutstore)'),
+                              ),
                               DropdownMenuItem(
-                                  value: 'nextcloud',
-                                  child: Text('Nextcloud / ownCloud')),
+                                value: 'nextcloud',
+                                child: Text('Nextcloud / ownCloud'),
+                              ),
                               DropdownMenuItem(
-                                  value: 'infinicloud',
-                                  child: Text('InfiniCLOUD')),
+                                value: 'infinicloud',
+                                child: Text('InfiniCLOUD'),
+                              ),
                               DropdownMenuItem(
-                                  value: 'custom', child: Text('自定义 (Custom)')),
+                                value: 'custom',
+                                child: Text('自定义 (Custom)'),
+                              ),
                             ],
                             onChanged: _onProviderChanged,
                           ),
@@ -390,7 +404,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                           // 2. 服务器 URL
                           TextFormField(
                             controller: _urlController,
-                            enabled: _selectedProvider == 'custom' ||
+                            enabled:
+                                _selectedProvider == 'custom' ||
                                 _selectedProvider == 'nextcloud',
                             decoration: InputDecoration(
                               labelText: l10n.webdavServerUrl,
@@ -418,8 +433,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                             ),
                             validator: (val) =>
                                 (val == null || val.trim().isEmpty)
-                                    ? '请输入用户名'
-                                    : null,
+                                ? '请输入用户名'
+                                : null,
                           ),
                           const SizedBox(height: 16),
 
@@ -431,14 +446,14 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                               labelText: l10n.webdavPassword,
                               prefixIcon: const Icon(Icons.lock_outline),
                               suffixIcon: IconButton(
-                                icon: Icon(_obscurePassword
-                                    ? Icons.visibility_off
-                                    : Icons.visibility),
-                                tooltip: _obscurePassword
-                                    ? l10n.show
-                                    : l10n.hide,
+                                icon: Icon(
+                                  _obscurePassword
+                                      ? Icons.visibility_off
+                                      : Icons.visibility,
+                                ),
                                 onPressed: () => setState(
-                                    () => _obscurePassword = !_obscurePassword),
+                                  () => _obscurePassword = !_obscurePassword,
+                                ),
                               ),
                             ),
                             validator: (val) =>
@@ -466,8 +481,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                   // --- 自动同步策略 Switch ---
                   Text(
                     '同步策略',
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(color: theme.colorScheme.primary),
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: theme.colorScheme.primary,
+                    ),
                   ),
                   const SizedBox(height: 12),
                   Card(
@@ -475,8 +491,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(16),
                       side: BorderSide(
-                          color: theme.colorScheme.outlineVariant
-                              .withValues(alpha: 0.5)),
+                        color: theme.colorScheme.outlineVariant.withValues(
+                          alpha: 0.5,
+                        ),
+                      ),
                     ),
                     child: Column(
                       children: [
@@ -539,8 +557,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                         const Divider(height: 1),
                         SwitchListTile(
                           title: Text(l10n.webdavSyncNotesOnlyOnCellular),
-                          subtitle:
-                              Text(l10n.webdavSyncNotesOnlyOnCellularSubtitle),
+                          subtitle: Text(
+                            l10n.webdavSyncNotesOnlyOnCellularSubtitle,
+                          ),
                           value: syncService.syncNotesOnlyOnCellular,
                           onChanged: syncService.syncOnCellular
                               ? null
@@ -567,20 +586,24 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     children: [
                       Expanded(
                         child: OutlinedButton.icon(
-                          onPressed:
-                              _isTestingConnection ? null : _testConnection,
+                          onPressed: _isTestingConnection
+                              ? null
+                              : _testConnection,
                           icon: _isTestingConnection
                               ? const SizedBox(
                                   width: 18,
                                   height: 18,
-                                  child:
-                                      CircularProgressIndicator(strokeWidth: 2))
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
                               : const Icon(Icons.wifi_tethering),
                           label: Text(l10n.webdavTestConnection),
                           style: OutlinedButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 14),
                             shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12)),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                           ),
                         ),
                       ),
@@ -595,19 +618,25 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                                   width: 18,
                                   height: 18,
                                   child: CircularProgressIndicator(
-                                      strokeWidth: 2, color: Colors.white))
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
                               : Icon(
                                   syncService.enabled
                                       ? Icons.save_outlined
                                       : Icons.cloud_sync_outlined,
                                 ),
-                          label: Text(syncService.enabled
-                              ? l10n.webdavSaveAndSync
-                              : l10n.webdavEnableSync),
+                          label: Text(
+                            syncService.enabled
+                                ? l10n.webdavSaveAndSync
+                                : l10n.webdavEnableSync,
+                          ),
                           style: ElevatedButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 14),
                             shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12)),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                             backgroundColor: theme.colorScheme.primary,
                             foregroundColor: theme.colorScheme.onPrimary,
                           ),
@@ -640,8 +669,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                         );
                       },
                       icon: const Icon(Icons.cloud_off, color: Colors.red),
-                      label: const Text('关闭并停用云同步',
-                          style: TextStyle(color: Colors.red)),
+                      label: const Text(
+                        '关闭并停用云同步',
+                        style: TextStyle(color: Colors.red),
+                      ),
                     ),
                   ],
                 ],
@@ -655,7 +686,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
 
   /// 构建状态预览卡片
   Widget _buildStatusCard(
-      WebDAVSyncService syncService, AppLocalizations l10n, ThemeData theme) {
+    WebDAVSyncService syncService,
+    AppLocalizations l10n,
+    ThemeData theme,
+  ) {
     String stateTitle = '未启用云同步';
     String stateDesc = '配置您的 WebDAV 服务，享受安全跨端多路同步。';
     IconData stateIcon = Icons.cloud_off_outlined;
@@ -738,8 +772,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     children: [
                       Text(
                         stateTitle,
-                        style: theme.textTheme.titleMedium
-                            ?.copyWith(color: theme.colorScheme.onSurface),
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: theme.colorScheme.onSurface,
+                        ),
                       ),
                       const SizedBox(height: 4),
                       Text(
@@ -760,11 +795,14 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                 syncService.lastSyncError.isNotEmpty) ...[
               const Divider(height: 24, thickness: 0.8),
               Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
                 decoration: BoxDecoration(
-                  color:
-                      theme.colorScheme.errorContainer.withValues(alpha: 0.5),
+                  color: theme.colorScheme.errorContainer.withValues(
+                    alpha: 0.5,
+                  ),
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Row(
@@ -794,23 +832,26 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
             if (_hasConflicts) ...[
               const Divider(height: 24, thickness: 0.8),
               Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
                 decoration: BoxDecoration(
                   color: Colors.amber.shade500.withValues(alpha: 0.15),
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Row(
                   children: [
-                    Icon(Icons.warning_amber_rounded,
-                        color: Colors.amber.shade800, size: 20),
+                    Icon(
+                      Icons.warning_amber_rounded,
+                      color: Colors.amber.shade800,
+                      size: 20,
+                    ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
                         '检测到有 $_conflictNotesCount 篇同步冲突备份，建议立即处理。',
-                        style: Theme.of(context)
-                            .textTheme
-                            .labelMedium
+                        style: Theme.of(context).textTheme.labelMedium
                             ?.copyWith(color: Colors.amber.shade900),
                       ),
                     ),
@@ -818,12 +859,16 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                       onPressed: _navigateToConflicts,
                       style: TextButton.styleFrom(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 4),
+                          horizontal: 12,
+                          vertical: 4,
+                        ),
                         minimumSize: Size.zero,
                         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                       ),
-                      child: Text('去处理',
-                          style: Theme.of(context).textTheme.titleSmall),
+                      child: Text(
+                        '去处理',
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
                     ),
                   ],
                 ),
@@ -841,7 +886,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                   label: Text(l10n.webdavSyncNow),
                   style: FilledButton.styleFrom(
                     shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12)),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
                     backgroundColor: theme.colorScheme.secondaryContainer,
                     foregroundColor: theme.colorScheme.onSecondaryContainer,
                   ),
@@ -880,14 +926,20 @@ class QuoteListViewByConflict extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(Icons.check_circle_outline,
-                    size: 64, color: Colors.green.shade500),
+                Icon(
+                  Icons.check_circle_outline,
+                  size: 64,
+                  color: Colors.green.shade500,
+                ),
                 const SizedBox(height: 16),
                 Text('没有检测到冲突笔记', style: theme.textTheme.titleMedium),
                 const SizedBox(height: 8),
-                Text('您的所有同步冲突均已处理干净。',
-                    style: theme.textTheme.bodyMedium
-                        ?.copyWith(color: theme.colorScheme.outline)),
+                Text(
+                  '您的所有同步冲突均已处理干净。',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
               ],
             ),
           );
@@ -902,7 +954,8 @@ class QuoteListViewByConflict extends StatelessWidget {
               margin: const EdgeInsets.only(bottom: 12),
               elevation: 1,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12)),
+                borderRadius: BorderRadius.circular(12),
+              ),
               child: ListTile(
                 title: Text(
                   quote.content,
@@ -914,13 +967,18 @@ class QuoteListViewByConflict extends StatelessWidget {
                   padding: const EdgeInsets.only(top: 6.0),
                   child: Row(
                     children: [
-                      Icon(Icons.access_time,
-                          size: 14, color: theme.colorScheme.outline),
+                      Icon(
+                        Icons.access_time,
+                        size: 14,
+                        color: theme.colorScheme.outline,
+                      ),
                       const SizedBox(width: 4),
                       Text(
                         LWWUtils.formatTimestamp(quote.lastModified),
                         style: TextStyle(
-                            fontSize: 12, color: theme.colorScheme.outline),
+                          fontSize: 12,
+                          color: theme.colorScheme.outline,
+                        ),
                       ),
                     ],
                   ),
@@ -931,15 +989,17 @@ class QuoteListViewByConflict extends StatelessWidget {
                     // 一键恢复/移动：改分类至默认，使其移出冲突
                     IconButton(
                       icon: const Icon(Icons.check, color: Colors.green),
-                      tooltip: AppLocalizations.of(context)
-                          .webdavConflictKeepTooltip,
+                      tooltip: AppLocalizations.of(
+                        context,
+                      ).webdavConflictKeepTooltip,
                       onPressed: () async {
                         // 更新分类为默认（空）
                         final updated = quote.copyWith(
                           categoryId: '',
                           content: quote.content.replaceFirst('[冲突备份] ', ''),
-                          lastModified:
-                              DateTime.now().toUtc().toIso8601String(),
+                          lastModified: DateTime.now()
+                              .toUtc()
+                              .toIso8601String(),
                         );
                         await dbService.updateQuote(updated);
                         dbService.refreshQuotes();
@@ -947,8 +1007,11 @@ class QuoteListViewByConflict extends StatelessWidget {
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: Text(AppLocalizations.of(context)
-                                  .webdavConflictKeepSuccess),
+                              content: Text(
+                                AppLocalizations.of(
+                                  context,
+                                ).webdavConflictKeepSuccess,
+                              ),
                               behavior: SnackBarBehavior.floating,
                             ),
                           );
@@ -958,8 +1021,9 @@ class QuoteListViewByConflict extends StatelessWidget {
                     // 一键丢弃/删除
                     IconButton(
                       icon: const Icon(Icons.delete_outline, color: Colors.red),
-                      tooltip: AppLocalizations.of(context)
-                          .webdavConflictDiscardTooltip,
+                      tooltip: AppLocalizations.of(
+                        context,
+                      ).webdavConflictDiscardTooltip,
                       onPressed: () async {
                         // 永久删除该笔记
                         await dbService.permanentlyDeleteQuote(quote.id!);
@@ -968,8 +1032,11 @@ class QuoteListViewByConflict extends StatelessWidget {
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: Text(AppLocalizations.of(context)
-                                  .webdavConflictDiscardSuccess),
+                              content: Text(
+                                AppLocalizations.of(
+                                  context,
+                                ).webdavConflictDiscardSuccess,
+                              ),
                               behavior: SnackBarBehavior.floating,
                             ),
                           );

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -434,6 +434,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                                 icon: Icon(_obscurePassword
                                     ? Icons.visibility_off
                                     : Icons.visibility),
+                                tooltip: _obscurePassword
+                                    ? l10n.show
+                                    : l10n.hide,
                                 onPressed: () => setState(
                                     () => _obscurePassword = !_obscurePassword),
                               ),

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -312,6 +312,14 @@ class SettingsService extends ChangeNotifier {
     notifyListeners();
   }
 
+  // 开发者实验：记录页添加/更新卡片动画类型 ('scale' 或 'slide')
+  String get noteInsertAnimationType => _appSettings.noteInsertAnimationType;
+  Future<void> setNoteInsertAnimationType(String type) async {
+    _appSettings = _appSettings.copyWith(noteInsertAnimationType: type);
+    await _mmkv.setString(_appSettingsKey, json.encode(_appSettings.toJson()));
+    notifyListeners();
+  }
+
   // 语言设置：获取当前语言代码（null 表示跟随系统）
   String? get localeCode => _appSettings.localeCode;
 

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -590,13 +590,13 @@ class NoteListViewState extends State<NoteListView> {
     _loadMore();
   }
 
-  /// 触发指定 ID 的笔记卡片高亮动画（保存/修改后调用）。
-  /// 动画时长 650ms，900ms 后自动清除高亮状态。
+  /// 触发指定 ID 的笔记卡片出现/更新动画（保存/修改后调用）。
+  /// 动画时长 250ms，300ms 后自动清除状态以保证性能。
   void highlightNote(String id) {
     if (!mounted) return;
-    _highlightTimer?.cancel(); // 取消上一次高亮计时
+    _highlightTimer?.cancel();
     setState(() => _highlightedQuoteId = id);
-    _highlightTimer = Timer(const Duration(milliseconds: 900), () {
+    _highlightTimer = Timer(const Duration(milliseconds: 300), () {
       if (mounted) {
         setState(() => _highlightedQuoteId = null);
       }

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -1252,30 +1252,33 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
 
     if (!widget.isHighlighted) return card;
 
-    // 保存/修改笔记后的高亮动画：仅影响单张卡片，TweenAnimationBuilder
-    // 做纯 GPU Opacity 操作（无 blur），性能开销极低。
+    final animationType = context.select<SettingsService, String>(
+      (s) => s.noteInsertAnimationType,
+    );
+
+    final bool isScale = animationType == 'scale';
+
+    // 气泡微升与渐入动画 (可根据开发者实验选项进行切换)
+    // 采用 TweenAnimationBuilder 制作纯 GPU 动效，结束后立即释放以保证性能。
     return TweenAnimationBuilder<double>(
-      key: ValueKey('save_highlight_${widget.quote.id}'),
-      tween: Tween(begin: 1.0, end: 0.0),
-      duration: const Duration(milliseconds: 650),
-      curve: Curves.easeOut,
+      key: ValueKey('save_animate_${widget.quote.id}_$animationType'),
+      tween: Tween(begin: 0.0, end: 1.0),
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOutCubic,
       builder: (context, value, child) {
-        if (value < 0.01) return child!;
-        return Stack(
-          children: [
-            child!,
-            Positioned.fill(
-              child: IgnorePointer(
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(AppTheme.cardRadius),
-                    color: theme.colorScheme.primary
-                        .withValues(alpha: 0.18 * value),
-                  ),
-                ),
-              ),
+        if (value >= 0.99) return child!;
+        final double scale = isScale ? (0.96 + 0.04 * value) : 1.0;
+        final double slideOffset = isScale ? 0.0 : (12.0 * (1.0 - value));
+
+        return Transform.translate(
+          offset: Offset(0, slideOffset),
+          child: Transform.scale(
+            scale: scale,
+            child: Opacity(
+              opacity: value.clamp(0.0, 1.0),
+              child: child,
             ),
-          ],
+          ),
         );
       },
       child: card,


### PR DESCRIPTION
💡 **What:** 为 `WebDAVSyncPage` 中的密码输入框的可见性切换按钮添加了动态 `tooltip`。
🎯 **Why:** 之前该 `IconButton` 缺少 tooltip，导致屏幕阅读器无法朗读此按钮的作用（显示/隐藏密码），且鼠标悬停时无提示。
♿ **Accessibility:** 提升了屏幕阅读器用户和桌面端/Web端鼠标用户的表单交互体验。

---
*PR created automatically by Jules for task [17516913047017662111](https://jules.google.com/task/17516913047017662111) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 WebDAV 同步页的密码可见性切换按钮新增本地化动态提示（“显示密码/隐藏密码”），改善屏幕阅读器朗读与悬停提示体验。另在记录页引入新增/更新卡片的轻量动画（开发者选项可切换“气泡缩放/平滑上升”），并优化保存后的聚焦与出现时序。

<sup>Written for commit 908bf1e59c3cc2d8f22927edc96587333b8c7927. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* WebDAV同步页面的密码可见性切换按钮现已添加动态工具提示，在悬停时显示"显示密码"或"隐藏密码"提示信息，增强用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->