### PR TITLE
🛡️ Sentinel: [CRITICAL] 修复 API Key 日志泄露漏洞

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,7 @@
 **Vulnerability:** 数据库查询参数（`$finalArgs`，可能包含用户标签、分类等敏感筛选条件）在 `logDebug` 中以明文形式记录，有数据泄漏风险。
 **Learning:** 在拼接或调用日志工具（如 `logDebug`、`AppLogger.e`）输出带参的 SQL 执行或排查信息时，极易忽略敏感信息脱敏，导致 PII 等数据泄漏。
 **Prevention:** 在日志中记录数据库操作时，永远不要将 `$args` 列表明文打印，必须使用 `[REDACTED]` 或其他脱敏手段隐藏参数内容。
+## 2026-06-26 - [防止日志中敏感凭证泄露]
+**Vulnerability:** API Key debugging logic printed substrings of sensitive credentials, potentially exposing full short keys or significant portions of long keys.
+**Learning:** Even partial logging of API keys for debugging can lead to full credential compromise, especially with short or predictable keys. `logDebug` outputs might be persisted or exposed.
+**Prevention:** Uniformly use `[REDACTED]` when masking credentials in logs and diagnostic UIs, rather than relying on substring operations that leak partial information.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2006,6 +2006,7 @@
   "aiProviderOllama": "Ollama",
   "aiProviderLMStudio": "LMStudio",
   "apiKeyStatusEmpty": "empty",
