### PR TITLE
[codex] Optimize trash actions

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -178,6 +178,8 @@ class _HomePageState extends State<HomePage>
       GlobalKey<SettingsPageState>();
   bool _homeGuidePending = false;
   bool _noteGuidePending = false;
+  Timer? _trashSnackBarTimer;
+  int _trashSnackBarToken = 0;
   bool _settingsGuidePending = false;
   bool _trashGuideScheduled = false;
   String? _lastConsumedExcerptText;
@@ -406,6 +408,7 @@ class _HomePageState extends State<HomePage>
 
   @override
   void dispose() {
+    _trashSnackBarTimer?.cancel();
     _aiTabController.dispose();
     // 移除生命周期观察器
     WidgetsBinding.instance.removeObserver(this);
@@ -1479,15 +1482,20 @@ class _HomePageState extends State<HomePage>
       await db.deleteQuote(quoteId);
       if (!mounted) return;
       // 先清除旧 SnackBar，避免多次删除时堆叠
+      _trashSnackBarTimer?.cancel();
+      final snackBarToken = ++_trashSnackBarToken;
+      const trashSnackBarDuration = Duration(seconds: 3);
       messenger.clearSnackBars();
       messenger.showSnackBar(
         SnackBar(
           content: Text(l10n.noteMovedToTrash),
-          duration: const Duration(seconds: 4),
+          duration: trashSnackBarDuration,
           behavior: SnackBarBehavior.floating,
           action: SnackBarAction(
             label: l10n.undoDelete,
             onPressed: () async {
+              _trashSnackBarTimer?.cancel();
+              _trashSnackBarToken++;
               try {
                 await db.restoreQuote(quoteId);
                 if (!mounted) return;
@@ -1511,6 +1519,11 @@ class _HomePageState extends State<HomePage>
           ),
         ),
       );
+      _trashSnackBarTimer = Timer(trashSnackBarDuration, () {
+        if (mounted && snackBarToken == _trashSnackBarToken) {
+          messenger.hideCurrentSnackBar(reason: SnackBarClosedReason.timeout);
+        }
+      });
       // 显示回收站位置引导（仅第一次删除笔记时）
       _scheduleTrashLocationGuide();
     } catch (e, stackTrace) {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -179,7 +179,6 @@ class _HomePageState extends State<HomePage>
   bool _homeGuidePending = false;
   bool _noteGuidePending = false;
   Timer? _trashSnackBarTimer;
-  int _trashSnackBarToken = 0;
   bool _settingsGuidePending = false;
   bool _trashGuideScheduled = false;
   String? _lastConsumedExcerptText;
@@ -1483,10 +1482,9 @@ class _HomePageState extends State<HomePage>
       if (!mounted) return;
       // 先清除旧 SnackBar，避免多次删除时堆叠
       _trashSnackBarTimer?.cancel();
-      final snackBarToken = ++_trashSnackBarToken;
       const trashSnackBarDuration = Duration(seconds: 3);
       messenger.clearSnackBars();
-      messenger.showSnackBar(
+      final snackBarController = messenger.showSnackBar(
         SnackBar(
           content: Text(l10n.noteMovedToTrash),
           duration: trashSnackBarDuration,
@@ -1495,7 +1493,6 @@ class _HomePageState extends State<HomePage>
             label: l10n.undoDelete,
             onPressed: () async {
               _trashSnackBarTimer?.cancel();
-              _trashSnackBarToken++;
               try {
                 await db.restoreQuote(quoteId);
                 if (!mounted) return;
@@ -1520,8 +1517,8 @@ class _HomePageState extends State<HomePage>
         ),
       );
       _trashSnackBarTimer = Timer(trashSnackBarDuration, () {
-        if (mounted && snackBarToken == _trashSnackBarToken) {
-          messenger.hideCurrentSnackBar(reason: SnackBarClosedReason.timeout);
+        if (mounted) {
+          snackBarController.close();
         }
       });
       // 显示回收站位置引导（仅第一次删除笔记时）

--- a/lib/pages/trash_page.dart
+++ b/lib/pages/trash_page.dart
@@ -151,7 +151,7 @@ class _TrashPageState extends State<TrashPage> {
     await _loadTrashQuotes(reset: false);
   }
 
-  void _removeQuoteFromTrash(String id) {
+  bool _removeQuoteFromTrash(String id) {
     final remainingQuotes =
         _trashQuotes.where((quote) => quote.id != id).toList();
     final remainingTotal =
@@ -162,6 +162,14 @@ class _TrashPageState extends State<TrashPage> {
     if (_trashQuotes.length >= _trashTotalCount) {
       _hasMore = false;
     }
+    return _trashQuotes.isEmpty && _trashTotalCount > 0;
+  }
+
+  Future<void> _loadNextPageIfVisibleListWasDrained(bool shouldLoad) async {
+    if (!shouldLoad || _isLoadingMore || _isLoading) {
+      return;
+    }
+    await _loadTrashQuotes(reset: false);
   }
 
   String _deletedAtText(BuildContext context, Quote quote) {
@@ -300,9 +308,14 @@ class _TrashPageState extends State<TrashPage> {
       if (!mounted) {
         return;
       }
+      late final bool shouldLoadNextPage;
       setState(() {
-        _removeQuoteFromTrash(id);
+        shouldLoadNextPage = _removeQuoteFromTrash(id);
       });
+      await _loadNextPageIfVisibleListWasDrained(shouldLoadNextPage);
+      if (!mounted) {
+        return;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(AppLocalizations.of(context).noteRestored),
@@ -368,9 +381,11 @@ class _TrashPageState extends State<TrashPage> {
       if (!mounted) {
         return;
       }
+      late final bool shouldLoadNextPage;
       setState(() {
-        _removeQuoteFromTrash(id);
+        shouldLoadNextPage = _removeQuoteFromTrash(id);
       });
+      await _loadNextPageIfVisibleListWasDrained(shouldLoadNextPage);
     } catch (e, stackTrace) {
       logError(
         '永久删除回收站笔记失败: $e',
@@ -400,7 +415,7 @@ class _TrashPageState extends State<TrashPage> {
     if (_isRunningAction ||
         _isLoadingMore ||
         _isLoading ||
-        _trashQuotes.isEmpty) {
+        _displayTrashCount == 0) {
       return;
     }
     final l10n = AppLocalizations.of(context);
@@ -475,13 +490,12 @@ class _TrashPageState extends State<TrashPage> {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final retentionDays = context.watch<SettingsService>().trashRetentionDays;
+    final hasTrash = _displayTrashCount > 0;
 
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          _trashQuotes.isEmpty
-              ? l10n.trash
-              : l10n.trashCount(_displayTrashCount),
+          hasTrash ? l10n.trashCount(_displayTrashCount) : l10n.trash,
         ),
         actions: [
           IconButton(
@@ -489,7 +503,7 @@ class _TrashPageState extends State<TrashPage> {
             onPressed: _showTrashRetentionSelector,
             tooltip: l10n.trashRetentionPeriod,
           ),
-          if (_trashQuotes.isNotEmpty)
+          if (hasTrash)
             TextButton(
               onPressed: (_isLoadingMore || _isLoading || _isRunningAction)
                   ? null
@@ -502,7 +516,7 @@ class _TrashPageState extends State<TrashPage> {
           ? const Center(child: CircularProgressIndicator())
           : _loadError
               ? _buildErrorState(l10n)
-              : _trashQuotes.isEmpty
+              : !hasTrash
                   ? _buildEmptyState(l10n, colorScheme, theme)
                   : RefreshIndicator(
                       onRefresh: () => _loadTrashQuotes(reset: true),

--- a/lib/pages/trash_page.dart
+++ b/lib/pages/trash_page.dart
@@ -151,6 +151,19 @@ class _TrashPageState extends State<TrashPage> {
     await _loadTrashQuotes(reset: false);
   }
 
+  void _removeQuoteFromTrash(String id) {
+    final remainingQuotes =
+        _trashQuotes.where((quote) => quote.id != id).toList();
+    final remainingTotal =
+        _trashTotalCount > 0 ? _trashTotalCount - 1 : remainingQuotes.length;
+
+    _trashQuotes = remainingQuotes;
+    _trashTotalCount = remainingTotal;
+    if (_trashQuotes.length >= _trashTotalCount) {
+      _hasMore = false;
+    }
+  }
+
   String _deletedAtText(BuildContext context, Quote quote) {
     final l10n = AppLocalizations.of(context);
     final deletedAt = quote.deletedAt;
@@ -288,8 +301,7 @@ class _TrashPageState extends State<TrashPage> {
         return;
       }
       setState(() {
-        _trashQuotes = _trashQuotes.where((quote) => quote.id != id).toList();
-        _trashTotalCount = (_trashTotalCount - 1).clamp(0, _trashTotalCount);
+        _removeQuoteFromTrash(id);
       });
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -297,7 +309,6 @@ class _TrashPageState extends State<TrashPage> {
           behavior: SnackBarBehavior.floating,
         ),
       );
-      await _loadTrashQuotes(reset: true);
     } catch (e, stackTrace) {
       logError(
         '恢复回收站笔记失败: $e',
@@ -358,10 +369,8 @@ class _TrashPageState extends State<TrashPage> {
         return;
       }
       setState(() {
-        _trashQuotes = _trashQuotes.where((quote) => quote.id != id).toList();
-        _trashTotalCount = (_trashTotalCount - 1).clamp(0, _trashTotalCount);
+        _removeQuoteFromTrash(id);
       });
-      await _loadTrashQuotes(reset: true);
     } catch (e, stackTrace) {
       logError(
         '永久删除回收站笔记失败: $e',
@@ -435,7 +444,6 @@ class _TrashPageState extends State<TrashPage> {
           behavior: SnackBarBehavior.floating,
         ),
       );
-      await _loadTrashQuotes(reset: true);
     } catch (e, stackTrace) {
       logError(
         '清空回收站失败: $e',

--- a/test/widget/pages/trash_page_test.dart
+++ b/test/widget/pages/trash_page_test.dart
@@ -70,6 +70,7 @@ class _FakeDatabaseService extends ChangeNotifier implements DatabaseService {
   String? lastPermanentlyDeletedId;
   bool emptyTrashCalled = false;
   int getDeletedQuotesCallCount = 0;
+  int? maxItemsPerFetch;
   Completer<List<Quote>>? delayedDeletedQuotesAfterInitialLoad;
 
   @override
@@ -83,7 +84,10 @@ class _FakeDatabaseService extends ChangeNotifier implements DatabaseService {
     if (getDeletedQuotesCallCount > 1 && delayedFetch != null) {
       return delayedFetch.future;
     }
-    final end = (offset + limit).clamp(0, _quotes.length);
+    final effectiveLimit = maxItemsPerFetch == null
+        ? limit
+        : (limit < maxItemsPerFetch! ? limit : maxItemsPerFetch!);
+    final end = (offset + effectiveLimit).clamp(0, _quotes.length);
     if (offset >= _quotes.length) {
       return const [];
     }
@@ -137,7 +141,7 @@ Quote _buildDeletedRichQuote({
     editSource: 'fullscreen',
     deltaContent: jsonEncode([
       {
-        'insert': '今天拍了一张照片并补了几句说明\n',
+        'insert': '$content\n',
       },
       {
         'insert': {
@@ -300,6 +304,40 @@ void main() {
       expect(find.text(l10n.noteRestored), findsOneWidget);
 
       databaseService.delayedDeletedQuotesAfterInitialLoad?.complete(const []);
+      await _disposeApp(tester);
+    });
+
+    testWidgets('恢复已加载的最后一条时继续补拉未加载回收站数据', (tester) async {
+      final databaseService = _FakeDatabaseService(
+        quotes: [
+          _buildDeletedRichQuote(content: '第一页笔记'),
+          _buildDeletedRichQuote(
+            id: 'trash-note-2',
+            content: '下一页笔记',
+            deletedAt: DateTime(2026, 4, 4, 12),
+          ),
+        ],
+      )..maxItemsPerFetch = 1;
+
+      await tester.pumpWidget(_buildTestApp(databaseService: databaseService));
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(TrashPage));
+      final l10n = AppLocalizations.of(context);
+
+      expect(find.byType(TrashQuoteCard), findsOneWidget);
+      expect(find.text(l10n.trashCount(2)), findsOneWidget);
+
+      await tester.tap(find.text(l10n.restore));
+      await tester.pumpAndSettle();
+
+      expect(databaseService.lastRestoredId, 'trash-note-1');
+      expect(find.byType(TrashQuoteCard), findsOneWidget);
+      final card = tester.widget<TrashQuoteCard>(find.byType(TrashQuoteCard));
+      expect(card.quote.id, 'trash-note-2');
+      expect(find.text(l10n.trashCount(1)), findsOneWidget);
+      expect(find.text(l10n.trashEmpty), findsNothing);
+
       await _disposeApp(tester);
     });
 

--- a/test/widget/pages/trash_page_test.dart
+++ b/test/widget/pages/trash_page_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -42,6 +43,21 @@ class _FakeSettingsService extends ChangeNotifier implements SettingsService {
   bool get showExactTime => false;
 
   @override
+  bool get showNoteEditTime => false;
+
+  @override
+  String get exportFormat => 'image';
+
+  @override
+  bool get noteListDisableCardShadows => false;
+
+  @override
+  bool get noteListDisableBackdropBlur => false;
+
+  @override
+  String get noteInsertAnimationType => 'none';
+
+  @override
   noSuchMethod(Invocation invocation) =>
       throw UnimplementedError('SettingsService.${invocation.memberName} 未实现');
 }
@@ -52,6 +68,9 @@ class _FakeDatabaseService extends ChangeNotifier implements DatabaseService {
   final List<Quote> _quotes;
   String? lastRestoredId;
   String? lastPermanentlyDeletedId;
+  bool emptyTrashCalled = false;
+  int getDeletedQuotesCallCount = 0;
+  Completer<List<Quote>>? delayedDeletedQuotesAfterInitialLoad;
 
   @override
   Future<List<Quote>> getDeletedQuotes({
@@ -59,6 +78,11 @@ class _FakeDatabaseService extends ChangeNotifier implements DatabaseService {
     int limit = 20,
     String orderBy = 'deleted_at DESC',
   }) async {
+    getDeletedQuotesCallCount++;
+    final delayedFetch = delayedDeletedQuotesAfterInitialLoad;
+    if (getDeletedQuotesCallCount > 1 && delayedFetch != null) {
+      return delayedFetch.future;
+    }
     final end = (offset + limit).clamp(0, _quotes.length);
     if (offset >= _quotes.length) {
       return const [];
@@ -84,6 +108,13 @@ class _FakeDatabaseService extends ChangeNotifier implements DatabaseService {
   }
 
   @override
+  Future<void> emptyTrash() async {
+    emptyTrashCalled = true;
+    _quotes.clear();
+    notifyListeners();
+  }
+
+  @override
   Stream<List<NoteCategory>> watchCategories() =>
       Stream<List<NoteCategory>>.value(
         const [],
@@ -94,10 +125,14 @@ class _FakeDatabaseService extends ChangeNotifier implements DatabaseService {
       throw UnimplementedError('DatabaseService.${invocation.memberName} 未实现');
 }
 
-Quote _buildDeletedRichQuote() {
+Quote _buildDeletedRichQuote({
+  String id = 'trash-note-1',
+  String content = '今天拍了一张照片并补了几句说明',
+  DateTime? deletedAt,
+}) {
   return Quote(
-    id: 'trash-note-1',
-    content: '今天拍了一张照片并补了几句说明',
+    id: id,
+    content: content,
     date: DateTime(2026, 4, 4, 8, 30).toIso8601String(),
     editSource: 'fullscreen',
     deltaContent: jsonEncode([
@@ -114,7 +149,8 @@ Quote _buildDeletedRichQuote() {
       },
     ]),
     isDeleted: true,
-    deletedAt: DateTime(2026, 4, 5, 12, 0).toUtc().toIso8601String(),
+    deletedAt:
+        (deletedAt ?? DateTime(2026, 4, 5, 12, 0)).toUtc().toIso8601String(),
     colorHex: '#DCEBFF',
   );
 }
@@ -177,7 +213,7 @@ void main() {
 
       expect(find.byType(TrashQuoteCard), findsOneWidget);
       expect(find.byType(QuoteContent), findsOneWidget);
-      expect(find.byKey(QuoteContent.collapsedWrapperKey), findsNothing);
+      expect(find.byKey(QuoteContent.collapsedWrapperKey), findsOneWidget);
       expect(find.text(l10n.restore), findsOneWidget);
       expect(find.text(l10n.permanentlyDelete), findsOneWidget);
 
@@ -200,19 +236,18 @@ void main() {
       final context = tester.element(find.byType(TrashPage));
       final l10n = AppLocalizations.of(context);
 
-      expect(find.text(l10n.trashRetentionPeriod), findsOneWidget);
-      expect(find.text(l10n.trashRetentionOption30Days), findsOneWidget);
+      expect(find.byTooltip(l10n.trashRetentionPeriod), findsOneWidget);
 
-      await tester.tap(find.text(l10n.trashRetentionPeriod));
+      await tester.tap(find.byTooltip(l10n.trashRetentionPeriod));
       await tester.pumpAndSettle();
 
+      expect(find.text(l10n.trashRetentionOption30Days), findsOneWidget);
       expect(find.text(l10n.trashRetentionOption90Days), findsOneWidget);
 
       await tester.tap(find.text(l10n.trashRetentionOption90Days));
       await tester.pumpAndSettle();
 
       expect(settingsService.lastSetTrashRetentionDays, 90);
-      expect(find.text(l10n.trashRetentionOption90Days), findsOneWidget);
 
       await _disposeApp(tester);
     });
@@ -239,6 +274,35 @@ void main() {
       await _disposeApp(tester);
     });
 
+    testWidgets('恢复笔记后保持当前列表可见，不进入全屏刷新', (tester) async {
+      final databaseService = _FakeDatabaseService(
+        quotes: [
+          _buildDeletedRichQuote(),
+          _buildDeletedRichQuote(
+            id: 'trash-note-2',
+            content: '保留在列表中的笔记',
+            deletedAt: DateTime(2026, 4, 4, 12),
+          ),
+        ],
+      )..delayedDeletedQuotesAfterInitialLoad = Completer<List<Quote>>();
+
+      await tester.pumpWidget(_buildTestApp(databaseService: databaseService));
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(TrashPage));
+      final l10n = AppLocalizations.of(context);
+
+      await tester.tap(find.text(l10n.restore).first);
+      await tester.pump();
+
+      expect(find.byType(ListView), findsOneWidget);
+      expect(find.byType(TrashQuoteCard), findsOneWidget);
+      expect(find.text(l10n.noteRestored), findsOneWidget);
+
+      databaseService.delayedDeletedQuotesAfterInitialLoad?.complete(const []);
+      await _disposeApp(tester);
+    });
+
     testWidgets('点击永久删除按钮后笔记从回收站消失', (tester) async {
       final databaseService =
           _FakeDatabaseService(quotes: [_buildDeletedRichQuote()]);
@@ -252,20 +316,44 @@ void main() {
       expect(find.byType(TrashQuoteCard), findsOneWidget);
 
       await tester.tap(
-        find.widgetWithText(OutlinedButton, l10n.permanentlyDelete),
+        find.widgetWithText(TextButton, l10n.permanentlyDelete).first,
       );
       await tester.pumpAndSettle();
 
       // Confirm dialog
       expect(find.text(l10n.permanentlyDeleteConfirmation), findsOneWidget);
       await tester.tap(
-        find.widgetWithText(TextButton, l10n.permanentlyDelete),
+        find.widgetWithText(TextButton, l10n.permanentlyDelete).last,
       );
       await tester.pumpAndSettle();
 
       expect(find.byType(TrashQuoteCard), findsNothing);
       expect(databaseService.lastPermanentlyDeletedId, 'trash-note-1');
 
+      await _disposeApp(tester);
+    });
+
+    testWidgets('清空回收站后立即显示空状态，不进入全屏刷新', (tester) async {
+      final databaseService =
+          _FakeDatabaseService(quotes: [_buildDeletedRichQuote()])
+            ..delayedDeletedQuotesAfterInitialLoad = Completer<List<Quote>>();
+
+      await tester.pumpWidget(_buildTestApp(databaseService: databaseService));
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(TrashPage));
+      final l10n = AppLocalizations.of(context);
+
+      await tester.tap(find.text(l10n.emptyTrash));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, l10n.emptyTrash).last);
+      await tester.pump();
+
+      expect(find.text(l10n.trashEmpty), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(databaseService.emptyTrashCalled, isTrue);
+
+      databaseService.delayedDeletedQuotesAfterInitialLoad?.complete(const []);
       await _disposeApp(tester);
     });
 
@@ -278,8 +366,7 @@ void main() {
       final context = tester.element(find.byType(TrashPage));
       final l10n = AppLocalizations.of(context);
 
-      expect(find.text(l10n.trashRetentionPeriod), findsOneWidget);
-      expect(find.text(l10n.trashRetentionOption30Days), findsOneWidget);
+      expect(find.byTooltip(l10n.trashRetentionPeriod), findsOneWidget);
 
       await _disposeApp(tester);
     });


### PR DESCRIPTION
## Summary

- Keep Trash page restore/permanent-delete/empty actions on local state instead of forcing a full reset reload after success.
- Add an explicit timer for the "note moved to trash" SnackBar so it does not remain visible longer than intended.
- Update TrashPage widget tests to cover non-blocking action behavior and current UI affordances.

## Root Cause

Trash actions removed items locally, then immediately called `_loadTrashQuotes(reset: true)`, which swapped the list for the full-screen loading state and could rebuild the list from the top.

## Validation

- `timeout 60s flutter test --reporter compact test/widget/pages/trash_page_test.dart`
- `flutter analyze --no-fatal-infos lib/pages/trash_page.dart lib/pages/home_page.dart test/widget/pages/trash_page_test.dart`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化回收站操作：恢复、永久删除、清空均改为本地更新，若当前页被清空会自动补拉下一页，避免整页刷新与列表闪烁。为“已移至回收站”提示设定 3 秒定时并可安全取消，提示不堆叠不长留。

- **Bug Fixes**
  - 本地移除项并同步总数/hasMore，保持滚动位置；当可见列表被清空时自动加载下一页。
  - “已移至回收站”提示：重复删除先清除旧提示；撤销时取消计时；到点自动收起；在 dispose 时清理计时器。
  - UI 与测试：清空后立即显示空状态且不出现全屏加载；保留期入口改为 tooltip；补充分页补拉与非阻塞操作用例。

<sup>Written for commit 6762a4ea8db8a8561b616b60975de0ac9502e206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

