### PR TITLE
🗃️ 黑匣: [完善 MediaCleanupService 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -35,3 +35,7 @@
 ## 2025-10-24 - 🗃️ 黑匣: [完善 DatabaseService 模块的结构化日志]
 **异常:** [DatabaseService 模块在数据库初始化失败、初始化新数据库失败、预加载笔记失败和数据库恢复失败时，仅使用了 logDebug 进行了粗糙的打印，丢失了关键的错误堆栈信息以及明确的模块来源信息，这使得排查数据库连接和读写故障十分困难。]
 **拦截:** [已将上述环节中的 catch (e) 替换为 catch (e, stackTrace)，并将 logDebug 替换为结构化的 AppLogger.e，注入了对应的报错描述、具体的异常对象 error: e、堆栈轨迹 stackTrace: stackTrace，并指定了来源模块 source: 'DatabaseService'。确认修改不超过 50 行，且未记录用户的任何隐私数据。]
+
+## 2025-05-18 - 🗃️ 黑匣: [完善 MediaCleanupService 模块的结构化日志]
+**异常:** [MediaCleanupService 模块在初始化、清理、迁移和统计媒体文件等任务发生错误时，仅使用了 `logDebug` 进行粗糙的字符串拼接打印。这不仅掩盖了底层 `FileSystemException` 或 `StateError` 等导致错误的真实原因，还丢失了完整的异常堆栈轨迹 (stackTrace)，导致排查本地文件系统的读写异常极其困难。]
+**拦截:** [已将上述所有流程中的 `catch (e)` 替换为结构化的 `catch (e, stackTrace)`，并使用 `AppLogger.e` 进行记录。注入了描述信息、具体的错误对象 `error: e`、堆栈轨迹 `stackTrace: stackTrace`，并指定了明确的日志来源模块 `source: 'MediaCleanupService'`。确认所有的错误记录仅涉及本地存储系统与数据库交互时的 IO/状态异常，未记录任何用户笔记的正文或凭证数据。]

--- a/lib/services/media_cleanup_service.dart
+++ b/lib/services/media_cleanup_service.dart
@@ -27,8 +27,13 @@ class MediaCleanupService {
 
       _isInitialized = true;
       logDebug('媒体清理服务初始化完成');
-    } catch (e) {
-      logDebug('媒体清理服务初始化失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '媒体清理服务初始化失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'MediaCleanupService',
+      );
     }
   }
 
@@ -56,8 +61,13 @@ class MediaCleanupService {
 
       logDebug('媒体清理任务完成: $results');
       return results;
-    } catch (e) {
-      logDebug('媒体清理任务失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '媒体清理任务失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'MediaCleanupService',
+      );
       return {'error': 1};
     }
   }
@@ -78,7 +88,7 @@ class MediaCleanupService {
       // 2. 清理所有临时文件
       final tempFiles = dryRun
           ? (await TemporaryMediaService.getTemporaryFilesStats())['totalFiles']
-              as int
+                as int
           : await TemporaryMediaService.cleanupAllTemporaryFiles();
       results['tempFilesCleared'] = tempFiles;
 
@@ -101,8 +111,13 @@ class MediaCleanupService {
 
       logDebug('完整清理完成: $results');
       return results;
-    } catch (e) {
-      logDebug('完整清理失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '完整清理失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'MediaCleanupService',
+      );
       return {'error': e.toString()};
     }
   }
@@ -133,8 +148,13 @@ class MediaCleanupService {
 
       logDebug('迁移完成: $results');
       return results;
-    } catch (e) {
-      logDebug('迁移失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '迁移失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'MediaCleanupService',
+      );
       return {'error': e.toString()};
     }
   }
@@ -157,8 +177,13 @@ class MediaCleanupService {
       stats.addAll(sizeStats);
 
       return stats;
-    } catch (e) {
-      logDebug('获取媒体统计信息失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '获取媒体统计信息失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'MediaCleanupService',
+      );
       return {'error': e.toString()};
     }
   }
@@ -200,8 +225,13 @@ class MediaCleanupService {
             } else if (relativePath.startsWith('audios')) {
               audiosSize += fileSize;
             }
-          } catch (e) {
-            logDebug('获取文件大小失败: ${entity.path}, 错误: $e');
+          } catch (e, stackTrace) {
+            AppLogger.e(
+              '获取文件大小失败: ${entity.path}',
+              error: e,
+              stackTrace: stackTrace,
+              source: 'MediaCleanupService',
+            );
           }
         }
       }
@@ -212,8 +242,13 @@ class MediaCleanupService {
         'videosSizeMB': videosSize / 1024 / 1024,
         'audiosSizeMB': audiosSize / 1024 / 1024,
       };
