### PR TITLE
⚡ Bolt: [优化 QuillAiApplyUtils 的正则表达式编译性能]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,8 @@
 ## 2024-05-24 - Optimize MediaCleanupService verifyMediaIntegrity
 **Learning:** The verifyMediaIntegrity method processed quotes sequentially and awaited extractMediaPathsFromQuote on each, causing significant I/O blocking when iterating over hundreds or thousands of quotes. Redundant directory lookups per extraction further exacerbated the overhead.
 **Action:** Replaced the sequential `for (final quote in quotes)` loop with a chunked `Future.wait` implementation that processes quotes in batches of 50. Passed down the pre-calculated `appPath` via `cachedAppPath` to eliminate repeated platform IPC calls. This reduced execution time by over 80%.
+## 2026-06-26 - [优化 QuillAiApplyUtils 正则表达式编译性能]
+**Learning:**
+在处理文档内容的高频工具方法（如 `stripMediaMarkersForDisplay`）中，内联调用 `RegExp` 构造函数会导致每次方法执行时重新分配和编译正则表达式。在连续使用链式 `replaceAll` 操作时，这种性能损耗会被进一步放大。
+**Action:**
+将 `QuillAiApplyUtils` 中的空白字符和换行符匹配模式提取为类的 `static final RegExp` 静态成员，使其仅在类加载时编译一次。测试执行通过且时间未受影响，有效降低了高频字符串处理时的资源消耗。

--- a/lib/utils/quill_ai_apply_utils.dart
+++ b/lib/utils/quill_ai_apply_utils.dart
@@ -5,6 +5,9 @@ import 'package:flutter_quill/flutter_quill.dart' as quill;
 /// Utilities for applying AI-generated plain text back into a Quill document.
 class QuillAiApplyUtils {
   static final RegExp _mediaMarkerPattern = RegExp(r'\[\[TE_MEDIA_(\d+)]]');
+  static final RegExp _trailingWhitespacePattern = RegExp(r'[ \t]+\n');
+  static final RegExp _multipleNewlinesPattern = RegExp(r'\n{3,}');
+  static final RegExp _multipleSpacesPattern = RegExp(r' {2,}');
 
   static String buildPolishInputText(quill.Document document) {
     final buffer = StringBuffer();
@@ -102,9 +105,9 @@ class QuillAiApplyUtils {
   static String stripMediaMarkersForDisplay(String text) {
     final withoutMarkers = text.replaceAll(_mediaMarkerPattern, '');
     return withoutMarkers
-        .replaceAll(RegExp(r'[ \t]+\n'), '\n')
-        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
-        .replaceAll(RegExp(r' {2,}'), ' ');
+        .replaceAll(_trailingWhitespacePattern, '\n')
+        .replaceAll(_multipleNewlinesPattern, '\n\n')
+        .replaceAll(_multipleSpacesPattern, ' ');
   }
 
   static String _markerForIndex(int index) => '[[TE_MEDIA_$index]]';


### PR DESCRIPTION
💡 **What:** 
将 `lib/utils/quill_ai_apply_utils.dart` 中 `stripMediaMarkersForDisplay` 方法内的 3 个匿名正则表达式提取为 `static final` 的静态常量成员。

🎯 **Why:** 
原实现中，每次处理 AI 优化后的纯文本或截断显示时都会重新实例化并编译 `RegExp` 对象。由于 `replaceAll` 在富文本渲染中可能会被高频调用，内联编译正则表达式存在不必要的性能和内存分配开销。

📊 **Measured Improvement:** 
将每次方法调用附带的 3 次 RegExp 对象分配减少为全局仅分配一次（O(1) 的初始化开销）。这降低了垃圾回收（GC）的压力以及渲染循环时的 CPU 编译开销。

🔬 **Measurement:** 
通过运行 `flutter test test/unit/utils/quill_ai_apply_utils_test.dart` 确保其替换逻辑能够严格等效地清除富文本标记及折叠过多的换行符/空白。

---
*PR created automatically by Jules for task [16140408273838600838](https://jules.google.com/task/16140408273838600838) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `stripMediaMarkersForDisplay` 中 3 个内联正则提取为类级 `static final RegExp` 常量，避免在高频渲染路径中重复编译。行为不变，减少对象分配与 GC 压力，提升字符串清理性能。

<sup>Written for commit b2e83c667182c597caaaf72fc49983df9b028061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化了文本清理相关的正则处理，减少重复编译，提升运行效率。
  * 统一了行尾空白、连续空行和连续空格的处理方式，清理结果保持一致。
  * 相关性能优化已验证，未影响执行时间。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->