### PR TITLE
🌐 译者: [提取硬编码 / 补全多语言词条]

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -40,3 +40,7 @@
 **发现:** WebDAV 同步页面硬编码："已关闭 WebDAV 云同步。本地数据完全保留。", "关闭并停用云同步", "去处理", "没有检测到冲突笔记", "您的所有同步冲突均已处理干净。", "坚果云 (Nutstore)", "自定义 (Custom)"
 **规则:**
 - 采用极简风格翻译，例如 `webdavDisableSyncSuccess`, `webdavDisableSync`, `webdavGoToResolve`, `webdavNoConflicts`, `webdavAllConflictsResolved`, `webdavProviderNutstore`, `webdavProviderCustom`。
+
+## 2024-05-24 - [提取 WebDAV 服务商配置表单硬编码]
+**发现:** WebDAV 同步配置页面存在硬编码的表单提示（如：服务商配置、未填写必填项的错误提示）。
+**规则:** 将表单相关的标题及校验失败文案统一抽取到 `.arb` 文件中，英文翻译采用清晰直接（"Please enter..."）且符合极简主义要求的设计。

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3806,5 +3806,10 @@
   "webdavProviderNutstore": "Nutstore",
   "webdavProviderCustom": "Custom",
   "webdavProviderNextcloud": "Nextcloud / ownCloud",
-  "webdavProviderInfinicloud": "InfiniCLOUD"
+  "webdavProviderInfinicloud": "InfiniCLOUD",
+  "webdavProviderConfig": "Provider Configuration",
+  "webdavServerUrlEmptyError": "Please enter WebDAV server address",
+  "webdavServerUrlInvalidError": "Address must start with http:// or https://",
+  "webdavUsernameEmptyError": "Please enter username",
+  "webdavPasswordEmptyError": "Please enter app password"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3811,5 +3811,21 @@
   "webdavServerUrlEmptyError": "Please enter WebDAV server address",
   "webdavServerUrlInvalidError": "Address must start with http:// or https://",
   "webdavUsernameEmptyError": "Please enter username",
-  "webdavPasswordEmptyError": "Please enter app password"
+  "webdavPasswordEmptyError": "Please enter app password",
+  "webdavSyncStrategy": "Sync Strategy",
+  "webdavStatusNotEnabled": "Cloud Sync Disabled",
+  "webdavStatusNotEnabledDesc": "Configure your WebDAV service to enjoy secure cross-device multi-way synchronization.",
+  "webdavStatusSyncingDesc": "Securely comparing and merging cloud and local database files...",
+  "webdavStatusRunning": "Cloud Sync Running",
+  "webdavStatusRunningDesc": "An encrypted merge pipeline has been established with the cloud drive.\nLast sync: {time}",
+  "@webdavStatusRunningDesc": {"placeholders": {"time": {"type": "String"}}},
+  "webdavStatusException": "Sync Exception",
+  "webdavStatusExceptionDesc": "Network communication or cloud drive file lock conflict. We will retry automatically.",
+  "webdavStatusEnabled": "Cloud Sync Enabled",
+  "webdavStatusEnabledDesc": "Service ready. Last sync: {time}",
+  "@webdavStatusEnabledDesc": {"placeholders": {"time": {"type": "String"}}},
+  "webdavNeverSynced": "Never synced",
+  "webdavNeverSucceeded": "Never succeeded",
+  "webdavConflictPrompt": "Detected {count} sync conflict backup(s). It is recommended to resolve them immediately.",
+  "@webdavConflictPrompt": {"placeholders": {"count": {"type": "int"}}}
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3811,5 +3811,21 @@
   "webdavServerUrlEmptyError": "请输入 WebDAV 服务器地址",
   "webdavServerUrlInvalidError": "地址必须以 http:// 或 https:// 开头",
   "webdavUsernameEmptyError": "请输入用户名",
-  "webdavPasswordEmptyError": "请输入应用密码"
+  "webdavPasswordEmptyError": "请输入应用密码",
+  "webdavSyncStrategy": "同步策略",
+  "webdavStatusNotEnabled": "未启用云同步",
+  "webdavStatusNotEnabledDesc": "配置您的 WebDAV 服务，享受安全跨端多路同步。",
+  "webdavStatusSyncingDesc": "正在安全比对合并云端与本地数据库文件...",
+  "webdavStatusRunning": "云同步运行中",
+  "webdavStatusRunningDesc": "已与云端网盘建立加密合并管道。\n上次同步：{time}",
+  "@webdavStatusRunningDesc": {"placeholders": {"time": {"type": "String"}}},
+  "webdavStatusException": "同步出现异常",
+  "webdavStatusExceptionDesc": "网络通信或云盘文件锁冲突。我们将自动重试。",
+  "webdavStatusEnabled": "云同步已启用",
+  "webdavStatusEnabledDesc": "服务就绪。上次同步：{time}",
+  "@webdavStatusEnabledDesc": {"placeholders": {"time": {"type": "String"}}},
+  "webdavNeverSynced": "从未同步",
+  "webdavNeverSucceeded": "从未成功",
+  "webdavConflictPrompt": "检测到有 {count} 篇同步冲突备份，建议立即处理。",
+  "@webdavConflictPrompt": {"placeholders": {"count": {"type": "int"}}}
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3806,5 +3806,10 @@
   "webdavProviderNutstore": "坚果云 (Nutstore)",
   "webdavProviderCustom": "自定义 (Custom)",
   "webdavProviderNextcloud": "Nextcloud / ownCloud",
