### PR TITLE
Fix note collapse boundary detection

### DIFF
--- a/lib/widgets/quote_content_widget.dart
+++ b/lib/widgets/quote_content_widget.dart
@@ -108,6 +108,7 @@ class QuoteContent extends StatelessWidget {
     _cacheGeneration++;
     _QuoteDocumentCache.clear();
     _QuoteHeightEstimateCache.clear();
+    _QuotePlainTextLayoutExpansionCache.clear();
     _QuoteContentControllerCache.clear();
   }
 
@@ -437,6 +438,40 @@ class QuoteContent extends StatelessWidget {
           builder: () => _estimateRenderedHeight(quote),
         ) >
         collapsedContentMaxHeight;
+  }
+
+  static bool exceedsCollapsedHeightForLayout({
+    required Quote quote,
+    required TextStyle? style,
+    required double maxWidth,
+    required TextDirection textDirection,
+    required TextScaler textScaler,
+    Locale? locale,
+  }) {
+    if (quote.deltaContent != null && quote.editSource == 'fullscreen') {
+      return exceedsCollapsedHeight(quote);
+    }
+    if (!maxWidth.isFinite || maxWidth <= 0) {
+      return exceedsCollapsedHeight(quote);
+    }
+
+    return _QuotePlainTextLayoutExpansionCache.getOrCreate(
+      quote: quote,
+      style: style,
+      maxWidth: maxWidth,
+      textDirection: textDirection,
+      textScaler: textScaler,
+      locale: locale,
+      builder: () {
+        final painter = TextPainter(
+          text: TextSpan(text: quote.content, style: style),
+          textDirection: textDirection,
+          textScaler: textScaler,
+          locale: locale,
+        )..layout(maxWidth: maxWidth);
+        return painter.height > collapsedContentMaxHeight + 0.5;
+      },
+    );
   }
 
   static double _estimateRenderedHeight(Quote quote) {
@@ -815,6 +850,122 @@ class _HeightEstimateCacheEntry {
       : lastAccess = DateTime.now();
 
   final double height;
+  DateTime lastAccess;
+
+  void touch() {
+    lastAccess = DateTime.now();
+  }
+}
+
+class _QuotePlainTextLayoutExpansionCache {
+  static final LinkedHashMap<_PlainTextLayoutExpansionCacheKey,
+          _PlainTextLayoutExpansionCacheEntry> _cache =
+      LinkedHashMap<_PlainTextLayoutExpansionCacheKey,
+          _PlainTextLayoutExpansionCacheEntry>();
+
+  static const int _maxCacheSize = 300;
+  static const int _pruneBatchSize = 50;
+
+  static bool getOrCreate({
+    required Quote quote,
+    required TextStyle? style,
+    required double maxWidth,
+    required TextDirection textDirection,
+    required TextScaler textScaler,
+    required Locale? locale,
+    required bool Function() builder,
+  }) {
+    final key = _PlainTextLayoutExpansionCacheKey(
+      contentSignature:
+          Object.hash(quote.content.hashCode, quote.content.length),
+      maxWidth: maxWidth.ceil(),
+      styleHash: style.hashCode,
+      textDirection: textDirection,
+      textScalerHash: textScaler.hashCode,
+      localeTag: locale?.toLanguageTag(),
+    );
+    final existing = _cache.remove(key);
+    if (existing != null) {
+      existing.touch();
+      _cache[key] = existing;
+      return existing.exceedsCollapsedHeight;
+    }
+
+    if (_cache.length >= _maxCacheSize) {
+      _pruneOldest();
+    }
+
+    final exceedsCollapsedHeight = builder();
+    _cache[key] = _PlainTextLayoutExpansionCacheEntry(
+      exceedsCollapsedHeight: exceedsCollapsedHeight,
+    );
+    return exceedsCollapsedHeight;
+  }
+
+  static void clear() {
+    _cache.clear();
+  }
+
+  static void _pruneOldest() {
+    if (_cache.isEmpty) {
+      return;
+    }
+
+    final entries = _cache.entries.toList()
+      ..sort((a, b) => a.value.lastAccess.compareTo(b.value.lastAccess));
+
+    for (final entry in entries.take(_pruneBatchSize)) {
+      _cache.remove(entry.key);
+    }
+  }
+}
+
+class _PlainTextLayoutExpansionCacheKey {
+  const _PlainTextLayoutExpansionCacheKey({
+    required this.contentSignature,
+    required this.maxWidth,
+    required this.styleHash,
+    required this.textDirection,
+    required this.textScalerHash,
+    required this.localeTag,
+  });
+
+  final int contentSignature;
+  final int maxWidth;
+  final int styleHash;
+  final TextDirection textDirection;
+  final int textScalerHash;
+  final String? localeTag;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is _PlainTextLayoutExpansionCacheKey &&
+        other.contentSignature == contentSignature &&
+        other.maxWidth == maxWidth &&
+        other.styleHash == styleHash &&
+        other.textDirection == textDirection &&
+        other.textScalerHash == textScalerHash &&
+        other.localeTag == localeTag;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        contentSignature,
+        maxWidth,
+        styleHash,
+        textDirection,
+        textScalerHash,
+        localeTag,
+      );
+}
+
+class _PlainTextLayoutExpansionCacheEntry {
+  _PlainTextLayoutExpansionCacheEntry({
+    required this.exceedsCollapsedHeight,
+  }) : lastAccess = DateTime.now();
+
+  final bool exceedsCollapsedHeight;
   DateTime lastAccess;
 
   void touch() {

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -342,8 +342,12 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
     return width;
   }
 
-  void _handleDoubleTap(bool isExpanded, Quote quote) {
-    if (!_needsExpansion(quote)) {
+  void _handleDoubleTap(
+    bool isExpanded,
+    Quote quote, {
+    bool? canExpand,
+  }) {
+    if (!(canExpand ?? _needsExpansion(quote))) {
       return;
     }
 
@@ -353,6 +357,22 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
     Feedback.forTap(context);
 
     widget.onToggleExpanded(!isExpanded);
+  }
+
+  bool _needsExpansionForLayout(
+    BuildContext context,
+    Quote quote,
+    TextStyle? contentStyle,
+    double maxWidth,
+  ) {
+    return QuoteContent.exceedsCollapsedHeightForLayout(
+      quote: quote,
+      style: contentStyle,
+      maxWidth: maxWidth,
+      textDirection: Directionality.maybeOf(context) ?? TextDirection.ltr,
+      textScaler: MediaQuery.textScalerOf(context),
+      locale: Localizations.maybeLocaleOf(context),
+    );
   }
 
   @override
@@ -657,144 +677,152 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
             ),
 
           // 笔记内容 - 支持双击展开/折叠
-          GestureDetector(
-            key: widget.foldToggleGuideKey ??
-                const ValueKey('quote_item.double_tap_region'),
-            behavior: HitTestBehavior.translucent,
-            onDoubleTap: _needsExpansion(quote)
-                ? () => _handleDoubleTap(isExpanded, quote)
-                : null,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(4, 8, 4, 8),
-              child: Builder(
-                builder: (context) {
-                  final innerTheme = Theme.of(context);
-                  final needsExpansion = _needsExpansion(quote);
-                  final showFullContent = isExpanded || !needsExpansion;
+          Padding(
+            padding: const EdgeInsets.fromLTRB(4, 8, 4, 8),
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final innerTheme = Theme.of(context);
+                final contentStyle = innerTheme.textTheme.bodyLarge?.copyWith(
+                  color: primaryTextColor,
+                  height: 1.5,
+                );
+                final needsExpansion = _needsExpansionForLayout(
+                  context,
+                  quote,
+                  contentStyle,
+                  constraints.maxWidth,
+                );
+                final showFullContent = isExpanded || !needsExpansion;
 
-                  // 构建不依赖双击动画的内容子树（QuoteContent + 底部遮罩）
-                  // 作为 AnimatedBuilder 的 child 传入，避免动画 tick 时重建重型子树
-                  final contentChild = Stack(
-                    clipBehavior: Clip.none,
-                    children: [
-                      AnimatedSwitcher(
-                        duration: QuoteItemWidget._fadeDuration,
-                        switchInCurve: Curves.easeOut,
-                        switchOutCurve: Curves.easeIn,
-                        layoutBuilder: (currentChild, previousChildren) =>
-                            Stack(
-                          clipBehavior: Clip.none,
-                          children: [
-                            ...previousChildren,
-                            if (currentChild != null) currentChild,
-                          ],
-                        ),
-                        child: KeyedSubtree(
-                          key: ValueKey<bool>(showFullContent),
-                          child: QuoteContent(
-                            quote: quote,
-                            style: innerTheme.textTheme.bodyLarge?.copyWith(
-                              color: primaryTextColor,
-                              height: 1.5,
-                            ),
-                            showFullContent: showFullContent,
-                            collapseRichTextSemantics: true,
-                          ),
+                // 构建不依赖双击动画的内容子树（QuoteContent + 底部遮罩）
+                // 作为 AnimatedBuilder 的 child 传入，避免动画 tick 时重建重型子树
+                final contentChild = Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    AnimatedSwitcher(
+                      duration: QuoteItemWidget._fadeDuration,
+                      switchInCurve: Curves.easeOut,
+                      switchOutCurve: Curves.easeIn,
+                      layoutBuilder: (currentChild, previousChildren) => Stack(
+                        clipBehavior: Clip.none,
+                        children: [
+                          ...previousChildren,
+                          if (currentChild != null) currentChild,
+                        ],
+                      ),
+                      child: KeyedSubtree(
+                        key: ValueKey<bool>(showFullContent),
+                        child: QuoteContent(
+                          quote: quote,
+                          style: contentStyle,
+                          showFullContent: showFullContent,
+                          collapseRichTextSemantics: true,
                         ),
                       ),
-                      Positioned(
-                        left: 0,
-                        right: 0,
-                        bottom: 0,
-                        height: 30,
-                        child: IgnorePointer(
-                          child: AnimatedSwitcher(
-                            duration: QuoteItemWidget._fadeDuration,
-                            switchInCurve: Curves.easeIn,
-                            switchOutCurve: Curves.easeOut,
-                            child: (!isExpanded && needsExpansion)
-                                ? Builder(
-                                    builder: (context) {
-                                      final fadeScrim = Container(
-                                        decoration: BoxDecoration(
-                                          gradient: LinearGradient(
-                                            begin: Alignment.topCenter,
-                                            end: Alignment.bottomCenter,
-                                            colors: [
-                                              innerTheme.colorScheme.surface
-                                                  .withValues(alpha: 0.0),
-                                              innerTheme.colorScheme.surface
-                                                  .withValues(alpha: 0.08),
-                                              innerTheme.colorScheme.surface
-                                                  .withValues(alpha: 0.18),
-                                            ],
-                                            stops: const [0.0, 0.4, 1.0],
-                                          ),
+                    ),
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: 0,
+                      height: 30,
+                      child: IgnorePointer(
+                        child: AnimatedSwitcher(
+                          duration: QuoteItemWidget._fadeDuration,
+                          switchInCurve: Curves.easeIn,
+                          switchOutCurve: Curves.easeOut,
+                          child: (!isExpanded && needsExpansion)
+                              ? Builder(
+                                  builder: (context) {
+                                    final fadeScrim = Container(
+                                      decoration: BoxDecoration(
+                                        gradient: LinearGradient(
+                                          begin: Alignment.topCenter,
+                                          end: Alignment.bottomCenter,
+                                          colors: [
+                                            innerTheme.colorScheme.surface
+                                                .withValues(alpha: 0.0),
+                                            innerTheme.colorScheme.surface
+                                                .withValues(alpha: 0.08),
+                                            innerTheme.colorScheme.surface
+                                                .withValues(alpha: 0.18),
+                                          ],
+                                          stops: const [0.0, 0.4, 1.0],
                                         ),
-                                      );
+                                      ),
+                                    );
 
-                                      return Stack(
-                                        fit: StackFit.expand,
-                                        children: [
-                                          ExcludeSemantics(
-                                            child: backdropBlurDisabled
-                                                ? fadeScrim
-                                                : RepaintBoundary(
-                                                    child: ClipRect(
-                                                      child: BackdropFilter(
-                                                        backdropGroupKey:
-                                                            _backdropKey,
-                                                        filter:
-                                                            ui.ImageFilter.blur(
-                                                          sigmaX: 1.2,
-                                                          sigmaY: 1.2,
-                                                        ),
-                                                        child: fadeScrim,
+                                    return Stack(
+                                      fit: StackFit.expand,
+                                      children: [
+                                        ExcludeSemantics(
+                                          child: backdropBlurDisabled
+                                              ? fadeScrim
+                                              : RepaintBoundary(
+                                                  child: ClipRect(
+                                                    child: BackdropFilter(
+                                                      backdropGroupKey:
+                                                          _backdropKey,
+                                                      filter:
+                                                          ui.ImageFilter.blur(
+                                                        sigmaX: 1.2,
+                                                        sigmaY: 1.2,
                                                       ),
+                                                      child: fadeScrim,
                                                     ),
                                                   ),
-                                          ),
-                                          Align(
-                                            alignment: Alignment.center,
-                                            child: Container(
-                                              padding:
-                                                  const EdgeInsets.symmetric(
-                                                horizontal: 8,
-                                                vertical: 2,
-                                              ),
-                                              decoration: BoxDecoration(
-                                                color: innerTheme
-                                                    .colorScheme.surface
-                                                    .withValues(alpha: 0.35),
-                                                borderRadius:
-                                                    BorderRadius.circular(12),
-                                              ),
-                                              child: Text(
-                                                l10n.doubleTapToViewFull,
-                                                style: innerTheme
-                                                    .textTheme.bodySmall
-                                                    ?.copyWith(
-                                                  color: innerTheme
-                                                      .colorScheme.onSurface
-                                                      .withValues(alpha: 0.65),
-                                                  fontSize: 11,
-                                                  fontStyle: FontStyle.italic,
                                                 ),
+                                        ),
+                                        Align(
+                                          alignment: Alignment.center,
+                                          child: Container(
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 8,
+                                              vertical: 2,
+                                            ),
+                                            decoration: BoxDecoration(
+                                              color: innerTheme
+                                                  .colorScheme.surface
+                                                  .withValues(alpha: 0.35),
+                                              borderRadius:
+                                                  BorderRadius.circular(12),
+                                            ),
+                                            child: Text(
+                                              l10n.doubleTapToViewFull,
+                                              style: innerTheme
+                                                  .textTheme.bodySmall
+                                                  ?.copyWith(
+                                                color: innerTheme
+                                                    .colorScheme.onSurface
+                                                    .withValues(alpha: 0.65),
+                                                fontSize: 11,
+                                                fontStyle: FontStyle.italic,
                                               ),
                                             ),
                                           ),
-                                        ],
-                                      );
-                                    },
-                                  )
-                                : const SizedBox.shrink(),
-                          ),
+                                        ),
+                                      ],
+                                    );
+                                  },
+                                )
+                              : const SizedBox.shrink(),
                         ),
                       ),
-                    ],
-                  );
+                    ),
+                  ],
+                );
 
-                  return AnimatedSize(
+                return GestureDetector(
+                  key: widget.foldToggleGuideKey ??
+                      const ValueKey('quote_item.double_tap_region'),
+                  behavior: HitTestBehavior.translucent,
+                  onDoubleTap: needsExpansion
+                      ? () => _handleDoubleTap(
+                            isExpanded,
+                            quote,
+                            canExpand: needsExpansion,
+                          )
+                      : null,
+                  child: AnimatedSize(
                     duration: QuoteItemWidget.expandCollapseDuration,
                     curve: QuoteItemWidget._expandCurve,
                     alignment: Alignment.topLeft,
@@ -840,9 +868,9 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                         );
                       },
                     ),
-                  );
-                },
-              ),
+                  ),
+                );
+              },
             ),
           ),
 

--- a/test/widgets/quote_item_widget_test.dart
+++ b/test/widgets/quote_item_widget_test.dart
@@ -271,6 +271,64 @@ void main() {
       expect(find.text('双击查看全文'), findsOneWidget);
     });
 
+    testWidgets('宽布局下实际未溢出的边界文本不显示展开提示', (tester) async {
+      final quote = _buildQuote(
+        id: 'wide-boundary',
+        content: List.filled(170, '界').join(),
+        editSource: 'inline',
+      );
+
+      expect(QuoteItemWidget.needsExpansionFor(quote), isTrue);
+
+      bool toggled = false;
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: _FakeSettingsService(),
+          child: MaterialApp(
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+            home: Material(
+              child: Center(
+                child: SizedBox(
+                  width: 720,
+                  child: QuoteItemWidget(
+                    quote: quote,
+                    tagMap: const {},
+                    isExpanded: false,
+                    onToggleExpanded: (_) {
+                      toggled = true;
+                    },
+                    onEdit: () {},
+                    onDelete: () {},
+                    onAskAI: () {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('双击查看全文'), findsNothing);
+
+      final contentGesture = find.byKey(
+        const ValueKey('quote_item.double_tap_region'),
+      );
+      await tester.tap(contentGesture);
+      await tester.pump(const Duration(milliseconds: 40));
+      await tester.tap(contentGesture);
+      await tester.pumpAndSettle();
+
+      expect(toggled, isFalse);
+    });
+
     testWidgets('折叠遮罩使用卡片级独立BackdropKey', (tester) async {
       final quote = _buildQuote(
         content: List.filled(6, _longContentChunk).join('\n'),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
修复笔记折叠边界判定：现在按实际布局宽度精确判断是否超过折叠高度。避免未溢出却显示“双击查看全文”，并防止误触发展开。

- **Bug Fixes**
  - 基于实际布局测量判定溢出（TextPainter + 样式/语言环境/文本缩放 + maxWidth），替代高度估算。
  - `QuoteItemWidget` 使用 `LayoutBuilder` 的宽度决定是否需要展开与遮罩；双击仅在可展开时响应。
  - 未溢出时不再显示“双击查看全文”提示，也不会触发展开切换。
  - 增加宽布局边界用例测试；引入 LRU 文本布局结果缓存并纳入清理流程以减少重复测量。

<sup>Written for commit 2dd92fc1f875696eb4073522494da43242622fa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化了引用内容的折叠高度判断，能根据实际排版结果更准确地决定是否显示“查看全文”提示。
  * 双击展开的触发条件改为与当前布局结果一致，避免不必要的展开操作。

* **测试**
  * 新增了边界场景测试，验证内容未超出折叠高度时不会显示展开提示，且双击不会触发展开。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->