### PR TITLE
🧹 代码健康改善: 弃用 MergeReport 遗留 API

### DIFF
--- a/lib/models/merge_report.dart
+++ b/lib/models/merge_report.dart
@@ -9,7 +9,9 @@
 /// 旧代码仍可使用 addAppliedQuote/addAppliedCategory（标记为 @deprecated）。
 class MergeReport {
   // 旧统计（兼容）: 应用的笔记与分类（新增 + 更新）
+  @Deprecated('Use insertedQuotes and updatedQuotes instead')
   final int appliedQuotes;
+  @Deprecated('Use insertedCategories and updatedCategories instead')
   final int appliedCategories;
 
   // 新增：细分统计
@@ -35,7 +37,9 @@ class MergeReport {
   final String? sourceDevice;
 
   const MergeReport({
+    @Deprecated('Use insertedQuotes and updatedQuotes instead')
     this.appliedQuotes = 0,
+    @Deprecated('Use insertedCategories and updatedCategories instead')
     this.appliedCategories = 0,
     this.insertedQuotes = 0,
     this.updatedQuotes = 0,
@@ -130,6 +134,7 @@ class MergeReport {
 
   /// 复制并修改
   MergeReport copyWith({
+    @Deprecated('Use insertedQuotes and updatedQuotes instead')
     int? appliedQuotes,
     int? insertedQuotes,
     int? updatedQuotes,
@@ -137,6 +142,7 @@ class MergeReport {
     int? deletedByTombstoneQuotes,
     int? skippedQuotes,
     int? sameTimestampDiffQuotes,
+    @Deprecated('Use insertedCategories and updatedCategories instead')
     int? appliedCategories,
     int? insertedCategories,
     int? updatedCategories,
@@ -292,6 +298,7 @@ class MergeReport {
 
 /// 可变的合并报告构建器，用于在合并过程中累积统计信息
 class MergeReportBuilder {
+  @Deprecated('Use _insertedQuotes and _updatedQuotes instead')
   int _appliedQuotes = 0; // 兼容旧逻辑
   int _insertedQuotes = 0;
   int _updatedQuotes = 0;
@@ -300,6 +307,7 @@ class MergeReportBuilder {
   int _sameTimestampDiffQuotes = 0;
   int _skippedQuotes = 0;
 
+  @Deprecated('Use _insertedCategories and _updatedCategories instead')
   int _appliedCategories = 0; // 兼容旧逻辑
   int _insertedCategories = 0;
   int _updatedCategories = 0;


### PR DESCRIPTION
🎯 **What:** The legacy fields `appliedQuotes` and `appliedCategories` in the `MergeReport` model and its `MergeReportBuilder` have been formally marked as deprecated using the `@Deprecated` annotation. 

💡 **Why:** To improve codebase health and readability, the legacy fields represent a merged semantic (inserted + updated) which should eventually be cleaned up by migrating callers to the new separate semantics (`insertedQuotes`, `updatedQuotes`, etc.). By marking them as deprecated without removing them or altering their type, existing code will still compile but developers will be warned and nudged to update their logic.

✅ **Verification:** Verified by checking out the changes, observing no missing fields, running tests (`test/lww_merge_report_test.dart`) to ensure everything still passes. A code review also validated this backwards compatible approach.

✨ **Result:** Developers are now correctly warned about legacy API usage at compile time, easing the transition to the new `MergeReport` semantics without breaking existing calls.

---
*PR created automatically by Jules for task [4912104340445340161](https://jules.google.com/task/4912104340445340161) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
弃用 MergeReport 与 MergeReportBuilder 中的遗留字段 appliedQuotes、appliedCategories，使用 @Deprecated 标注且不改变类型或行为。现有代码仍可编译，但会收到告警；请迁移到 insertedQuotes/updatedQuotes 与 insertedCategories/updatedCategories。

<sup>Written for commit f47cf93b475faa9ca52137f80f422ad25fda23aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 优化了数据统计模型，引入更细分的统计字段以实现更精确的数据跟踪。旧统计字段已标记为已弃用，现有集成保持向后兼容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->