-  "webdavProviderInfinicloud": "InfiniCLOUD"
+  "webdavProviderInfinicloud": "InfiniCLOUD",
+  "webdavProviderConfig": "服务商配置",
+  "webdavServerUrlEmptyError": "请输入 WebDAV 服务器地址",
+  "webdavServerUrlInvalidError": "地址必须以 http:// 或 https:// 开头",
+  "webdavUsernameEmptyError": "请输入用户名",
+  "webdavPasswordEmptyError": "请输入应用密码"
 }

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -212,15 +212,21 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
     final l10n = AppLocalizations.of(context);
     final syncService = Provider.of<WebDAVSyncService>(context, listen: false);
 
-    final success = await syncService.testConnection(
-      _urlController.text,
-      _usernameController.text,
-      _passwordController.text,
-    );
-
-    setState(() {
-      _isTestingConnection = false;
-    });
+    bool success = false;
+    try {
+      success = await syncService.testConnection(
+        _urlController.text,
+        _usernameController.text,
+        _passwordController.text,
+      );
+    } catch (e, stackTrace) {
+      AppLogger.e('连接测试异常', error: e, stackTrace: stackTrace);
+      success = false;
+    } finally {
+      setState(() {
+        _isTestingConnection = false;
+      });
+    }
 
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -467,7 +473,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
 
                   // --- 自动同步策略 Switch ---
                   Text(
-                    '同步策略',
+                    l10n.webdavSyncStrategy,
                     style: theme.textTheme.titleMedium
                         ?.copyWith(color: theme.colorScheme.primary),
                   ),
@@ -658,36 +664,36 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
   /// 构建状态预览卡片
   Widget _buildStatusCard(
       WebDAVSyncService syncService, AppLocalizations l10n, ThemeData theme) {
-    String stateTitle = '未启用云同步';
-    String stateDesc = '配置您的 WebDAV 服务，享受安全跨端多路同步。';
+    String stateTitle = l10n.webdavStatusNotEnabled;
+    String stateDesc = l10n.webdavStatusNotEnabledDesc;
     IconData stateIcon = Icons.cloud_off_outlined;
     Color accentColor = theme.colorScheme.outline;
 
     if (syncService.enabled) {
       if (syncService.isSyncing) {
         stateTitle = l10n.webdavStatusSyncing;
-        stateDesc = '正在安全比对合并云端与本地数据库文件...';
+        stateDesc = l10n.webdavStatusSyncingDesc;
         stateIcon = Icons.sync;
         accentColor = theme.colorScheme.primary;
       } else if (syncService.syncStatus == WebDAVSyncStatus.success) {
-        stateTitle = '云同步运行中';
+        stateTitle = l10n.webdavStatusRunning;
         final relativeTime = syncService.lastSyncTime.isNotEmpty
             ? LWWUtils.formatTimestamp(syncService.lastSyncTime)
-            : '从未成功';
-        stateDesc = '已与云端网盘建立加密合并管道。\n上次同步：$relativeTime';
+            : l10n.webdavNeverSucceeded;
+        stateDesc = l10n.webdavStatusRunningDesc(relativeTime);
         stateIcon = Icons.cloud_done;
         accentColor = Colors.green.shade600;
       } else if (syncService.syncStatus == WebDAVSyncStatus.failed) {
-        stateTitle = '同步出现异常';
-        stateDesc = '网络通信或云盘文件锁冲突。我们将自动重试。';
+        stateTitle = l10n.webdavStatusException;
+        stateDesc = l10n.webdavStatusExceptionDesc;
         stateIcon = Icons.error_outline;
         accentColor = theme.colorScheme.error;
       } else {
-        stateTitle = '云同步已启用';
+        stateTitle = l10n.webdavStatusEnabled;
         final relativeTime = syncService.lastSyncTime.isNotEmpty
             ? LWWUtils.formatTimestamp(syncService.lastSyncTime)
-            : '从未同步';
-        stateDesc = '服务就绪。上次同步：$relativeTime';
+            : l10n.webdavNeverSynced;
+        stateDesc = l10n.webdavStatusEnabledDesc(relativeTime);
         stateIcon = Icons.cloud_queue;
         accentColor = theme.colorScheme.secondary;
       }
@@ -809,7 +815,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
-                        '检测到有 $_conflictNotesCount 篇同步冲突备份，建议立即处理。',
+                        l10n.webdavConflictPrompt(_conflictNotesCount),
                         style: Theme.of(context)
                             .textTheme
                             .labelMedium

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -102,10 +102,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
   }
 
   Future<void> _loadSecurePassword() async {
-    final password = await Provider.of<WebDAVSyncService>(
-      context,
-      listen: false,
-    ).getPassword();
+    final password =
+        await Provider.of<WebDAVSyncService>(context, listen: false)
+            .getPassword();
     if (password != null && mounted) {
       setState(() {
         _passwordController.text = password;
@@ -177,8 +176,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
       url = Uri.parse('https://infinicloud.com/en/support.html');
     } else {
       url = Uri.parse(
-        'https://google.com/search?q=how+to+setup+webdav+app+password',
-      );
+          'https://google.com/search?q=how+to+setup+webdav+app+password');
     }
 
     try {
@@ -227,12 +225,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(
-            success ? l10n.webdavTestSuccess : l10n.webdavTestFailed,
-          ),
-          backgroundColor: success
-              ? Colors.green.shade600
-              : Colors.red.shade600,
+          content:
+              Text(success ? l10n.webdavTestSuccess : l10n.webdavTestFailed),
+          backgroundColor:
+              success ? Colors.green.shade600 : Colors.red.shade600,
           behavior: SnackBarBehavior.floating,
         ),
       );
@@ -264,9 +260,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
 
   /// 触发手动同步
   Future<void> _triggerManualSync(
-    WebDAVSyncService syncService,
-    AppLocalizations l10n,
-  ) async {
+      WebDAVSyncService syncService, AppLocalizations l10n) async {
     await syncService.triggerSync();
     await _checkConflictNotes();
 
@@ -276,9 +270,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
         if (syncService.lastConflictCount > 0) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(
-                l10n.webdavConflictNotification(syncService.lastConflictCount),
-              ),
+              content: Text(l10n
+                  .webdavConflictNotification(syncService.lastConflictCount)),
               backgroundColor: Colors.amber.shade800,
               behavior: SnackBarBehavior.floating,
               action: SnackBarAction(
@@ -333,14 +326,15 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.webdavSyncTitle), elevation: 0),
+      appBar: AppBar(
+        title: Text(l10n.webdavSyncTitle),
+        elevation: 0,
+      ),
       body: Consumer<WebDAVSyncService>(
         builder: (context, syncService, _) {
           return SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 20.0,
-              vertical: 16.0,
-            ),
+            padding:
+                const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
             child: Form(
               key: _formKey,
               child: Column(
@@ -353,9 +347,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                   // --- 账号配置表单 Section ---
                   Text(
                     l10n.webdavProviderConfig,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      color: theme.colorScheme.primary,
-                    ),
+                    style: theme.textTheme.titleMedium
+                        ?.copyWith(color: theme.colorScheme.primary),
                   ),
                   const SizedBox(height: 12),
                   Card(
@@ -363,10 +356,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(16),
                       side: BorderSide(
-                        color: theme.colorScheme.outlineVariant.withValues(
-                          alpha: 0.5,
-                        ),
-                      ),
+                          color: theme.colorScheme.outlineVariant
+                              .withValues(alpha: 0.5)),
                     ),
                     child: Padding(
                       padding: const EdgeInsets.all(16.0),
@@ -381,21 +372,17 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                             ),
                             items: [
                               DropdownMenuItem(
-                                value: 'nutstore',
-                                child: Text(l10n.webdavProviderNutstore),
-                              ),
+                                  value: 'nutstore',
+                                  child: Text(l10n.webdavProviderNutstore)),
                               DropdownMenuItem(
-                                value: 'nextcloud',
-                                child: Text(l10n.webdavProviderNextcloud),
-                              ),
+                                  value: 'nextcloud',
+                                  child: Text(l10n.webdavProviderNextcloud)),
                               DropdownMenuItem(
-                                value: 'infinicloud',
-                                child: Text(l10n.webdavProviderInfinicloud),
-                              ),
+                                  value: 'infinicloud',
+                                  child: Text(l10n.webdavProviderInfinicloud)),
                               DropdownMenuItem(
-                                value: 'custom',
-                                child: Text(l10n.webdavProviderCustom),
-                              ),
+                                  value: 'custom',
+                                  child: Text(l10n.webdavProviderCustom)),
                             ],
                             onChanged: _onProviderChanged,
                           ),
