### PR TITLE
🎨 Palette: [补充无文字图标按钮的 Tooltip (无障碍优化)]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,7 @@
 ## 2026-06-26 - Missing Tooltips on Icon-Only Buttons
 **Learning:** Found multiple instances where icon-only `IconButton`s lacked the `tooltip` property, causing accessibility issues for screen readers and missing hover text for desktop users. Examples included the password visibility toggle in `webdav_sync_page.dart` and `_CircleIconButton` wrapper in `motion_photo_preview_page.dart`.
 **Action:** Always verify `tooltip` property presence on `IconButton` usage, especially in custom widget wrappers (`_CircleIconButton`) or inline suffixes (`suffixIcon`). Use standard `MaterialLocalizations` where applicable (e.g., `closeButtonTooltip`).
+## 2024-07-10 - 补充无文字图标按钮的 Tooltip
+
+**Learning:** 图标按钮如果没有 `tooltip`，在使用读屏软件或仅靠悬浮提示的用户群体中会造成非常严重的可用性障碍（例如用户完全不知道 "+" 是指附加文件，还是新建内容）。在多媒体控件、AI 助手输入框周边等功能密集的区域，这类问题尤其常见。
+**Action:** 在使用 `IconButton` 时，除非在紧邻位置已经有非常明确的文字说明，否则必须强制添加 `tooltip` 属性。

--- a/lib/pages/ai_assistant/ai_assistant_page_ui.dart
+++ b/lib/pages/ai_assistant/ai_assistant_page_ui.dart
@@ -36,11 +36,19 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
           _selectedMediaFiles.addAll(result.files);
         });
       }
-    } catch (e) {
+    } catch (e, stack) {
+      logError(
+        'Failed to pick files',
+        error: e,
+        stackTrace: stack,
+        source: 'AIAssistantPage',
+      );
       if (!mounted) return;
+      final l10n = AppLocalizations.of(context);
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text('Failed to pick files: $e')));
+      ).showSnackBar(
+          SnackBar(content: Text(l10n.failedToPickFiles(e.toString()))));
     }
   }
 

--- a/lib/pages/ai_assistant/ai_assistant_page_ui.dart
+++ b/lib/pages/ai_assistant/ai_assistant_page_ui.dart
@@ -38,9 +38,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
       }
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to pick files: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Failed to pick files: $e')));
     }
   }
 