+  "apiKeyStatusRedacted": "[REDACTED]",
   "apiKeyStatusNotEmpty": "{length} characters",
   "@apiKeyStatusNotEmpty": {
     "placeholders": {
@@ -3593,6 +3594,14 @@
   "testReportTitle": "=== Manual API Key Test Report ===",
   "testParamsLabel": "Test Parameters:",
   "keyFormatCheckLabel": "Key Format Check:",
+  "testApiKeyPrefixLabel": "  API Key Prefix: {prefix}",
+  "@testApiKeyPrefixLabel": {
+    "placeholders": {
+      "prefix": {
+        "type": "String"
+      }
+    }
+  },
   "sendRequestLabel": "Send Request:",
   "responseResultLabel": "Response Result:",
   "testApiKey": "Test API Key",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1922,6 +1922,7 @@
   "aiProviderOllama": "Ollama",
   "aiProviderLMStudio": "LMStudio",
   "apiKeyStatusEmpty": "vide",
+  "apiKeyStatusRedacted": "[REDACTED]",
   "apiKeyStatusNotEmpty": "{length} caractères",
   "@apiKeyStatusNotEmpty": {
     "placeholders": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1929,6 +1929,7 @@
   "aiProviderOllama": "Ollama",
   "aiProviderLMStudio": "LMStudio",
   "apiKeyStatusEmpty": "空",
+  "apiKeyStatusRedacted": "[REDACTED]",
   "apiKeyStatusNotEmpty": "{length}文字",
   "@apiKeyStatusNotEmpty": {
     "placeholders": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1929,6 +1929,7 @@
   "aiProviderOllama": "장차 ~ 가 되는",
   "aiProviderLMStudio": "LM스튜디오",
   "apiKeyStatusEmpty": "비어 있는",
+  "apiKeyStatusRedacted": "[REDACTED]",
   "apiKeyStatusNotEmpty": "{length} characters",
   "@apiKeyStatusNotEmpty": {
     "placeholders": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2013,6 +2013,7 @@
   "aiProviderOllama": "Ollama",
   "aiProviderLMStudio": "LMStudio",
   "apiKeyStatusEmpty": "空",
+  "apiKeyStatusRedacted": "[REDACTED]",
   "apiKeyStatusNotEmpty": "{length}字符",
   "@apiKeyStatusNotEmpty": {
     "placeholders": {
@@ -3593,6 +3594,14 @@
   "testReportTitle": "=== 手动API密钥测试报告 ===",
   "testParamsLabel": "测试参数:",
   "keyFormatCheckLabel": "密钥格式检查:",
+  "testApiKeyPrefixLabel": "  API Key前缀: {prefix}",
+  "@testApiKeyPrefixLabel": {
+    "placeholders": {
+      "prefix": {
+        "type": "String"
+      }
+    }
+  },
   "sendRequestLabel": "发送请求:",
   "responseResultLabel": "响应结果:",
   "testApiKey": "测试API密钥",

--- a/lib/pages/api_key_diagnostics_page.dart
+++ b/lib/pages/api_key_diagnostics_page.dart
@@ -139,9 +139,8 @@ class _ApiKeyDiagnosticsPageState extends State<ApiKeyDiagnosticsPage> {
           buffer.writeln(
               l10n.diagnosticApiKeyLength(currentProvider.apiKey.length));
           buffer.writeln(
-            l10n.diagnosticApiKeyPrefix(currentProvider.apiKey.length > 15
-                ? "${currentProvider.apiKey.substring(0, 15)}..."
-                : currentProvider.apiKey),
+            l10n.diagnosticApiKeyPrefix(
+                currentProvider.apiKey.isEmpty ? "空" : "[REDACTED]"),
           );
         }
 
@@ -157,9 +156,8 @@ class _ApiKeyDiagnosticsPageState extends State<ApiKeyDiagnosticsPage> {
           buffer
               .writeln(l10n.diagnosticSecureApiKeyLength(secureApiKey.length));
           buffer.writeln(
-            l10n.diagnosticSecureApiKeyPrefix(secureApiKey.length > 15
-                ? "${secureApiKey.substring(0, 15)}..."
-                : secureApiKey),
+            l10n.diagnosticSecureApiKeyPrefix(
+                secureApiKey.isEmpty ? "空" : "[REDACTED]"),
           );
         }
         buffer.writeln();

--- a/lib/pages/api_key_diagnostics_page.dart
+++ b/lib/pages/api_key_diagnostics_page.dart
@@ -139,8 +139,9 @@ class _ApiKeyDiagnosticsPageState extends State<ApiKeyDiagnosticsPage> {
           buffer.writeln(
               l10n.diagnosticApiKeyLength(currentProvider.apiKey.length));
           buffer.writeln(
-            l10n.diagnosticApiKeyPrefix(
-                currentProvider.apiKey.isEmpty ? "空" : "[REDACTED]"),
+            l10n.diagnosticApiKeyPrefix(currentProvider.apiKey.isEmpty
+                ? l10n.apiKeyStatusEmpty
+                : l10n.apiKeyStatusRedacted),
           );
         }
 
@@ -156,8 +157,9 @@ class _ApiKeyDiagnosticsPageState extends State<ApiKeyDiagnosticsPage> {
           buffer
               .writeln(l10n.diagnosticSecureApiKeyLength(secureApiKey.length));
           buffer.writeln(
-            l10n.diagnosticSecureApiKeyPrefix(
-                secureApiKey.isEmpty ? "空" : "[REDACTED]"),
+            l10n.diagnosticSecureApiKeyPrefix(secureApiKey.isEmpty
+                ? l10n.apiKeyStatusEmpty
+                : l10n.apiKeyStatusRedacted),
           );
         }
         buffer.writeln();

--- a/lib/pages/manual_api_test_page.dart
+++ b/lib/pages/manual_api_test_page.dart
@@ -149,7 +149,9 @@ class _ManualApiKeyTestPageState extends State<ManualApiKeyTestPage> {
       buffer.writeln('  Model: $model');
       buffer.writeln('  API Key长度: ${apiKey.length}');
       buffer.writeln(
-        '  API Key前缀: ${apiKey.isEmpty ? "空" : "[REDACTED]"}',
+        l10n.testApiKeyPrefixLabel(apiKey.isEmpty
+            ? l10n.apiKeyStatusEmpty
+            : l10n.apiKeyStatusRedacted),
       );
       buffer.writeln();
 

--- a/lib/pages/manual_api_test_page.dart
+++ b/lib/pages/manual_api_test_page.dart
@@ -149,7 +149,7 @@ class _ManualApiKeyTestPageState extends State<ManualApiKeyTestPage> {
       buffer.writeln('  Model: $model');
       buffer.writeln('  API Key长度: ${apiKey.length}');
       buffer.writeln(
-        '  API Key前缀: ${apiKey.substring(0, apiKey.length > 10 ? 10 : apiKey.length)}...',
+        '  API Key前缀: ${apiKey.isEmpty ? "空" : "[REDACTED]"}',
       );
       buffer.writeln();
 

--- a/lib/utils/api_key_debugger.dart
+++ b/lib/utils/api_key_debugger.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'dart:math' as math;
 import '../services/api_key_manager.dart';
 import '../services/settings_service.dart';
 import 'package:thoughtecho/utils/app_logger.dart';
@@ -33,7 +32,7 @@ class ApiKeyDebugger {
           '   配置中的API Key: ${currentProvider.apiKey.isEmpty ? "空" : "${currentProvider.apiKey.length}字符"}',
         );
         logDebug(
-          '   配置中的API Key内容: ${currentProvider.apiKey.isEmpty ? "空" : "${currentProvider.apiKey.substring(0, math.min(4, currentProvider.apiKey.length))}****"}',
+          '   配置中的API Key内容: ${currentProvider.apiKey.isEmpty ? "空" : "[REDACTED]"}',
         );
 
         // 3. 检查加密存储中的API Key状态
@@ -45,7 +44,7 @@ class ApiKeyDebugger {
           '   安全存储中的API Key: ${secureApiKey.isEmpty ? "空" : "${secureApiKey.length}字符"}',
         );
         logDebug(
-          '   安全存储中的API Key内容: ${secureApiKey.isEmpty ? "空" : "${secureApiKey.substring(0, math.min(4, secureApiKey.length))}****"}',
+          '   安全存储中的API Key内容: ${secureApiKey.isEmpty ? "空" : "[REDACTED]"}',
         );
 
         // 4. 检查有效性验证结果
@@ -69,7 +68,7 @@ class ApiKeyDebugger {
             '   Headers中的API Key: ${apiKeyFromHeader.isEmpty ? "空" : "${apiKeyFromHeader.length}字符"}',
           );
           logDebug(
-            '   Headers中的API Key内容: ${apiKeyFromHeader.isEmpty ? "空" : apiKeyFromHeader.substring(0, math.min(20, apiKeyFromHeader.length))}...',
+            '   Headers中的API Key内容: ${apiKeyFromHeader.isEmpty ? "空" : "[REDACTED]"}',
           );
           logDebug('   Headers与安全存储是否一致: ${apiKeyFromHeader == secureApiKey}');
         } else {
@@ -117,7 +116,7 @@ class ApiKeyDebugger {
     logDebug('Provider ID: $providerId');
     logDebug('API Key长度: ${apiKey.length}');
     logDebug(
-      'API Key前缀: ${apiKey.length > 20 ? apiKey.substring(0, 20) : apiKey}...',
+      'API Key前缀: ${apiKey.isEmpty ? "空" : "[REDACTED]"}',
     );
 
     try {
@@ -164,7 +163,7 @@ class ApiKeyDebugger {
     logDebug('传入API Key长度: ${apiKey.length}');
     logDebug('传入API Key是否为空: ${apiKey.isEmpty}');
     logDebug(
-      '传入API Key前缀: ${apiKey.isNotEmpty ? apiKey.substring(0, math.min(20, apiKey.length)) : "无"}',
+      '传入API Key前缀: ${apiKey.isNotEmpty ? "[REDACTED]" : "无"}',
     );
 
     try {
@@ -175,7 +174,7 @@ class ApiKeyDebugger {
       logDebug('存储中的API Key长度: ${storedApiKey.length}');
       logDebug('存储中的API Key是否为空: ${storedApiKey.isEmpty}');
       logDebug(
-        '存储中的API Key前缀: ${storedApiKey.isNotEmpty ? storedApiKey.substring(0, math.min(20, storedApiKey.length)) : "无"}',
+        '存储中的API Key前缀: ${storedApiKey.isNotEmpty ? "[REDACTED]" : "无"}',
       );
 
       // 比较传入的API Key和存储的API Key


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: 在 API Key 调试日志和 UI 诊断信息中使用了 `substring(0, 15)` 等截取手段，这导致较短的 API Key 会被完整泄露，较长的 API Key 也会暴露出前缀特征。这些日志信息可能被外部读取或在报错反馈中泄露。
🎯 **Impact**: 如果恶意用户获取到截取出来的 API Key，尤其是当 API 服务商的短密钥（如 10 余个字符）被完整记录时，可能导致凭证泄露及未授权的 API 使用。
🔧 **Fix**: 使用统一的 `[REDACTED]` 掩码替换原有的 `substring` 逻辑，同时对于原本为空的情况依旧显示"空"，从而兼顾了调试状态感知与彻底的脱敏。
✅ **Verification**: 运行了代码检查（已忽略因版本导致的 `scrollCacheExtent` 预期错误）并人工 `git diff` 验证了脱敏代码覆盖到了所有发生过的泄露情况。并在 `.jules/sentinel.md` 记录了相关安全实践。

始终用中文创建PR！

---
*PR created automatically by Jules for task [4902320215295833182](https://jules.google.com/task/4902320215295833182) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复调试日志与诊断/手动测试 UI 中 API Key 前缀截取导致的泄露风险。UI 使用本地化掩码文案；非空统一显示“[REDACTED]”，空值显示“空”。

- **Bug Fixes**
  - 在 `lib/utils/api_key_debugger.dart`、`lib/pages/api_key_diagnostics_page.dart`、`lib/pages/manual_api_test_page.dart` 中用 `[REDACTED]` 替换全部前缀截取；移除相关 `substring` 与冗余 `dart:math` 依赖。
  - 统一配置、加密存储、请求头三处的 Key 输出；仅保留长度与是否为空的信息。
  - 补充国际化：新增并使用 `apiKeyStatusRedacted`、`testApiKeyPrefixLabel` 翻译键（更新各语言 `*.arb`），移除硬编码；在 `.jules/sentinel.md` 记录安全实践。

<sup>Written for commit afdb4bb773741e9e84a44ad01c7f5c08a01da35a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整了 API 密钥相关诊断与调试信息，避免在日志和测试报告中显示任何密钥片段。
  * 空值仍会明确显示为“空”，非空内容统一以“[REDACTED]”替代，减少敏感信息泄露风险。
  * 其他诊断结果、校验流程和长度信息保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->