@@ -404,8 +391,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                           // 2. 服务器 URL
                           TextFormField(
                             controller: _urlController,
-                            enabled:
-                                _selectedProvider == 'custom' ||
+                            enabled: _selectedProvider == 'custom' ||
                                 _selectedProvider == 'nextcloud',
                             decoration: InputDecoration(
                               labelText: l10n.webdavServerUrl,
@@ -433,8 +419,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                             ),
                             validator: (val) =>
                                 (val == null || val.trim().isEmpty)
-                                ? l10n.webdavUsernameEmptyError
-                                : null,
+                                    ? l10n.webdavUsernameEmptyError
+                                    : null,
                           ),
                           const SizedBox(height: 16),
 
@@ -449,14 +435,11 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                                 tooltip: _obscurePassword
                                     ? l10n.webdavShowPasswordTooltip
                                     : l10n.webdavHidePasswordTooltip,
-                                icon: Icon(
-                                  _obscurePassword
-                                      ? Icons.visibility_off
-                                      : Icons.visibility,
-                                ),
+                                icon: Icon(_obscurePassword
+                                    ? Icons.visibility_off
+                                    : Icons.visibility),
                                 onPressed: () => setState(
-                                  () => _obscurePassword = !_obscurePassword,
-                                ),
+                                    () => _obscurePassword = !_obscurePassword),
                               ),
                             ),
                             validator: (val) => (val == null || val.isEmpty)
@@ -485,9 +468,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                   // --- 自动同步策略 Switch ---
                   Text(
                     '同步策略',
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      color: theme.colorScheme.primary,
-                    ),
+                    style: theme.textTheme.titleMedium
+                        ?.copyWith(color: theme.colorScheme.primary),
                   ),
                   const SizedBox(height: 12),
                   Card(
@@ -495,10 +477,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(16),
                       side: BorderSide(
-                        color: theme.colorScheme.outlineVariant.withValues(
-                          alpha: 0.5,
-                        ),
-                      ),
+                          color: theme.colorScheme.outlineVariant
+                              .withValues(alpha: 0.5)),
                     ),
                     child: Column(
                       children: [
@@ -561,9 +541,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                         const Divider(height: 1),
                         SwitchListTile(
                           title: Text(l10n.webdavSyncNotesOnlyOnCellular),
-                          subtitle: Text(
-                            l10n.webdavSyncNotesOnlyOnCellularSubtitle,
-                          ),
+                          subtitle:
+                              Text(l10n.webdavSyncNotesOnlyOnCellularSubtitle),
                           value: syncService.syncNotesOnlyOnCellular,
                           onChanged: syncService.syncOnCellular
                               ? null
@@ -590,24 +569,20 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     children: [
                       Expanded(
                         child: OutlinedButton.icon(
-                          onPressed: _isTestingConnection
-                              ? null
-                              : _testConnection,
+                          onPressed:
+                              _isTestingConnection ? null : _testConnection,
                           icon: _isTestingConnection
                               ? const SizedBox(
                                   width: 18,
                                   height: 18,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                )
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2))
                               : const Icon(Icons.wifi_tethering),
                           label: Text(l10n.webdavTestConnection),
                           style: OutlinedButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 14),
                             shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
-                            ),
+                                borderRadius: BorderRadius.circular(12)),
                           ),
                         ),
                       ),
