### PR TITLE
📏 标尺: [补充 Utils 核心纯函数的测试]

### DIFF
--- a/.jules/caliper.md
+++ b/.jules/caliper.md
@@ -30,9 +30,11 @@
 ## 2026-06-28 - 补充 SearchController 的测试
 **盲点:** SearchController 的核心 `updateSearch` 和 `resetSearchState` 逻辑（包含长度校验和异步超时定时器）缺失测试覆盖。
 **对策:** 添加了针对这部分逻辑的单元测试，涵盖了空查询清除、短查询忽略、超时定时器挂起等核心场景，并使用 `fakeAsync` 测试了定时器的启动与取消，防止定时器泄漏。
-
 ## 2026-06-30 - [补充 homepage 各项功能的测试]
 **盲点:** `HomePage` 作为最复杂的主页面，其内部包含众多 Service 和子视图，原本仅进行了极其简单的 widget 测试，缺乏对 `DailyQuoteView`、`HomeDailyPromptPanel` 等核心业务组件的加载与切换验证。
 **对策:**
 1. 为 `HomeDailyPromptPanel` 编写了独立的 Widget 测试，采用 `MultiProvider` 注入 `MockAIService`、`MockSettingsService` 等完整依赖链，成功测试了流式提示信息的渲染以及失败降级的本地提示加载机制。
 2. 彻底重构 `HomePage` 的 Widget 测试，Mock 其依赖的至少 8 个核心 Service，验证了 `DailyQuoteView` 和 `HomeDailyPromptPanel` 的正确挂载，并通过模拟用户交互点击 `NavigationBar`，全面验证了由主页向 `NoteListView`、`AIFeaturesPage`、`SettingsPage` 三个主要 Tab 页面的无缝切换逻辑，大幅提升了主页面的功能稳定性保证。
+## 2026-06-30 - [补充 Utils 核心纯函数的测试]
+**盲点:** 诸如 `AIRequestHelper`, `DatabasePlatformInit`, `ChatThemeHelper` 等核心工具类和纯函数缺乏基本测试覆盖。它们涉及 AI 参数组装、核心 FFI 数据库初始化和聊天主题配置，如果被破坏可能导致核心功能静默失效或引发启动崩溃。
+**对策:** 为这些高优先级、易测试的纯函数和单例/配置类编写了极简的隔离测试。比如校验 AIRequestHelper 的消息格式是否符合 Provider 标准，以及确保 DatabasePlatformInit 的状态重置逻辑正常，在不增加过多执行成本的前提下，提升基础代码的健壮性。