-    } catch (e) {
-      logDebug('计算媒体文件大小失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '计算媒体文件大小失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'MediaCleanupService',
+      );
       return {
         'totalSizeMB': 0.0,
         'imagesSizeMB': 0.0,
@@ -252,12 +287,14 @@ class MediaCleanupService {
           i + chunkSize > quotes.length ? quotes.length : i + chunkSize,
         );
 
-        final chunkResults = await Future.wait(chunk.map((quote) async {
-          return await MediaReferenceService.extractMediaPathsFromQuote(
-            quote,
-            cachedAppPath: appPath, // 传递缓存的路径以避免多余的平台调用
-          );
-        }));
+        final chunkResults = await Future.wait(
+          chunk.map((quote) async {
+            return await MediaReferenceService.extractMediaPathsFromQuote(
+              quote,
+              cachedAppPath: appPath, // 传递缓存的路径以避免多余的平台调用
+            );
+          }),
+        );
 
         for (var j = 0; j < chunk.length; j++) {
           final quote = chunk[j];
@@ -286,8 +323,13 @@ class MediaCleanupService {
 
       logDebug('媒体文件完整性验证完成: $results');
       return results;
-    } catch (e) {
-      logDebug('验证媒体文件完整性失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '验证媒体文件完整性失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'MediaCleanupService',
+      );
       return {'error': e.toString()};
     }
   }
@@ -309,8 +351,13 @@ class MediaCleanupService {
 
       logDebug('媒体文件引用修复完成: $results');
       return results;
-    } catch (e) {
-      logDebug('修复媒体文件引用失败: $e');
+    } catch (e, stackTrace) {
+      AppLogger.e(
+        '修复媒体文件引用失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'MediaCleanupService',
+      );
       return {'error': e.toString()};
     }
   }

--- a/lib/services/media_cleanup_service.dart
+++ b/lib/services/media_cleanup_service.dart
@@ -227,7 +227,7 @@ class MediaCleanupService {
             }
           } catch (e, stackTrace) {
             AppLogger.e(
-              '获取文件大小失败: ${entity.path}',
+              '获取媒体文件大小失败',
               error: e,
               stackTrace: stackTrace,
               source: 'MediaCleanupService',

--- a/lib/services/media_cleanup_service.dart
+++ b/lib/services/media_cleanup_service.dart
@@ -88,7 +88,7 @@ class MediaCleanupService {
       // 2. 清理所有临时文件
       final tempFiles = dryRun
           ? (await TemporaryMediaService.getTemporaryFilesStats())['totalFiles']
-                as int
+              as int
           : await TemporaryMediaService.cleanupAllTemporaryFiles();
       results['tempFilesCleared'] = tempFiles;
 


### PR DESCRIPTION
**What:** 
- 将 `MediaCleanupService` 中的 `logDebug('...失败: $e')` 替换为统一的 `AppLogger.e`。
- 修改了所有的 `catch (e)` 捕获块，新增了 `stackTrace` 捕获以保留完整的错误堆栈轨迹。

**Why:** 
该模块负责清理、验证和迁移本地媒体文件。由于原有的异常捕获抛弃了堆栈信息 (stackTrace)，当用户遇到由 `FileSystemException` 等引发的文件读写权限或路径问题时，排查极其困难。结构化日志记录可以有效保留错误上下文。

**Security Check:** 
已确认所有错误拦截点仅涉及本地文件系统 API 的报错和数据库统计操作报错，绝不包含也未输出任何用户存储的笔记文本、账号凭据或其他隐私敏感数据。

---
*PR created automatically by Jules for task [7988799460724878306](https://jules.google.com/task/7988799460724878306) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `MediaCleanupService` 的错误日志切换为结构化输出，统一使用 `AppLogger.e` 并捕获 `stackTrace`。覆盖初始化、清理、迁移、统计等路径，提升文件系统异常的可观测性且不泄露敏感数据。

- **Refactors**
  - 将 `catch (e)` 全量升级为 `catch (e, stackTrace)`，并以 `AppLogger.e` 替代 `logDebug`，注入 `source: 'MediaCleanupService'`。
  - 覆盖初始化、清理/完整清理、迁移、统计与大小计算、完整性校验与引用修复等流程。
  - 新增对单个文件大小统计失败的逐条结构化记录（含堆栈）。
  - 已核验仅记录本地 IO/状态异常，不含任何用户笔记内容或凭证。

<sup>Written for commit 844c86b742b0cf0da5e1b6910643acdbdef7e8c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进媒体清理相关流程的错误记录方式，异常时会保留错误对象和堆栈信息，便于排查问题。
  * 涉及初始化、定期清理、全量清理、数据迁移、媒体统计、完整性校验与修复等场景的异常日志均已统一优化。
  * 在媒体完整性校验中，保持并发检查逻辑不变，同时提升了异常处理的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->