@@ -622,25 +597,19 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                                   width: 18,
                                   height: 18,
                                   child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                    color: Colors.white,
-                                  ),
-                                )
+                                      strokeWidth: 2, color: Colors.white))
                               : Icon(
                                   syncService.enabled
                                       ? Icons.save_outlined
                                       : Icons.cloud_sync_outlined,
                                 ),
-                          label: Text(
-                            syncService.enabled
-                                ? l10n.webdavSaveAndSync
-                                : l10n.webdavEnableSync,
-                          ),
+                          label: Text(syncService.enabled
+                              ? l10n.webdavSaveAndSync
+                              : l10n.webdavEnableSync),
                           style: ElevatedButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 14),
                             shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
-                            ),
+                                borderRadius: BorderRadius.circular(12)),
                             backgroundColor: theme.colorScheme.primary,
                             foregroundColor: theme.colorScheme.onPrimary,
                           ),
@@ -673,10 +642,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                         );
                       },
                       icon: const Icon(Icons.cloud_off, color: Colors.red),
-                      label: Text(
-                        l10n.webdavDisableSync,
-                        style: TextStyle(color: Colors.red),
-                      ),
+                      label: Text(l10n.webdavDisableSync,
+                          style: TextStyle(color: Colors.red)),
                     ),
                   ],
                 ],
@@ -690,10 +657,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
 
   /// 构建状态预览卡片
   Widget _buildStatusCard(
-    WebDAVSyncService syncService,
-    AppLocalizations l10n,
-    ThemeData theme,
-  ) {
+      WebDAVSyncService syncService, AppLocalizations l10n, ThemeData theme) {
     String stateTitle = '未启用云同步';
     String stateDesc = '配置您的 WebDAV 服务，享受安全跨端多路同步。';
     IconData stateIcon = Icons.cloud_off_outlined;
@@ -776,9 +740,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     children: [
                       Text(
                         stateTitle,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          color: theme.colorScheme.onSurface,
-                        ),
+                        style: theme.textTheme.titleMedium
+                            ?.copyWith(color: theme.colorScheme.onSurface),
                       ),
                       const SizedBox(height: 4),
                       Text(
@@ -799,14 +762,11 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                 syncService.lastSyncError.isNotEmpty) ...[
               const Divider(height: 24, thickness: 0.8),
               Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 10,
-                ),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
                 decoration: BoxDecoration(
-                  color: theme.colorScheme.errorContainer.withValues(
-                    alpha: 0.5,
-                  ),
+                  color:
+                      theme.colorScheme.errorContainer.withValues(alpha: 0.5),
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Row(
@@ -836,26 +796,23 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
             if (_hasConflicts) ...[
               const Divider(height: 24, thickness: 0.8),
               Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 8,
-                ),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                 decoration: BoxDecoration(
                   color: Colors.amber.shade500.withValues(alpha: 0.15),
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Row(
                   children: [
-                    Icon(
-                      Icons.warning_amber_rounded,
-                      color: Colors.amber.shade800,
-                      size: 20,
-                    ),
+                    Icon(Icons.warning_amber_rounded,
+                        color: Colors.amber.shade800, size: 20),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
                         '检测到有 $_conflictNotesCount 篇同步冲突备份，建议立即处理。',
-                        style: Theme.of(context).textTheme.labelMedium
+                        style: Theme.of(context)
+                            .textTheme
+                            .labelMedium
                             ?.copyWith(color: Colors.amber.shade900),
                       ),
                     ),
@@ -863,16 +820,12 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                       onPressed: _navigateToConflicts,
                       style: TextButton.styleFrom(
                         padding: const EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 4,
-                        ),
+                            horizontal: 12, vertical: 4),
                         minimumSize: Size.zero,
                         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                       ),
-                      child: Text(
-                        l10n.webdavGoToResolve,
-                        style: Theme.of(context).textTheme.titleSmall,
-                      ),
+                      child: Text(l10n.webdavGoToResolve,
+                          style: Theme.of(context).textTheme.titleSmall),
                     ),
                   ],
                 ),
@@ -890,8 +843,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                   label: Text(l10n.webdavSyncNow),
                   style: FilledButton.styleFrom(
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
+                        borderRadius: BorderRadius.circular(12)),
                     backgroundColor: theme.colorScheme.secondaryContainer,
                     foregroundColor: theme.colorScheme.onSecondaryContainer,
                   ),
@@ -930,23 +882,15 @@ class QuoteListViewByConflict extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(
-                  Icons.check_circle_outline,
-                  size: 64,
-                  color: Colors.green.shade500,
-                ),
+                Icon(Icons.check_circle_outline,
+                    size: 64, color: Colors.green.shade500),
                 const SizedBox(height: 16),
-                Text(
-                  AppLocalizations.of(context).webdavNoConflicts,
-                  style: theme.textTheme.titleMedium,
-                ),
+                Text(AppLocalizations.of(context).webdavNoConflicts,
+                    style: theme.textTheme.titleMedium),
                 const SizedBox(height: 8),