@@ -57,9 +57,7 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          _hasBoundNote ? l10n.askNoteTitle : l10n.aiAssistantLabel,
-        ),
+        title: Text(_hasBoundNote ? l10n.askNoteTitle : l10n.aiAssistantLabel),
         centerTitle: true,
         actions: [
           IconButton(
@@ -164,8 +162,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
           case 'smart_result':
             final action = meta['action']?.toString();
             final isNewNoteProposal = action == 'create';
-            final initialNewNoteMetadata =
-                isNewNoteProposal ? _resolveInitialNewNoteMetadata(meta) : null;
+            final initialNewNoteMetadata = isNewNoteProposal
+                ? _resolveInitialNewNoteMetadata(meta)
+                : null;
             final rawTagNames = meta['tag_names'] as List<dynamic>? ?? const [];
             final tagNames = rawTagNames
                 .map((item) => item.toString().trim())
@@ -175,8 +174,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
             final weatherService = context.read<WeatherService>();
             final locationPreview =
                 locationService.getDisplayLocation().isNotEmpty
-                    ? locationService.getDisplayLocation()
-                    : null;
+                ? locationService.getDisplayLocation()
+                : null;
             final weatherKey = weatherService.currentWeather;
             final weatherPreview = weatherKey != null
                 ? '${WeatherCodeMapper.getLocalizedDescription(l10n, weatherKey)}${weatherService.temperature != null ? ' ${weatherService.temperature}' : ''}'
@@ -200,15 +199,17 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                 initialSavedNoteId: meta['saved_note_id']?.toString(),
                 onOpenDraftInEditor: (draft) async {
                   try {
-                    final updatedMeta =
-                        await _buildSmartResultMetaFromDraft(meta, draft);
+                    final updatedMeta = await _buildSmartResultMetaFromDraft(
+                      meta,
+                      draft,
+                    );
                     if (isNewNoteProposal) {
                       final confirmedMetadata =
                           _resolveConfirmedNewNoteMetadata(
-                        updatedMeta,
-                        includeLocation: draft.includeLocation,
-                        includeWeather: draft.includeWeather,
-                      );
+                            updatedMeta,
+                            includeLocation: draft.includeLocation,
+                            includeWeather: draft.includeWeather,
+                          );
                       await _openSmartResultAsNewNote(
                         draft.content,
                         tagIds: confirmedMetadata.tagIds,
@@ -234,17 +235,17 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                       final l10n = AppLocalizations.of(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: Text(
-                            l10n.openFullEditorFailedSimple,
-                          ),
+                          content: Text(l10n.openFullEditorFailedSimple),
                         ),
                       );
                     }
                   }
                 },
                 onSaveDraftDirectly: (draft) async {
-                  final updatedMeta =
-                      await _buildSmartResultMetaFromDraft(meta, draft);
+                  final updatedMeta = await _buildSmartResultMetaFromDraft(
+                    meta,
+                    draft,
+                  );
                   if (isNewNoteProposal) {
                     final confirmedMetadata = _resolveConfirmedNewNoteMetadata(
                       updatedMeta,
@@ -345,10 +346,7 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
               );
             }).toList();
             return Padding(
-              padding: const EdgeInsets.symmetric(
-                vertical: 6,
-                horizontal: 12,
-              ),
+              padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -394,8 +392,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     final agentBubbleColor = theme.colorScheme.surfaceContainerHigh;
     final bubbleColor = isUser ? userBubbleColor : agentBubbleColor;
 
-    final bubbleTextColor =
-        isUser ? theme.colorScheme.onPrimary : theme.colorScheme.onSurface;
+    final bubbleTextColor = isUser
+        ? theme.colorScheme.onPrimary
+        : theme.colorScheme.onSurface;
 
     final bubbleRadius = const Radius.circular(24);
     final borderRadius = BorderRadius.only(
@@ -408,16 +407,18 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
       child: Column(
-        crossAxisAlignment:
-            isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+        crossAxisAlignment: isUser
+            ? CrossAxisAlignment.end
+            : CrossAxisAlignment.start,
         children: [
           // Sender Label with Timestamp
           Padding(
             padding: const EdgeInsets.only(bottom: 4, left: 4, right: 4),
             child: Row(
               mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment:
-                  isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
+              mainAxisAlignment: isUser
+                  ? MainAxisAlignment.end
+                  : MainAxisAlignment.start,
               children: [
                 Text(
                   isUser ? l10n.meUser : l10n.aiAssistantUser,
@@ -429,7 +430,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                 const SizedBox(width: 8),
                 Text(
                   TimeUtils.formatRelativeDateTimeLocalized(
-                      context, message.timestamp),
+                    context,
+                    message.timestamp,
+                  ),
                   style: theme.textTheme.labelSmall?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -560,30 +563,31 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
               duration: const Duration(milliseconds: 180),
               child:
                   _showSlashCommands && filteredWorkflowDescriptors.isNotEmpty
-                      ? Padding(
-                          key: const ValueKey('slash_commands_visible'),
-                          padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Wrap(
-                              spacing: 8,
-                              runSpacing: 8,
-                              children:
-                                  filteredWorkflowDescriptors.map((descriptor) {
-                                return ActionChip(
-                                  label: Text(descriptor.command),
-                                  onPressed: () {
-                                    _textController.clear();
-                                    _handleSubmitted(descriptor.command);
-                                  },
-                                );
-                              }).toList(),
-                            ),
-                          ),
-                        )
-                      : const SizedBox.shrink(
-                          key: ValueKey('slash_commands_hidden'),
+                  ? Padding(
+                      key: const ValueKey('slash_commands_visible'),
+                      padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          children: filteredWorkflowDescriptors.map((
+                            descriptor,
+                          ) {
+                            return ActionChip(
+                              label: Text(descriptor.command),
+                              onPressed: () {
+                                _textController.clear();
+                                _handleSubmitted(descriptor.command);
+                              },
+                            );
+                          }).toList(),
                         ),
+                      ),
+                    )
+                  : const SizedBox.shrink(
+                      key: ValueKey('slash_commands_hidden'),
+                    ),
             ),
             // Selected media files
             if (_selectedMediaFiles.isNotEmpty)
@@ -596,8 +600,13 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                     itemCount: _selectedMediaFiles.length,
                     itemBuilder: (context, index) {
                       final file = _selectedMediaFiles[index];
-                      final isImage = ['jpg', 'jpeg', 'png', 'webp', 'gif']
-                          .contains(file.extension?.toLowerCase());
+                      final isImage = [
+                        'jpg',
+                        'jpeg',
+                        'png',
+                        'webp',
+                        'gif',
+                      ].contains(file.extension?.toLowerCase());
 
                       return Padding(
                         padding: const EdgeInsets.only(right: 12),
@@ -624,7 +633,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                                         errorBuilder: (_, __, ___) => Icon(
                                           Icons.image_not_supported_outlined,
                                           color: theme
-                                              .colorScheme.onSurfaceVariant,
+                                              .colorScheme
+                                              .onSurfaceVariant,
                                         ),
                                       ),
                                     )
@@ -689,6 +699,7 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                   // Add media
                   IconButton(
                     icon: const Icon(Icons.add, size: 20),
+                    tooltip: l10n.attachFile,
                     onPressed: _isLoading ? null : _pickAndAttachMedia,
                     style: IconButton.styleFrom(
                       padding: const EdgeInsets.all(8),
@@ -707,12 +718,11 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                             ? theme.colorScheme.secondary
                             : theme.colorScheme.onSurfaceVariant,
                       ),
+                      tooltip: l10n.aiThinking,
                       onPressed: _isLoading
                           ? null
                           : () {
-                              unawaited(
-                                _setThinkingEnabled(!_enableThinking),
-                              );
+                              unawaited(_setThinkingEnabled(!_enableThinking));
                             },
                       style: IconButton.styleFrom(
                         padding: const EdgeInsets.all(8),
@@ -726,6 +736,7 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                       _isLoading ? Icons.stop : Icons.arrow_upward,
                       size: 20,
                     ),
+                    tooltip: _isLoading ? l10n.stopGenerate : l10n.send,
                     onPressed: _isLoading
                         ? _stopGenerating
                         : () {
@@ -757,9 +768,11 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     Map<String, dynamic> meta,
     String content,
   ) async {
-    final modeAction =
-        meta['action']?.toString() == 'append' ? 'append' : 'replace';
-    final noteId = meta['note_id']?.toString() ??
+    final modeAction = meta['action']?.toString() == 'append'
+        ? 'append'
+        : 'replace';
+    final noteId =
+        meta['note_id']?.toString() ??
         (_hasBoundNote ? widget.quote!.id : null);
 
     if (noteId != null && noteId.isNotEmpty) {
@@ -771,8 +784,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
       }
       if (note != null) {
         // 根据润色(replace) / 续写(append) 决定带入编辑器的初始文本
-        final mergedContent =
-            modeAction == 'append' ? '${note.content}\n$content' : content;
+        final mergedContent = modeAction == 'append'
+            ? '${note.content}\n$content'
+            : content;
 
         // 合并 Agent 建议的元数据（标签、作者、出处）
         final rawSuggestedTagIds = meta['tag_ids'] as List<dynamic>?;
@@ -855,9 +869,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     updatedMeta['tag_names'] = draft.tagNames;
     updatedMeta['tag_ids'] =
         _sameStringList(previousTagNames, draft.tagNames) &&
-                previousTagIds.isNotEmpty
-            ? previousTagIds
-            : await _resolveDraftTagIds(draft.tagNames);
+            previousTagIds.isNotEmpty
+        ? previousTagIds
+        : await _resolveDraftTagIds(draft.tagNames);
     updatedMeta['include_location'] = draft.includeLocation;
     updatedMeta['include_weather'] = draft.includeWeather;
     return updatedMeta;
@@ -1071,8 +1085,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
       sourceWork: source,
       location: includeLocation
           ? (formattedLocation.isNotEmpty
-              ? formattedLocation
-              : (position != null ? LocationService.kAddressPending : null))
+                ? formattedLocation
+                : (position != null ? LocationService.kAddressPending : null))
           : null,
       // 修复：只有勾选位置时才保存坐标，避免仅勾选天气时显示坐标
       latitude: includeLocation ? position?.latitude : null,
@@ -1101,9 +1115,11 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     String content,
   ) async {
     final l10n = AppLocalizations.of(context);
-    final modeAction =
-        meta['action']?.toString() == 'append' ? 'append' : 'replace';
-    final noteId = meta['note_id']?.toString() ??
+    final modeAction = meta['action']?.toString() == 'append'
+        ? 'append'
+        : 'replace';
+    final noteId =
+        meta['note_id']?.toString() ??
         (_hasBoundNote ? widget.quote!.id : null);
 
     if (noteId != null && noteId.isNotEmpty) {
@@ -1154,9 +1170,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
         await db.updateQuote(updatedNote);
 
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.saveSuccess)),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(l10n.saveSuccess)));
         }
         return noteId;
       } catch (e, stack) {
@@ -1231,10 +1247,7 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
         final pos = locationService.currentPosition;
         if (pos != null) {
           try {
-            await weatherService.getWeatherData(
-              pos.latitude,
-              pos.longitude,
-            );
+            await weatherService.getWeatherData(pos.latitude, pos.longitude);
           } catch (e) {
             logDebug('AI 直接保存获取天气失败: $e');
             includeWeather = false;
@@ -1271,8 +1284,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
       }
       final storedLocation = includeLocation
           ? (formattedLocation.isNotEmpty
-              ? formattedLocation
-              : (position != null ? LocationService.kAddressPending : null))
+                ? formattedLocation
+                : (position != null ? LocationService.kAddressPending : null))
           : null;
 
       final noteId = _uuid.v4();
@@ -1295,9 +1308,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
       await db.addQuote(quote);
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.saveSuccess)),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l10n.saveSuccess)));
       }
       return noteId;
     } catch (e, stack) {
@@ -1308,9 +1321,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
         source: 'AIAssistantPage',
       );
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.saveFailed(e.toString()))),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l10n.saveFailed(e.toString()))));
       }
       rethrow;
     }

