### PR TITLE
🔒 修复明文记录 API Key 的安全漏洞

### DIFF
--- a/lib/utils/api_key_debugger.dart
+++ b/lib/utils/api_key_debugger.dart
@@ -63,8 +63,9 @@ class ApiKeyDebugger {
         final authHeader =
             headers['Authorization'] ?? headers['x-api-key'] ?? '';
         if (authHeader.isNotEmpty) {
-          final apiKeyFromHeader =
-              authHeader.replaceAll('Bearer ', '').replaceAll('x-api-key ', '');
+          final apiKeyFromHeader = authHeader
+              .replaceAll('Bearer ', '')
+              .replaceAll('x-api-key ', '');
           logDebug(
             '   Headers中的API Key: ${apiKeyFromHeader.isEmpty ? "空" : "${apiKeyFromHeader.length}字符"}',
           );
@@ -140,8 +141,8 @@ class ApiKeyDebugger {
 
       if (afterSave != apiKey) {
         logDebug('❌ 保存验证失败！');
-        logDebug('期望: $apiKey');
-        logDebug('实际: $afterSave');
+        logDebug('期望: [REDACTED]');
+        logDebug('实际: [REDACTED]');
       }
     } catch (e) {
       logDebug('❌ 保存过程出错: $e');


### PR DESCRIPTION
🎯 **What:** 修复了 `api_key_debugger.dart` 中在保存 API Key 时将明文内容记录到日志的问题。
⚠️ **Risk:** 在调试模式或开启详细日志时，明文打印的敏感凭证有泄露风险。
🛡️ **Solution:** 使用 `[REDACTED]` 静态占位符替换明文打印的 `$apiKey` 和 `$afterSave` 变量。

---
*PR created automatically by Jules for task [18018428364204251453](https://jules.google.com/task/18018428364204251453) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `api_key_debugger.dart` 在保存验证失败时明文打印 API Key 的漏洞，改为用 [REDACTED] 占位符输出。避免在调试或详细日志中泄露敏感凭证。

<sup>Written for commit ae8a603bcd01d3c1259facd1f2957a5bf824f9fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