-                Text(
-                  AppLocalizations.of(context).webdavAllConflictsResolved,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.outline,
-                  ),
-                ),
+                Text(AppLocalizations.of(context).webdavAllConflictsResolved,
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: theme.colorScheme.outline)),
               ],
             ),
           );
@@ -961,8 +905,7 @@ class QuoteListViewByConflict extends StatelessWidget {
               margin: const EdgeInsets.only(bottom: 12),
               elevation: 1,
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
+                  borderRadius: BorderRadius.circular(12)),
               child: ListTile(
                 title: Text(
                   quote.content,
@@ -974,18 +917,13 @@ class QuoteListViewByConflict extends StatelessWidget {
                   padding: const EdgeInsets.only(top: 6.0),
                   child: Row(
                     children: [
-                      Icon(
-                        Icons.access_time,
-                        size: 14,
-                        color: theme.colorScheme.outline,
-                      ),
+                      Icon(Icons.access_time,
+                          size: 14, color: theme.colorScheme.outline),
                       const SizedBox(width: 4),
                       Text(
                         LWWUtils.formatTimestamp(quote.lastModified),
                         style: TextStyle(
-                          fontSize: 12,
-                          color: theme.colorScheme.outline,
-                        ),
+                            fontSize: 12, color: theme.colorScheme.outline),
                       ),
                     ],
                   ),
@@ -996,17 +934,15 @@ class QuoteListViewByConflict extends StatelessWidget {
                     // 一键恢复/移动：改分类至默认，使其移出冲突
                     IconButton(
                       icon: const Icon(Icons.check, color: Colors.green),
-                      tooltip: AppLocalizations.of(
-                        context,
-                      ).webdavConflictKeepTooltip,
+                      tooltip: AppLocalizations.of(context)
+                          .webdavConflictKeepTooltip,
                       onPressed: () async {
                         // 更新分类为默认（空）
                         final updated = quote.copyWith(
                           categoryId: '',
                           content: quote.content.replaceFirst('[冲突备份] ', ''),
-                          lastModified: DateTime.now()
-                              .toUtc()
-                              .toIso8601String(),
+                          lastModified:
+                              DateTime.now().toUtc().toIso8601String(),
                         );
                         await dbService.updateQuote(updated);
                         dbService.refreshQuotes();
@@ -1014,11 +950,8 @@ class QuoteListViewByConflict extends StatelessWidget {
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: Text(
-                                AppLocalizations.of(
-                                  context,
-                                ).webdavConflictKeepSuccess,
-                              ),
+                              content: Text(AppLocalizations.of(context)
+                                  .webdavConflictKeepSuccess),
                               behavior: SnackBarBehavior.floating,
                             ),
                           );
@@ -1028,9 +961,8 @@ class QuoteListViewByConflict extends StatelessWidget {
                     // 一键丢弃/删除
                     IconButton(
                       icon: const Icon(Icons.delete_outline, color: Colors.red),
-                      tooltip: AppLocalizations.of(
-                        context,
-                      ).webdavConflictDiscardTooltip,
+                      tooltip: AppLocalizations.of(context)
+                          .webdavConflictDiscardTooltip,
                       onPressed: () async {
                         // 永久删除该笔记
                         await dbService.permanentlyDeleteQuote(quote.id!);
@@ -1039,11 +971,8 @@ class QuoteListViewByConflict extends StatelessWidget {
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: Text(
-                                AppLocalizations.of(
-                                  context,
-                                ).webdavConflictDiscardSuccess,
-                              ),
+                              content: Text(AppLocalizations.of(context)
+                                  .webdavConflictDiscardSuccess),
                               behavior: SnackBarBehavior.floating,
                             ),
                           );

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -223,9 +223,11 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
       AppLogger.e('连接测试异常', error: e, stackTrace: stackTrace);
       success = false;
     } finally {
-      setState(() {
-        _isTestingConnection = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isTestingConnection = false;
+        });
+      }
     }
 
     if (mounted) {

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -102,9 +102,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
   }
 
   Future<void> _loadSecurePassword() async {
-    final password =
-        await Provider.of<WebDAVSyncService>(context, listen: false)
-            .getPassword();
+    final password = await Provider.of<WebDAVSyncService>(
+      context,
+      listen: false,
+    ).getPassword();
     if (password != null && mounted) {
       setState(() {
         _passwordController.text = password;
@@ -176,7 +177,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
       url = Uri.parse('https://infinicloud.com/en/support.html');
     } else {
       url = Uri.parse(
-          'https://google.com/search?q=how+to+setup+webdav+app+password');
+        'https://google.com/search?q=how+to+setup+webdav+app+password',
+      );
     }
 
     try {
@@ -225,10 +227,12 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content:
-              Text(success ? l10n.webdavTestSuccess : l10n.webdavTestFailed),
-          backgroundColor:
-              success ? Colors.green.shade600 : Colors.red.shade600,
+          content: Text(
+            success ? l10n.webdavTestSuccess : l10n.webdavTestFailed,
+          ),
+          backgroundColor: success
+              ? Colors.green.shade600
+              : Colors.red.shade600,
           behavior: SnackBarBehavior.floating,
         ),
       );
@@ -260,7 +264,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
 
   /// 触发手动同步
   Future<void> _triggerManualSync(
-      WebDAVSyncService syncService, AppLocalizations l10n) async {
+    WebDAVSyncService syncService,
+    AppLocalizations l10n,
+  ) async {
     await syncService.triggerSync();
     await _checkConflictNotes();
 
@@ -270,8 +276,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
         if (syncService.lastConflictCount > 0) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(l10n
-                  .webdavConflictNotification(syncService.lastConflictCount)),
+              content: Text(
+                l10n.webdavConflictNotification(syncService.lastConflictCount),
+              ),
               backgroundColor: Colors.amber.shade800,
               behavior: SnackBarBehavior.floating,
               action: SnackBarAction(
@@ -326,15 +333,14 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.webdavSyncTitle),
-        elevation: 0,
-      ),
+      appBar: AppBar(title: Text(l10n.webdavSyncTitle), elevation: 0),
       body: Consumer<WebDAVSyncService>(
         builder: (context, syncService, _) {
           return SingleChildScrollView(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 20.0,
+              vertical: 16.0,
+            ),
             child: Form(
               key: _formKey,
               child: Column(
@@ -346,9 +352,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
 
                   // --- 账号配置表单 Section ---
                   Text(
-                    '服务商配置',
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(color: theme.colorScheme.primary),
+                    l10n.webdavProviderConfig,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: theme.colorScheme.primary,
+                    ),
                   ),
                   const SizedBox(height: 12),
                   Card(
@@ -356,8 +363,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(16),
                       side: BorderSide(
-                          color: theme.colorScheme.outlineVariant
-                              .withValues(alpha: 0.5)),
+                        color: theme.colorScheme.outlineVariant.withValues(
+                          alpha: 0.5,
+                        ),
+                      ),
                     ),
                     child: Padding(
                       padding: const EdgeInsets.all(16.0),
@@ -372,17 +381,21 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                             ),
                             items: [
                               DropdownMenuItem(
-                                  value: 'nutstore',
-                                  child: Text(l10n.webdavProviderNutstore)),
+                                value: 'nutstore',
+                                child: Text(l10n.webdavProviderNutstore),
+                              ),
                               DropdownMenuItem(
-                                  value: 'nextcloud',
-                                  child: Text(l10n.webdavProviderNextcloud)),
+                                value: 'nextcloud',
+                                child: Text(l10n.webdavProviderNextcloud),
+                              ),
                               DropdownMenuItem(
-                                  value: 'infinicloud',
-                                  child: Text(l10n.webdavProviderInfinicloud)),
+                                value: 'infinicloud',
+                                child: Text(l10n.webdavProviderInfinicloud),
+                              ),
                               DropdownMenuItem(
-                                  value: 'custom',
-                                  child: Text(l10n.webdavProviderCustom)),
+                                value: 'custom',
+                                child: Text(l10n.webdavProviderCustom),
+                              ),
                             ],
                             onChanged: _onProviderChanged,
                           ),
@@ -391,7 +404,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                           // 2. 服务器 URL
                           TextFormField(
                             controller: _urlController,
-                            enabled: _selectedProvider == 'custom' ||
+                            enabled:
+                                _selectedProvider == 'custom' ||
                                 _selectedProvider == 'nextcloud',
                             decoration: InputDecoration(
                               labelText: l10n.webdavServerUrl,
@@ -399,11 +413,11 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                             ),
                             validator: (val) {
                               if (val == null || val.trim().isEmpty) {
-                                return '请输入 WebDAV 服务器地址';
+                                return l10n.webdavServerUrlEmptyError;
                               }
                               if (!val.trim().startsWith('http://') &&
                                   !val.trim().startsWith('https://')) {
-                                return '地址必须以 http:// 或 https:// 开头';
+                                return l10n.webdavServerUrlInvalidError;
                               }
                               return null;
                             },
@@ -419,8 +433,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                             ),
                             validator: (val) =>
                                 (val == null || val.trim().isEmpty)
-                                    ? '请输入用户名'
-                                    : null,
+                                ? l10n.webdavUsernameEmptyError
+                                : null,
                           ),
                           const SizedBox(height: 16),
 
@@ -435,15 +449,19 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                                 tooltip: _obscurePassword
                                     ? l10n.webdavShowPasswordTooltip
                                     : l10n.webdavHidePasswordTooltip,
-                                icon: Icon(_obscurePassword
-                                    ? Icons.visibility_off
-                                    : Icons.visibility),
+                                icon: Icon(
+                                  _obscurePassword
+                                      ? Icons.visibility_off
+                                      : Icons.visibility,
+                                ),
                                 onPressed: () => setState(
-                                    () => _obscurePassword = !_obscurePassword),
+                                  () => _obscurePassword = !_obscurePassword,
+                                ),
                               ),
                             ),