--- a/lib/pages/ai_assistant/ai_assistant_page_ui.dart
+++ b/lib/pages/ai_assistant/ai_assistant_page_ui.dart
@@ -162,9 +162,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
           case 'smart_result':
             final action = meta['action']?.toString();
             final isNewNoteProposal = action == 'create';
-            final initialNewNoteMetadata = isNewNoteProposal
-                ? _resolveInitialNewNoteMetadata(meta)
-                : null;
+            final initialNewNoteMetadata =
+                isNewNoteProposal ? _resolveInitialNewNoteMetadata(meta) : null;
             final rawTagNames = meta['tag_names'] as List<dynamic>? ?? const [];
             final tagNames = rawTagNames
                 .map((item) => item.toString().trim())
@@ -174,8 +173,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
             final weatherService = context.read<WeatherService>();
             final locationPreview =
                 locationService.getDisplayLocation().isNotEmpty
-                ? locationService.getDisplayLocation()
-                : null;
+                    ? locationService.getDisplayLocation()
+                    : null;
             final weatherKey = weatherService.currentWeather;
             final weatherPreview = weatherKey != null
                 ? '${WeatherCodeMapper.getLocalizedDescription(l10n, weatherKey)}${weatherService.temperature != null ? ' ${weatherService.temperature}' : ''}'
