### PR TITLE
[codex] Improve smart push note selection

### DIFF
--- a/lib/services/smart_push/smart_push_content.dart
+++ b/lib/services/smart_push/smart_push_content.dart
@@ -21,6 +21,8 @@ extension SmartPushContentSelection on SmartPushService {
     AppLogger.w(
       '智能选择：数据库查询完成 (总笔记数: ${allNotes.length})',
     );
+    final todayPushedIds = _getTodayPushedNoteIds();
+    final contentTypeScores = await _analytics.getContentTypeScores();
 
     if (allNotes.isEmpty) {
       // 没有任何笔记时，回退到每日一言
@@ -42,6 +44,7 @@ extension SmartPushContentSelection on SmartPushService {
       candidates: allNotes,
       now: now,
       recentlyPushedIds: _settings.recentlyPushedNoteIds.toSet(),
+      todayPushedIds: todayPushedIds,
     );
 
     SmartPushFilterResult filterResult;
@@ -85,13 +88,20 @@ extension SmartPushContentSelection on SmartPushService {
       availableContent['yearAgoToday'] = _ContentCandidate(
         note: note,
         title: pickYearAgoTodayTitle(_random, years),
-        priority: 100, // 最高优先级
+        priority: scoreSmartPushCandidate(
+          basePriority: 100,
+          note: note,
+          contentTypeScore: contentTypeScores['yearAgoToday'] ?? 0.5,
+        ).round(),
       );
     }
 
     // 2. 相同地点的笔记（动态 priority）
     if (sameLocationNotes.isNotEmpty) {
-      final note = _selectUnpushedNote(sameLocationNotes);
+      final note = _selectUnpushedNote(
+        sameLocationNotes,
+        strictExcludedIds: todayPushedIds,
+      );
       if (note != null) {
         final locationPriority = calcLocationPriority(
           sameLocationNotes.length,
@@ -100,7 +110,11 @@ extension SmartPushContentSelection on SmartPushService {
         availableContent['sameLocation'] = _ContentCandidate(
           note: note,
           title: pickSameLocationTitle(_random),
-          priority: locationPriority,
+          priority: scoreSmartPushCandidate(
+            basePriority: locationPriority,
+            note: note,
+            contentTypeScore: contentTypeScores['sameLocation'] ?? 0.5,
+          ).round(),
         );
       }
     }
@@ -120,27 +134,43 @@ extension SmartPushContentSelection on SmartPushService {
       availableContent['monthAgoToday'] = _ContentCandidate(
         note: note,
         title: title,
-        priority: 70,
+        priority: scoreSmartPushCandidate(
+          basePriority: 70,
+          note: note,
+          contentTypeScore: contentTypeScores['monthAgoToday'] ?? 0.5,
+        ).round(),
       );
     }
 
     // 4. 上周今日
     if (filterResult.selectedWeekAgo != null) {
+      final note = filterResult.selectedWeekAgo!;
       availableContent['weekAgoToday'] = _ContentCandidate(
-        note: filterResult.selectedWeekAgo!,
+        note: note,
         title: pickWeekAgoTodayTitle(_random),
-        priority: 55,
+        priority: scoreSmartPushCandidate(
+          basePriority: 55,
+          note: note,
+          contentTypeScore: contentTypeScores['weekAgoToday'] ?? 0.5,
+        ).round(),
       );
     }
 
     // 5. 相同天气的笔记
     if (sameWeatherNotes.isNotEmpty) {
-      final note = _selectUnpushedNote(sameWeatherNotes);
+      final note = _selectUnpushedNote(
+        sameWeatherNotes,
+        strictExcludedIds: todayPushedIds,
+      );
       if (note != null) {
         availableContent['sameWeather'] = _ContentCandidate(
           note: note,
           title: '🌤️ 同样的天气',
-          priority: 40,
+          priority: scoreSmartPushCandidate(
+            basePriority: 40,
+            note: note,
+            contentTypeScore: contentTypeScores['sameWeather'] ?? 0.5,
+          ).round(),
         );
       }
     }
@@ -170,7 +200,11 @@ extension SmartPushContentSelection on SmartPushService {
       fallbackContent['sameTimeOfDay'] = _ContentCandidate(
         note: note,
         title: title,
-        priority: 20, // 最低优先级
+        priority: scoreSmartPushCandidate(
+          basePriority: 20,
+          note: note,
+          contentTypeScore: contentTypeScores['sameTimeOfDay'] ?? 0.5,
+        ).round(),
       );
     }
 
@@ -259,11 +293,15 @@ extension SmartPushContentSelection on SmartPushService {
   }
 
   /// 从候选列表中选择未被推送过的笔记
-  Quote? _selectUnpushedNote(List<Quote> candidates) {
+  Quote? _selectUnpushedNote(
+    List<Quote> candidates, {
+    Set<String> strictExcludedIds = const {},
+  }) {
     return selectUnpushedNote(
       candidates,
       _settings.recentlyPushedNoteIds.toSet(),
       _random,
+      strictExcludedIds: strictExcludedIds,
     );
   }
 

--- a/lib/services/smart_push/smart_push_execution.dart
+++ b/lib/services/smart_push/smart_push_execution.dart
@@ -314,6 +314,9 @@ extension SmartPushExecution on SmartPushService {
 
         // 记录推送历史（避免重复推送，测试模式也不记录）
         if (!isDailyQuote && noteToShow.id != null && !isTest) {
+          if (_settings.pushMode == PushMode.smart) {
+            _markNotePushedToday(noteToShow.id!);
+          }
           final updatedSettings = _settings.addPushedNoteId(noteToShow.id!);
           await _saveSettingsQuietly(updatedSettings);
         }

--- a/lib/services/smart_push_analytics.dart
+++ b/lib/services/smart_push_analytics.dart
@@ -294,6 +294,11 @@ class SmartPushAnalytics extends ChangeNotifier {
     return true;
   }
 
+  /// 获取内容类型点击学习得分快照，供候选排序使用。
+  Future<Map<String, double>> getContentTypeScores() async {
+    return Map.unmodifiable(await _getContentScores());
+  }
+
   /// 消费疲劳预算（发送推送后调用）
   Future<void> consumeBudget(String contentType) async {
     final cost = contentTypeCosts[contentType] ?? 3.0;

--- a/lib/services/smart_push_computation.dart
+++ b/lib/services/smart_push_computation.dart
@@ -8,11 +8,13 @@ class SmartPushFilterInput {
   final List<Quote> candidates;
   final DateTime now;
   final Set<String> recentlyPushedIds;
+  final Set<String> todayPushedIds;
 
   SmartPushFilterInput({
     required this.candidates,
     required this.now,
     required this.recentlyPushedIds,
+    this.todayPushedIds = const {},
   });
 }
 
@@ -76,21 +78,25 @@ SmartPushFilterResult runSmartPushFilters(SmartPushFilterInput input) {
       yearAgoQuotes,
       input.recentlyPushedIds,
       random,
+      strictExcludedIds: input.todayPushedIds,
     ),
     selectedSameTime: selectUnpushedNote(
       sameTimeQuotes,
       input.recentlyPushedIds,
       random,
+      strictExcludedIds: input.todayPushedIds,
     ),
     selectedMonthAgo: selectUnpushedNote(
       monthAgoQuotes,
       input.recentlyPushedIds,
       random,
+      strictExcludedIds: input.todayPushedIds,
     ),
     selectedWeekAgo: selectUnpushedNote(
       weekAgoQuotes,
       input.recentlyPushedIds,
       random,
+      strictExcludedIds: input.todayPushedIds,
     ),
     selectedRandom: null,
   );
@@ -182,9 +188,32 @@ List<Quote> filterRandomMemory(
 Quote? selectUnpushedNote(
   List<Quote> candidates,
   Set<String> recentlyPushedIds,
-  Random random,
-) {
-  final unpushed = candidates
+  Random random, {
+  Set<String> strictExcludedIds = const {},
+}) {
+  return selectSmartPushNote(
+    candidates,
+    recentlyPushedIds,
+    random,
+    strictExcludedIds: strictExcludedIds,
+  );
+}
+
+/// Selects a smart-push note while strictly excluding notes that must not be
+/// repeated in the current context, such as notes already pushed today.
+Quote? selectSmartPushNote(
+  List<Quote> candidates,
+  Set<String> recentlyPushedIds,
+  Random random, {
+  Set<String> strictExcludedIds = const {},
+}) {
+  final eligible = candidates
+      .where(
+        (note) => note.id == null || !strictExcludedIds.contains(note.id),
+      )
+      .toList();
+
+  final unpushed = eligible
       .where(
         (note) => note.id == null || !recentlyPushedIds.contains(note.id),
       )
@@ -195,13 +224,25 @@ Quote? selectUnpushedNote(
     return unpushed.first;
   }
 
-  if (candidates.isNotEmpty) {
-    final shuffled = List<Quote>.from(candidates);
+  if (eligible.isNotEmpty) {
+    final shuffled = List<Quote>.from(eligible);
     shuffled.shuffle(random);
     return shuffled.first;
   }
 
   return null;
+}
+
+double scoreSmartPushCandidate({
+  required int basePriority,
+  required Quote note,
+  double contentTypeScore = 0.5,
+}) {
+  final normalizedTypeScore = contentTypeScore.clamp(0.0, 1.0);
+  final engagementBonus = (normalizedTypeScore - 0.5) * 20;
+  final favoriteBonus = min(log(note.favoriteCount + 1) / ln2 * 4, 16);
+
+  return basePriority + engagementBonus + favoriteBonus;
 }
 
 List<TypedSmartPushCandidate> buildTypedCandidates({

--- a/lib/services/smart_push_service.dart
+++ b/lib/services/smart_push_service.dart
@@ -84,6 +84,10 @@ class SmartPushService extends ChangeNotifier {
   /// 今日智能推送是否已执行过（任意内容类型）
   static const String _todayPushedDateKey = 'smart_push_today_pushed_date';
 
+  /// 今日智能推送已发送过的用户笔记 ID 列表
+  static const String _todayPushedNoteIdsKey =
+      'smart_push_today_pushed_note_ids';
+
   /// 今日是否已推送过每日一言（智能推送流程内）
   static const String _todayDailyQuotePushedKey =
       'smart_push_today_daily_quote_pushed';
@@ -179,6 +183,28 @@ class SmartPushService extends ChangeNotifier {
   void _markPushedToday() {
     final today = DateTime.now().toIso8601String().substring(0, 10);
     _mmkv.setString(_todayPushedDateKey, today);
+  }
+
+  Set<String> _getTodayPushedNoteIds() {
+    final today = DateTime.now().toIso8601String().substring(0, 10);
+    final rawData = _mmkv.getString(_todayPushedNoteIdsKey);
+    if (rawData == null || !rawData.startsWith('$today|')) return {};
+
+    final ids = rawData
+        .substring(today.length + 1)
+        .split(',')
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    return ids;
+  }
+
+  void _markNotePushedToday(String noteId) {
+    if (noteId.isEmpty) return;
+
+    final today = DateTime.now().toIso8601String().substring(0, 10);
+    final ids = _getTodayPushedNoteIds()..add(noteId);
+    _mmkv.setString(_todayPushedNoteIdsKey, '$today|${ids.join(',')}');
   }
 
   /// 检查今日在智能推送流程中是否已推送每日一言

--- a/test/unit/services/smart_push_computation_test.dart
+++ b/test/unit/services/smart_push_computation_test.dart
@@ -156,5 +156,97 @@ void main() {
       expect(locationCandidates.single.note.id, 'old-location');
       expect(weatherCandidates.single.note.id, 'old-weather');
     });
+
+    test('smart filter skips today-pushed notes when another match exists', () {
+      final yearAgo = _quote(
+        id: 'year',
+        date: DateTime(2025, 3, 13, 9, 0),
+      );
+      final olderYearAgo = _quote(
+        id: 'older-year',
+        date: DateTime(2024, 3, 13, 9, 0),
+      );
+
+      final result = runSmartPushFilters(
+        SmartPushFilterInput(
+          candidates: [yearAgo, olderYearAgo],
+          now: now,
+          recentlyPushedIds: const {},
+          todayPushedIds: const {'year'},
+        ),
+      );
+
+      expect(result.selectedYearAgo?.id, 'older-year');
+    });
+
+    test('custom typed candidates keep existing unweighted priorities', () {
+      final favoredMonthAgo = Quote(
+        id: 'favored',
+        content: 'note-favored',
+        date: DateTime(2026, 2, 13, 9, 0).toIso8601String(),
+        favoriteCount: 99,
+      );
+      final yearAgo = _quote(
+        id: 'year',
+        date: DateTime(2025, 3, 13, 9, 0),
+      );
+
+      final typed = buildTypedCandidates(
+        notes: [favoredMonthAgo, yearAgo],
+        now: now,
+        enabledPastNoteTypes: const {
+          PastNoteType.yearAgoToday,
+          PastNoteType.monthAgoToday,
+        },
+        recentPushedIds: const {},
+        random: Random(7),
+      );
+
+      expect(typed.first.note.id, 'year');
+      expect(typed.first.priority, 100);
+    });
+
+    test('strict exclusion returns no note instead of repeating same-day push',
+        () {
+      final onlyCandidate = _quote(
+        id: 'year',
+        date: DateTime(2025, 3, 13, 9, 0),
+      );
+
+      final selected = selectSmartPushNote(
+        [onlyCandidate],
+        const {},
+        Random(6),
+        strictExcludedIds: const {'year'},
+      );
+
+      expect(selected, isNull);
+    });
+
+    test('candidate score includes favorite count and content engagement', () {
+      final plain = _quote(
+        id: 'plain',
+        date: DateTime(2026, 2, 13, 9, 0),
+      );
+      final favored = Quote(
+        id: 'favored',
+        content: 'note-favored',
+        date: DateTime(2026, 2, 13, 9, 0).toIso8601String(),
+        favoriteCount: 8,
+      );
+
+      final plainScore = scoreSmartPushCandidate(
+        basePriority: 75,
+        note: plain,
+        contentTypeScore: 0.5,
+      );
+      final favoredScore = scoreSmartPushCandidate(
+        basePriority: 70,
+        note: favored,
+        contentTypeScore: 0.8,
+      );
+
+      expect(favoredScore, greaterThan(plainScore));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- prevent smart push from repeating the same user note again on the same day when another smart candidate exists
- weight smart-mode note candidates with favorite count and learned content-type engagement score
- keep custom/past-note user-configured candidate ordering unchanged

## Root Cause
Smart push only used the general recent-push list as a soft preference. When all candidates in a selected category had been pushed recently, selection could fall back to the same note, so a note could appear twice in one day.

## Validation
- timeout 60s flutter test --reporter compact test/unit/services/smart_push_computation_test.dart
- timeout 120s flutter analyze --no-fatal-infos lib/services/smart_push_service.dart lib/services/smart_push/smart_push_content.dart lib/services/smart_push/smart_push_execution.dart lib/services/smart_push_computation.dart lib/services/smart_push_analytics.dart test/unit/services/smart_push_computation_test.dart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
改进智能推送候选选择，避免同日重复推送同一条用户笔记。基于收藏数与内容类型参与度为候选加权，提升相关性与点击率。

- **Bug Fixes**
  - 当存在其他候选时，严格跳过当天已推送的笔记（记录与读取今日已推送 ID，选择时强排除）。
  - 修复在同类全部近期推送时可能回落到同一笔记的情况。

- **New Features**
  - 新增候选评分：基础优先级 + 收藏数加成 + 内容类型参与度加成（来自 `getContentTypeScores()`）。
  - 保持自定义/过往笔记类型的既有顺序不变，仅在同类内部加权。

<sup>Written for commit 7f3caec26698f570840166b50420620b686dbbe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