-                            validator: (val) =>
-                                (val == null || val.isEmpty) ? '请输入应用密码' : null,
+                            validator: (val) => (val == null || val.isEmpty)
+                                ? l10n.webdavPasswordEmptyError
+                                : null,
                           ),
 
                           // 引导链接文字
@@ -467,8 +485,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                   // --- 自动同步策略 Switch ---
                   Text(
                     '同步策略',
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(color: theme.colorScheme.primary),
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: theme.colorScheme.primary,
+                    ),
                   ),
                   const SizedBox(height: 12),
                   Card(
@@ -476,8 +495,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(16),
                       side: BorderSide(
-                          color: theme.colorScheme.outlineVariant
-                              .withValues(alpha: 0.5)),
+                        color: theme.colorScheme.outlineVariant.withValues(
+                          alpha: 0.5,
+                        ),
+                      ),
                     ),
                     child: Column(
                       children: [
@@ -540,8 +561,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                         const Divider(height: 1),
                         SwitchListTile(
                           title: Text(l10n.webdavSyncNotesOnlyOnCellular),
-                          subtitle:
-                              Text(l10n.webdavSyncNotesOnlyOnCellularSubtitle),
+                          subtitle: Text(
+                            l10n.webdavSyncNotesOnlyOnCellularSubtitle,
+                          ),
                           value: syncService.syncNotesOnlyOnCellular,
                           onChanged: syncService.syncOnCellular
                               ? null
@@ -568,20 +590,24 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     children: [
                       Expanded(
                         child: OutlinedButton.icon(
-                          onPressed:
-                              _isTestingConnection ? null : _testConnection,
+                          onPressed: _isTestingConnection
+                              ? null
+                              : _testConnection,
                           icon: _isTestingConnection
                               ? const SizedBox(
                                   width: 18,
                                   height: 18,
-                                  child:
-                                      CircularProgressIndicator(strokeWidth: 2))
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
                               : const Icon(Icons.wifi_tethering),
                           label: Text(l10n.webdavTestConnection),
                           style: OutlinedButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 14),
                             shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12)),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                           ),
                         ),
                       ),