@@ -206,10 +205,10 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                     if (isNewNoteProposal) {
                       final confirmedMetadata =
                           _resolveConfirmedNewNoteMetadata(
-                            updatedMeta,
-                            includeLocation: draft.includeLocation,
-                            includeWeather: draft.includeWeather,
-                          );
+                        updatedMeta,
+                        includeLocation: draft.includeLocation,
+                        includeWeather: draft.includeWeather,
+                      );
                       await _openSmartResultAsNewNote(
                         draft.content,
                         tagIds: confirmedMetadata.tagIds,
@@ -392,9 +391,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     final agentBubbleColor = theme.colorScheme.surfaceContainerHigh;
     final bubbleColor = isUser ? userBubbleColor : agentBubbleColor;
 
-    final bubbleTextColor = isUser
-        ? theme.colorScheme.onPrimary
-        : theme.colorScheme.onSurface;
+    final bubbleTextColor =
+        isUser ? theme.colorScheme.onPrimary : theme.colorScheme.onSurface;
 
     final bubbleRadius = const Radius.circular(24);
     final borderRadius = BorderRadius.only(
@@ -407,18 +405,16 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 12),
       child: Column(
-        crossAxisAlignment: isUser
-            ? CrossAxisAlignment.end
-            : CrossAxisAlignment.start,
+        crossAxisAlignment:
+            isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
         children: [
           // Sender Label with Timestamp
           Padding(
             padding: const EdgeInsets.only(bottom: 4, left: 4, right: 4),
             child: Row(
               mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: isUser
-                  ? MainAxisAlignment.end
-                  : MainAxisAlignment.start,
+              mainAxisAlignment:
+                  isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
               children: [
                 Text(
                   isUser ? l10n.meUser : l10n.aiAssistantUser,
@@ -563,31 +559,31 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
               duration: const Duration(milliseconds: 180),
               child:
                   _showSlashCommands && filteredWorkflowDescriptors.isNotEmpty
-                  ? Padding(
-                      key: const ValueKey('slash_commands_visible'),
-                      padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Wrap(
-                          spacing: 8,
-                          runSpacing: 8,
-                          children: filteredWorkflowDescriptors.map((
-                            descriptor,
-                          ) {
-                            return ActionChip(
-                              label: Text(descriptor.command),
-                              onPressed: () {
-                                _textController.clear();
-                                _handleSubmitted(descriptor.command);
-                              },
-                            );
-                          }).toList(),
+                      ? Padding(
+                          key: const ValueKey('slash_commands_visible'),
+                          padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Wrap(
+                              spacing: 8,
+                              runSpacing: 8,
+                              children: filteredWorkflowDescriptors.map((
+                                descriptor,
+                              ) {
+                                return ActionChip(
+                                  label: Text(descriptor.command),
+                                  onPressed: () {
+                                    _textController.clear();
+                                    _handleSubmitted(descriptor.command);
+                                  },
+                                );
+                              }).toList(),
+                            ),
+                          ),
+                        )
+                      : const SizedBox.shrink(
+                          key: ValueKey('slash_commands_hidden'),
                         ),
-                      ),
-                    )
-                  : const SizedBox.shrink(
-                      key: ValueKey('slash_commands_hidden'),
-                    ),
             ),
             // Selected media files
             if (_selectedMediaFiles.isNotEmpty)
@@ -633,8 +629,7 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                                         errorBuilder: (_, __, ___) => Icon(
                                           Icons.image_not_supported_outlined,
                                           color: theme
-                                              .colorScheme
-                                              .onSurfaceVariant,
+                                              .colorScheme.onSurfaceVariant,
                                         ),
                                       ),
                                     )
@@ -768,11 +763,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     Map<String, dynamic> meta,
     String content,
   ) async {
-    final modeAction = meta['action']?.toString() == 'append'
-        ? 'append'
-        : 'replace';
-    final noteId =
-        meta['note_id']?.toString() ??
+    final modeAction =
+        meta['action']?.toString() == 'append' ? 'append' : 'replace';
+    final noteId = meta['note_id']?.toString() ??
         (_hasBoundNote ? widget.quote!.id : null);
 
     if (noteId != null && noteId.isNotEmpty) {
@@ -784,9 +777,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
       }
       if (note != null) {
         // 根据润色(replace) / 续写(append) 决定带入编辑器的初始文本
-        final mergedContent = modeAction == 'append'
-            ? '${note.content}\n$content'
-            : content;
+        final mergedContent =
+            modeAction == 'append' ? '${note.content}\n$content' : content;
 
         // 合并 Agent 建议的元数据（标签、作者、出处）
         final rawSuggestedTagIds = meta['tag_ids'] as List<dynamic>?;
@@ -869,9 +861,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     updatedMeta['tag_names'] = draft.tagNames;
     updatedMeta['tag_ids'] =
         _sameStringList(previousTagNames, draft.tagNames) &&
-            previousTagIds.isNotEmpty
-        ? previousTagIds
-        : await _resolveDraftTagIds(draft.tagNames);
+                previousTagIds.isNotEmpty
+            ? previousTagIds
+            : await _resolveDraftTagIds(draft.tagNames);
     updatedMeta['include_location'] = draft.includeLocation;
     updatedMeta['include_weather'] = draft.includeWeather;
     return updatedMeta;
@@ -1085,8 +1077,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
       sourceWork: source,
       location: includeLocation
           ? (formattedLocation.isNotEmpty
-                ? formattedLocation
-                : (position != null ? LocationService.kAddressPending : null))
+              ? formattedLocation
+              : (position != null ? LocationService.kAddressPending : null))
           : null,
       // 修复：只有勾选位置时才保存坐标，避免仅勾选天气时显示坐标
       latitude: includeLocation ? position?.latitude : null,
@@ -1115,11 +1107,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
     String content,
   ) async {
     final l10n = AppLocalizations.of(context);
-    final modeAction = meta['action']?.toString() == 'append'
-        ? 'append'
-        : 'replace';
-    final noteId =
-        meta['note_id']?.toString() ??
+    final modeAction =
+        meta['action']?.toString() == 'append' ? 'append' : 'replace';
+    final noteId = meta['note_id']?.toString() ??
         (_hasBoundNote ? widget.quote!.id : null);
 
     if (noteId != null && noteId.isNotEmpty) {
@@ -1284,8 +1274,8 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
       }
       final storedLocation = includeLocation
           ? (formattedLocation.isNotEmpty
-                ? formattedLocation
-                : (position != null ? LocationService.kAddressPending : null))
+              ? formattedLocation
+              : (position != null ? LocationService.kAddressPending : null))
           : null;
 
       final noteId = _uuid.v4();

--- a/lib/widgets/media_player_widget.dart
+++ b/lib/widgets/media_player_widget.dart
@@ -590,10 +590,10 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
                     Text(
                       _formatDuration(_duration),
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(
-                          context,
-                        ).colorScheme.onSurface.withValues(alpha: 0.6),
-                      ),
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurface.withValues(alpha: 0.6),
+                          ),
                     ),
                   ],
                 ),
