### PR TITLE
⚡ Bolt: 优化字符串长度计算性能

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -66,3 +66,6 @@
 ## 2024-05-18 - [Batched Database Inserts for sqflite]
 **Learning:** Sequential `await txn.insert()` calls inside a loop in `sqflite` cause massive N+1 IPC overhead because each insert requires traversing the Dart-to-Native channel.
 **Action:** Always accumulate `insert` or `update` operations using `txn.batch()` (e.g., `batch.insert()`) and execute them together with a single `await batch.commit(noResult: true)` (if results aren't needed) to minimize platform channel serialization costs during migrations or bulk processing.
+## 2024-05-14 - 避免使用 split('').length 计算字符串长度
+**Learning:** 在 Dart 中，使用 `str.split('').length` 来计算字符串长度会导致 O(N) 的时间和空间开销，因为系统会分配一个包含每个字符的临时列表，这会引发频繁的内存分配和垃圾回收，影响性能。
+**Action:** 在计算字数等场景，应当直接使用 O(1) 的 `str.length`，或者在需要过滤不可见字符时，使用 `str.characters.length` 配合正则等更高效的方式。

--- a/lib/pages/ai_analysis_history_page_clean.dart
+++ b/lib/pages/ai_analysis_history_page_clean.dart
@@ -652,7 +652,7 @@ class _AIAnalysisHistoryPageState extends State<AIAnalysisHistoryPage> {
       final totalNotes = quotes.length;
       final totalWords = quotes.fold<int>(
         0,
-        (sum, quote) => sum + quote.content.split('').length,
+        (sum, quote) => sum + quote.content.length,
       );
       final averageWordsPerNote =
           totalNotes > 0 ? (totalWords / totalNotes).round() : 0;


### PR DESCRIPTION
💡 **What:** 在 AI 分析历史页面的年度报告生成逻辑中，将计算笔记总字数的代码从 `quote.content.split('').length` 替换为 `quote.content.length`。
🎯 **Why:** `split('')` 会分配一个 O(N) 长度的临时数组，产生大量额外的内存分配和垃圾回收开销，在计算大量笔记字数时会导致性能瓶颈。直接使用 `.length` 可以在 O(1) 内获取 UTF-16 code units 的数量，满足大多数字数统计的需求。
📊 **Impact:** 显著降低内存分配和垃圾回收开销，减少生成年度报告时的处理时间，提升应用流畅度。
🔬 **Measurement:** 通过 `dart format` 和 `flutter analyze` 验证代码无误，且修改前后业务逻辑保持一致。

---
*PR created automatically by Jules for task [15544747768339986301](https://jules.google.com/task/15544747768339986301) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
在分析历史页的年度报告生成中，将字数统计从 `quote.content.split('').length` 改为 `quote.content.length`。避免 O(N) 临时数组分配，降低内存与 GC 开销，加快报告生成。

<sup>Written for commit 9e7dd70a26a0506d1875cca58f76dacd319117c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化年度报告中的字数统计方式，减少生成报告时的额外处理开销。
  * 年度报告的“总字数”和“平均每篇字数”统计结果将基于内容长度直接计算。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->