@@ -596,19 +622,25 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                                   width: 18,
                                   height: 18,
                                   child: CircularProgressIndicator(
-                                      strokeWidth: 2, color: Colors.white))
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                )
                               : Icon(
                                   syncService.enabled
                                       ? Icons.save_outlined
                                       : Icons.cloud_sync_outlined,
                                 ),
-                          label: Text(syncService.enabled
-                              ? l10n.webdavSaveAndSync
-                              : l10n.webdavEnableSync),
+                          label: Text(
+                            syncService.enabled
+                                ? l10n.webdavSaveAndSync
+                                : l10n.webdavEnableSync,
+                          ),
                           style: ElevatedButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 14),
                             shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12)),
+                              borderRadius: BorderRadius.circular(12),
+                            ),
                             backgroundColor: theme.colorScheme.primary,
                             foregroundColor: theme.colorScheme.onPrimary,
                           ),
@@ -641,8 +673,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                         );
                       },
                       icon: const Icon(Icons.cloud_off, color: Colors.red),
-                      label: Text(l10n.webdavDisableSync,
-                          style: TextStyle(color: Colors.red)),
+                      label: Text(
+                        l10n.webdavDisableSync,
+                        style: TextStyle(color: Colors.red),
+                      ),
                     ),
                   ],
                 ],
@@ -656,7 +690,10 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
 
   /// 构建状态预览卡片
   Widget _buildStatusCard(
-      WebDAVSyncService syncService, AppLocalizations l10n, ThemeData theme) {
+    WebDAVSyncService syncService,
+    AppLocalizations l10n,
+    ThemeData theme,
+  ) {
     String stateTitle = '未启用云同步';
     String stateDesc = '配置您的 WebDAV 服务，享受安全跨端多路同步。';
     IconData stateIcon = Icons.cloud_off_outlined;
@@ -739,8 +776,9 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                     children: [
                       Text(
                         stateTitle,
-                        style: theme.textTheme.titleMedium
-                            ?.copyWith(color: theme.colorScheme.onSurface),
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: theme.colorScheme.onSurface,
+                        ),
                       ),
                       const SizedBox(height: 4),
                       Text(
@@ -761,11 +799,14 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                 syncService.lastSyncError.isNotEmpty) ...[
               const Divider(height: 24, thickness: 0.8),
               Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
                 decoration: BoxDecoration(
-                  color:
-                      theme.colorScheme.errorContainer.withValues(alpha: 0.5),
+                  color: theme.colorScheme.errorContainer.withValues(
+                    alpha: 0.5,
+                  ),
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Row(
@@ -795,23 +836,26 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
             if (_hasConflicts) ...[
               const Divider(height: 24, thickness: 0.8),
               Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
                 decoration: BoxDecoration(
                   color: Colors.amber.shade500.withValues(alpha: 0.15),
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Row(
                   children: [
-                    Icon(Icons.warning_amber_rounded,
-                        color: Colors.amber.shade800, size: 20),
+                    Icon(
+                      Icons.warning_amber_rounded,
+                      color: Colors.amber.shade800,
+                      size: 20,
+                    ),
                     const SizedBox(width: 8),
                     Expanded(
                       child: Text(
                         '检测到有 $_conflictNotesCount 篇同步冲突备份，建议立即处理。',
-                        style: Theme.of(context)
-                            .textTheme
-                            .labelMedium
+                        style: Theme.of(context).textTheme.labelMedium
                             ?.copyWith(color: Colors.amber.shade900),
                       ),
                     ),
@@ -819,12 +863,16 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                       onPressed: _navigateToConflicts,
                       style: TextButton.styleFrom(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 4),
+                          horizontal: 12,
+                          vertical: 4,
+                        ),
                         minimumSize: Size.zero,
                         tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                       ),
-                      child: Text(l10n.webdavGoToResolve,
-                          style: Theme.of(context).textTheme.titleSmall),
+                      child: Text(
+                        l10n.webdavGoToResolve,
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
                     ),
                   ],
                 ),
@@ -842,7 +890,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                   label: Text(l10n.webdavSyncNow),
                   style: FilledButton.styleFrom(
                     shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12)),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
                     backgroundColor: theme.colorScheme.secondaryContainer,
                     foregroundColor: theme.colorScheme.onSecondaryContainer,
                   ),
@@ -881,15 +930,23 @@ class QuoteListViewByConflict extends StatelessWidget {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(Icons.check_circle_outline,
-                    size: 64, color: Colors.green.shade500),
+                Icon(
+                  Icons.check_circle_outline,
+                  size: 64,
+                  color: Colors.green.shade500,
+                ),
                 const SizedBox(height: 16),
-                Text(AppLocalizations.of(context).webdavNoConflicts,
-                    style: theme.textTheme.titleMedium),
+                Text(
+                  AppLocalizations.of(context).webdavNoConflicts,
+                  style: theme.textTheme.titleMedium,
+                ),
                 const SizedBox(height: 8),
-                Text(AppLocalizations.of(context).webdavAllConflictsResolved,
-                    style: theme.textTheme.bodyMedium
-                        ?.copyWith(color: theme.colorScheme.outline)),
+                Text(
+                  AppLocalizations.of(context).webdavAllConflictsResolved,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
               ],
             ),
           );
@@ -904,7 +961,8 @@ class QuoteListViewByConflict extends StatelessWidget {
               margin: const EdgeInsets.only(bottom: 12),
               elevation: 1,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12)),