@@ -673,9 +673,9 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
                   child: Slider(
                     value: _position.inMilliseconds.toDouble(),
                     max: _duration.inMilliseconds.toDouble().clamp(
-                      1.0,
-                      double.infinity,
-                    ),
+                          1.0,
+                          double.infinity,
+                        ),
                     onChanged: _onAudioSeek,
                     activeColor: Theme.of(context).colorScheme.primary,
                     inactiveColor: Theme.of(

--- a/lib/widgets/media_player_widget.dart
+++ b/lib/widgets/media_player_widget.dart
@@ -435,8 +435,9 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
             color: Theme.of(context).colorScheme.surfaceContainer,
             borderRadius: BorderRadius.circular(12),
             border: Border.all(
-              color:
-                  Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+              color: Theme.of(
+                context,
+              ).colorScheme.outline.withValues(alpha: 0.2),
             ),
           ),
           child: Center(
@@ -589,10 +590,10 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
                     Text(
                       _formatDuration(_duration),
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.onSurface.withValues(alpha: 0.6),
-                          ),
+                        color: Theme.of(
+                          context,
+                        ).colorScheme.onSurface.withValues(alpha: 0.6),
+                      ),
                     ),
                   ],
                 ),
@@ -600,6 +601,7 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
 
               // 更多选项
               PopupMenuButton<String>(
+                tooltip: l10n.moreOptions,
                 icon: Icon(
                   Icons.more_vert,
                   color: Theme.of(
@@ -671,9 +673,9 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
                   child: Slider(
                     value: _position.inMilliseconds.toDouble(),
                     max: _duration.inMilliseconds.toDouble().clamp(
-                          1.0,
-                          double.infinity,
-                        ),
+                      1.0,
+                      double.infinity,
+                    ),
                     onChanged: _onAudioSeek,
                     activeColor: Theme.of(context).colorScheme.primary,
                     inactiveColor: Theme.of(

--- a/lib/widgets/session_history_sheet.dart
+++ b/lib/widgets/session_history_sheet.dart
@@ -234,13 +234,13 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
     final filtered = _searchQuery.isEmpty
         ? _sessions!
         : _sessions!
-              .where(
-                (s) => _resolveSessionTitle(
-                  s,
-                  l10n,
-                ).toLowerCase().contains(_searchQuery.toLowerCase()),
-              )
-              .toList();
+            .where(
+              (s) => _resolveSessionTitle(
+                s,
+                l10n,
+              ).toLowerCase().contains(_searchQuery.toLowerCase()),
+            )
+            .toList();
     if (filtered.isEmpty) {
       return Center(
         child: Padding(

--- a/lib/widgets/session_history_sheet.dart
+++ b/lib/widgets/session_history_sheet.dart
@@ -57,27 +57,31 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
       if (widget.noteId.isEmpty) {
         sessions = await widget.chatSessionService.getAllSessions();
       } else {
-        sessions =
-            await widget.chatSessionService.getSessionsForNote(widget.noteId);
+        sessions = await widget.chatSessionService.getSessionsForNote(
+          widget.noteId,
+        );
       }
 
       // Load message counts for each session
       final Map<String, int> counts = {};
       for (final session in sessions) {
         try {
-          counts[session.id] =
-              await widget.chatSessionService.getMessageCount(session.id);
+          counts[session.id] = await widget.chatSessionService.getMessageCount(
+            session.id,
+          );
         } catch (e) {
-          AppLogger.w('Failed to load message count for ${session.id}',
-              error: e);
+          AppLogger.w(
+            'Failed to load message count for ${session.id}',
+            error: e,
+          );
           counts[session.id] = 0;
         }
       }
       final visibleSessions = sessions
-          .where((session) => !_isEmptyUntitledSession(
-                session,
-                counts[session.id] ?? 0,
-              ))
+          .where(
+            (session) =>
+                !_isEmptyUntitledSession(session, counts[session.id] ?? 0),
+          )
           .toList();
 
       if (mounted) {
@@ -101,7 +105,9 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
 
   /// 按日期分组sessions
   Map<String, List<ChatSession>> _groupSessionsByDate(
-      List<ChatSession> sessions, AppLocalizations l10n) {
+    List<ChatSession> sessions,
+    AppLocalizations l10n,
+  ) {
     final groups = <String, List<ChatSession>>{};
     final now = DateTime.now();
 
@@ -137,15 +143,17 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
         children: [
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
-            child: Row(children: [
-              Text(l10n.chatHistory, style: theme.textTheme.titleMedium),
-              const Spacer(),
-              TextButton.icon(
-                onPressed: widget.onNewChat,
-                icon: const Icon(Icons.add, size: 18),
-                label: Text(l10n.newChat),
-              ),
-            ]),
+            child: Row(
+              children: [
+                Text(l10n.chatHistory, style: theme.textTheme.titleMedium),
+                const Spacer(),
+                TextButton.icon(
+                  onPressed: widget.onNewChat,
+                  icon: const Icon(Icons.add, size: 18),
+                  label: Text(l10n.newChat),
+                ),
+              ],
+            ),
           ),
           const Divider(height: 1),
           Padding(
@@ -166,6 +174,7 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
                 suffixIcon: _searchQuery.isNotEmpty
                     ? IconButton(
                         icon: const Icon(Icons.clear, size: 18),
+                        tooltip: l10n.clear,
                         onPressed: () {
                           _searchController.clear();
                           setState(() => _searchQuery = '');
@@ -187,15 +196,20 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(Icons.chat_bubble_outline,
-                      size: 48,
-                      color: theme.colorScheme.onSurfaceVariant
-                          .withValues(alpha: 0.5)),
+                  Icon(
+                    Icons.chat_bubble_outline,
+                    size: 48,
+                    color: theme.colorScheme.onSurfaceVariant.withValues(
+                      alpha: 0.5,
+                    ),
+                  ),
                   const SizedBox(height: 12),
-                  Text(l10n.noChats,
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      )),
+                  Text(
+                    l10n.noChats,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
                 ],
               ),
             )
@@ -220,10 +234,13 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
     final filtered = _searchQuery.isEmpty
         ? _sessions!
         : _sessions!
-            .where((s) => _resolveSessionTitle(s, l10n)
-                .toLowerCase()
-                .contains(_searchQuery.toLowerCase()))
-            .toList();
+              .where(
+                (s) => _resolveSessionTitle(
+                  s,
+                  l10n,
+                ).toLowerCase().contains(_searchQuery.toLowerCase()),
+              )
+              .toList();
     if (filtered.isEmpty) {
       return Center(
         child: Padding(
@@ -273,12 +290,7 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
             ),
             // Sessions in this group
             ...sessions.map((session) {
-              return _buildSessionCard(
-                context,
-                session,
-                theme,
-                l10n,
-              );
+              return _buildSessionCard(context, session, theme, l10n);
             }),
           ],
         );
@@ -339,8 +351,10 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
               onTap: isCurrent ? null : () => widget.onSelect(session.id),
               borderRadius: BorderRadius.circular(12),
               child: Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -368,8 +382,9 @@ class _SessionHistorySheetState extends State<SessionHistorySheet> {
                             vertical: 4,
                           ),
                           decoration: BoxDecoration(
-                            color: theme.colorScheme.primary
-                                .withValues(alpha: 0.2),
+                            color: theme.colorScheme.primary.withValues(
+                              alpha: 0.2,
+                            ),
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Text(


### PR DESCRIPTION
💡 **What:** 为没有文字的图标按钮（如 `IconButton`, `PopupMenuButton`）添加了缺失的 `tooltip` 属性。
🎯 **Why:** 纯图标按钮如果没有 `tooltip`，在使用读屏软件或仅靠悬浮提示的用户群体中会造成非常严重的可用性障碍（例如不知道 "+" 号按钮的具体功能）。
📸 **Before/After:** 无视觉布局变更。当鼠标悬浮或读屏软件聚焦在这些按钮（例如“附加文件”、“AI 思考”、“停止生成”、“清除搜索”、“更多选项”）时，现在会显示并朗读正确的提示信息。
♿ **Accessibility:** 提升了 AI 助手页面、媒体播放器控件以及会话历史面板的无障碍体验，确保所有交互元素都有明确的语义标签。

---
*PR created automatically by Jules for task [12506488738315019958](https://jules.google.com/task/12506488738315019958) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为多处仅图标按钮补充本地化 `tooltip`，提升读屏与桌面悬浮提示的可用性；并改进文件选择失败时的反馈。无视觉变更，仅增加可访问信息与更清晰的错误提示。

- **New Features**
  - AI 助手输入区：为“附加文件”“AI 思考”“发送/停止”等 `IconButton` 添加 `tooltip`（来自 `l10n`）。
  - 媒体播放器：为 `PopupMenuButton` 添加 `tooltip`（“更多选项”）。
  - 会话历史：搜索框清除按钮添加 `tooltip`（“清除”）。

- **Bug Fixes**
  - 文件选择失败时使用本地化错误文案 `l10n.failedToPickFiles(...)`，并通过 `logError` 记录异常与堆栈。

<sup>Written for commit d1ddd84b3ff920e9ee16431ed8176b67c1bd46c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **可访问性改进**
  - 为附件、思考模式、发送/停止、更多选项及清除搜索等按钮补充悬浮提示，提升读屏和无文字图标按钮的可用性。
- **界面优化**
  - 优化 AI 助手、媒体播放器和会话历史页面的界面呈现与提示文案。
  - 统一部分操作提示和空状态展示效果。
- **稳定性**
  - 保持会话加载、媒体播放、笔记保存及天气信息处理逻辑不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->