--- a/lib/utils/database_platform_init.dart
+++ b/lib/utils/database_platform_init.dart
@@ -2,11 +2,13 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'app_logger.dart';
+import 'package:sqflite/sqflite.dart' as sqflite_core;
 
 /// 数据库平台初始化工具类
 /// 确保FFI只初始化一次，避免Windows平台启动卡死问题
 class DatabasePlatformInit {
   static bool _isInitialized = false;
+  static sqflite_core.DatabaseFactory? _originalFactory;
 
   /// 初始化数据库平台支持
   /// 在Windows平台下配置FFI，其他平台使用默认配置
@@ -18,6 +20,7 @@ class DatabasePlatformInit {
 
     if (!kIsWeb && Platform.isWindows) {
       try {
+        _originalFactory ??= databaseFactory;
         sqfliteFfiInit();
         databaseFactory = databaseFactoryFfi;
         logInfo('Windows平台FFI数据库工厂初始化成功', source: 'DatabasePlatformInit');
@@ -41,5 +44,9 @@ class DatabasePlatformInit {
   @visibleForTesting
   static void resetForTesting() {
     _isInitialized = false;
+    if (_originalFactory != null) {
+      databaseFactory = _originalFactory!;
+      _originalFactory = null;
+    }
   }
 }

--- a/test/unit/utils/ai_request_helper_test.dart
+++ b/test/unit/utils/ai_request_helper_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/ai_request_helper.dart';
+
+void main() {
+  group('AIRequestHelper', () {
+    test('createMessages returns correct format', () {
+      final helper = AIRequestHelper();
+      final messages = helper.createMessages(
+        systemPrompt: 'You are a helpful assistant.',
+        userMessage: 'Hello world!',
+      );
+
+      expect(messages.length, 2);
+      expect(messages[0],
+          {'role': 'system', 'content': 'You are a helpful assistant.'});
+      expect(messages[1], {'role': 'user', 'content': 'Hello world!'});
+    });
+
+    test('singleton instance is same', () {
+      final helper1 = AIRequestHelper();
+      final helper2 = AIRequestHelper();
+
+      expect(identical(helper1, helper2), isTrue);
+    });
+  });
+}

--- a/test/unit/utils/chat_theme_helper_test.dart
+++ b/test/unit/utils/chat_theme_helper_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/chat_theme_helper.dart';
+import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
+
+void main() {
+  group('ChatThemeHelper', () {
+    testWidgets('createTextMessageBuilder applies correct styles',
+        (WidgetTester tester) async {
+      final theme = ThemeData(
+        colorScheme: const ColorScheme.light(
+          primary: Colors.blue,
+          onPrimary: Colors.white,
+          surface: Colors.grey,
+          onSurface: Colors.black,
+        ),
+      );
+
+      final builder = ChatThemeHelper.createTextMessageBuilder(theme);
+
+      final message = types.TextMessage(
+        id: '1',
+        author: const types.User(id: '1'),
+        text: 'Test message',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return builder(context, message, 0, isSentByMe: true);
+              },
+            ),
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, Colors.blue);
+
+      final text = tester.widget<Text>(find.text('Test message'));
+      expect(text.style?.color, Colors.white);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return builder(context, message, 0, isSentByMe: false);
+              },
+            ),
+          ),
+        ),
+      );
+
+      final container2 = tester.widget<Container>(find.byType(Container));
+      final decoration2 = container2.decoration as BoxDecoration;
+      expect(decoration2.color, Colors.grey);
+
+      final text2 = tester.widget<Text>(find.text('Test message'));
+      expect(text2.style?.color, Colors.black);
+    });
+  });
+}

--- a/test/unit/utils/database_platform_init_test.dart
+++ b/test/unit/utils/database_platform_init_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/database_platform_init.dart';
+
+void main() {
+  group('DatabasePlatformInit', () {
+    setUp(() {
+      DatabasePlatformInit.resetForTesting();
+    });
+
+    test('initialize sets _isInitialized to true', () {
+      expect(DatabasePlatformInit.isInitialized, isFalse);
+      DatabasePlatformInit.initialize();
+      expect(DatabasePlatformInit.isInitialized, isTrue);
+    });
+
+    test('initialize handles multiple calls gracefully', () {
+      DatabasePlatformInit.initialize();
+      expect(DatabasePlatformInit.isInitialized, isTrue);
+      DatabasePlatformInit.initialize();
+      expect(DatabasePlatformInit.isInitialized, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
补充了项目中多个缺失测试覆盖率的核心工具类与纯函数单元测试，包括：
- `DatabasePlatformInit`: 验证 FFI 数据库重置与单例初始化机制。
- `ChatThemeHelper`: 验证 UI Theming 的纯函数构建器 (Sender/Receiver)。
- `AIRequestHelper`: 验证 `createMessages` 构建正确的消息格式，以及保证其为单例对象。

更新了 `.jules/caliper.md`，记录了关于测试基础配置/纯函数的盲点及对策。

---
*PR created automatically by Jules for task [12863291170409661932](https://jules.google.com/task/12863291170409661932) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为核心 Utils 增加单元测试，覆盖 AIRequestHelper（消息格式与单例）、ChatThemeHelper（消息气泡样式）与 DatabasePlatformInit（初始化与重置），降低回归风险。修复 DatabasePlatformInit.resetForTesting 以恢复原始工厂，避免测试间副作用；并更新 `.jules/caliper.md`。

- **Bug Fixes**
  - 在 DatabasePlatformInit.resetForTesting 中保存并恢复全局 `sqflite` 的 `databaseFactory`，消除测试顺序依赖与副作用。

<sup>Written for commit 83272b1a0c4a2298ded0ffeec40d0556139cf124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 新增了对核心工具与初始化逻辑的单元测试，覆盖消息构建结果、单例行为、主题样式应用以及初始化状态保持。
  * 补充了相关测试说明，明确了本次测试覆盖范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->