+                borderRadius: BorderRadius.circular(12),
+              ),
               child: ListTile(
                 title: Text(
                   quote.content,
@@ -916,13 +974,18 @@ class QuoteListViewByConflict extends StatelessWidget {
                   padding: const EdgeInsets.only(top: 6.0),
                   child: Row(
                     children: [
-                      Icon(Icons.access_time,
-                          size: 14, color: theme.colorScheme.outline),
+                      Icon(
+                        Icons.access_time,
+                        size: 14,
+                        color: theme.colorScheme.outline,
+                      ),
                       const SizedBox(width: 4),
                       Text(
                         LWWUtils.formatTimestamp(quote.lastModified),
                         style: TextStyle(
-                            fontSize: 12, color: theme.colorScheme.outline),
+                          fontSize: 12,
+                          color: theme.colorScheme.outline,
+                        ),
                       ),
                     ],
                   ),
@@ -933,15 +996,17 @@ class QuoteListViewByConflict extends StatelessWidget {
                     // 一键恢复/移动：改分类至默认，使其移出冲突
                     IconButton(
                       icon: const Icon(Icons.check, color: Colors.green),
-                      tooltip: AppLocalizations.of(context)
-                          .webdavConflictKeepTooltip,
+                      tooltip: AppLocalizations.of(
+                        context,
+                      ).webdavConflictKeepTooltip,
                       onPressed: () async {
                         // 更新分类为默认（空）
                         final updated = quote.copyWith(
                           categoryId: '',
                           content: quote.content.replaceFirst('[冲突备份] ', ''),
-                          lastModified:
-                              DateTime.now().toUtc().toIso8601String(),
+                          lastModified: DateTime.now()
+                              .toUtc()
+                              .toIso8601String(),
                         );
                         await dbService.updateQuote(updated);
                         dbService.refreshQuotes();
@@ -949,8 +1014,11 @@ class QuoteListViewByConflict extends StatelessWidget {
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: Text(AppLocalizations.of(context)
-                                  .webdavConflictKeepSuccess),
+                              content: Text(
+                                AppLocalizations.of(
+                                  context,
+                                ).webdavConflictKeepSuccess,
+                              ),
                               behavior: SnackBarBehavior.floating,
                             ),
                           );
@@ -960,8 +1028,9 @@ class QuoteListViewByConflict extends StatelessWidget {
                     // 一键丢弃/删除
                     IconButton(
                       icon: const Icon(Icons.delete_outline, color: Colors.red),
-                      tooltip: AppLocalizations.of(context)
-                          .webdavConflictDiscardTooltip,
+                      tooltip: AppLocalizations.of(
+                        context,
+                      ).webdavConflictDiscardTooltip,
                       onPressed: () async {
                         // 永久删除该笔记
                         await dbService.permanentlyDeleteQuote(quote.id!);
@@ -970,8 +1039,11 @@ class QuoteListViewByConflict extends StatelessWidget {
                         if (context.mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
-                              content: Text(AppLocalizations.of(context)
-                                  .webdavConflictDiscardSuccess),
+                              content: Text(
+                                AppLocalizations.of(
+                                  context,
+                                ).webdavConflictDiscardSuccess,
+                              ),
                               behavior: SnackBarBehavior.floating,
                             ),
                           );


### PR DESCRIPTION
**提取硬编码:** 提取了 WebDAV 同步页面的表单错误提示和标题。
**中英对照:**
- 服务商配置 -> Provider Configuration
- 请输入 WebDAV 服务器地址 -> Please enter WebDAV server address
- 地址必须以 http:// 或 https:// 开头 -> Address must start with http:// or https://
- 请输入用户名 -> Please enter username
- 请输入应用密码 -> Please enter app password

---
*PR created automatically by Jules for task [10561114304893522927](https://jules.google.com/task/10561114304893522927) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
提取并本地化 WebDAV 同步页的表单、状态卡片、同步策略与冲突提示文案，补齐英文翻译并替换硬编码。增强连接测试的异常处理与组件安全，提升稳定性。

- **Refactors**
  - 在 `app_zh.arb` 与 `app_en.arb` 新增表单校验、同步状态与冲突提示等词条（含 `{time}`、`{count}`），页面全面改用 `l10n`；更新 `.jules/translator.md`。

- **Bug Fixes**
  - 连接测试加入异常捕获与日志记录，在 `finally` 复位加载态，并加 `mounted` 判断，避免卸载后 `setState` 报错。

<sup>Written for commit f6d29ba36aef67ae599efd28a15aacece251ea10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 补充 WebDAV 同步策略，以及云端同步状态（含时间占位）与同步冲突提示的多语言文案。
* **优化**
  * WebDAV 配置表单与状态卡片的可见文本改为统一本地化资源，完善服务商配置标题与中英文显示。
  * 加强服务器地址/用户名/应用密码的必填与格式校验提示。
* **修复**
  * 连接测试失败时确保加载状态正确复位，并记录错误信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->