### PR TITLE
🌐 译者: [提取 Slash Commands 菜单硬编码]

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -44,3 +44,7 @@
 ## 2024-05-24 - [提取 WebDAV 服务商配置表单硬编码]
 **发现:** WebDAV 同步配置页面存在硬编码的表单提示（如：服务商配置、未填写必填项的错误提示）。
 **规则:** 将表单相关的标题及校验失败文案统一抽取到 `.arb` 文件中，英文翻译采用清晰直接（"Please enter..."）且符合极简主义要求的设计。
+## 2026-07-13 - [提取 SlashCommandsMenu 硬编码中文字符串]
+**发现:** 在 `lib/widgets/ai/slash_commands_menu.dart` 中发现了硬编码的中文提示语：`'可用命令'` 和 `'输入 / 查看命令'`
+**规则:**
+- 采用极简风格进行国际化翻译，分别新增 `availableCommands` 和 `typeSlashToSeeCommands` 到所有 `app_*.arb` 语言包中。

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -75,5 +75,7 @@
   "agentWebSearching": "Websuche läuft...",
   "favoriteNotes": "Favorisierte Notizen",
   "clear": "Leeren",
-  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again."
+  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
+  "availableCommands": "Verfügbare Befehle",
+  "typeSlashToSeeCommands": "Tippen Sie / um Befehle zu sehen"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -77,5 +77,5 @@
   "clear": "Leeren",
   "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
   "availableCommands": "Verfügbare Befehle",
-  "typeSlashToSeeCommands": "Tippen Sie / um Befehle zu sehen"
+  "typeSlashToSeeCommands": "Tippen Sie /, um Befehle zu sehen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4083,5 +4083,7 @@
   "agentDiffInsertBefore": "Insert before this content",
   "agentDiffInsertAfter": "Insert after this content",
   "agentDiffAppend": "Append content",
-  "agentDiffDelete": "Delete content"
+  "agentDiffDelete": "Delete content",
+  "availableCommands": "Available Commands",
+  "typeSlashToSeeCommands": "Type / to see commands"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -76,6 +76,6 @@
   "favoriteNotes": "Notas favoritas",
   "clear": "Limpiar",
   "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
-  "availableCommands": "Comandos Disponibles",
+  "availableCommands": "Comandos disponibles",
   "typeSlashToSeeCommands": "Escribe / para ver los comandos"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -75,5 +75,7 @@
   "agentWebSearching": "Buscando en la web...",
   "favoriteNotes": "Notas favoritas",
   "clear": "Limpiar",
-  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again."
+  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
+  "availableCommands": "Comandos Disponibles",
+  "typeSlashToSeeCommands": "Escribe / para ver los comandos"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3571,6 +3571,6 @@
   "agentWebSearching": "Recherche sur le web...",
   "favoriteNotes": "Notes favorites",
   "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
-  "availableCommands": "Commandes Disponibles",
+  "availableCommands": "Commandes disponibles",
   "typeSlashToSeeCommands": "Tapez / pour voir les commandes"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3570,5 +3570,7 @@
   "agentAnalyzingData": "Analyse des données...",
   "agentWebSearching": "Recherche sur le web...",
   "favoriteNotes": "Notes favorites",
-  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again."
+  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
+  "availableCommands": "Commandes Disponibles",
+  "typeSlashToSeeCommands": "Tapez / pour voir les commandes"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3588,5 +3588,7 @@
   "agentAnalyzingData": "データを分析中...",
   "agentWebSearching": "ウェブを検索中...",
   "favoriteNotes": "お気に入りノート",
-  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again."
+  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
+  "availableCommands": "利用可能なコマンド",
+  "typeSlashToSeeCommands": "/ を入力してコマンドを表示"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -3584,5 +3584,7 @@
   "agentAnalyzingData": "데이터 분석 중...",
   "agentWebSearching": "웹 검색 중...",
   "favoriteNotes": "즐겨찾는 노트",
-  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again."
+  "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
+  "availableCommands": "사용 가능한 명령",
+  "typeSlashToSeeCommands": "/ 를 입력하여 명령 보기"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -3586,5 +3586,5 @@
   "favoriteNotes": "즐겨찾는 노트",
   "richTextSaveUnavailable": "Save stopped: rich text content could not be processed without data loss. Close other apps to free memory and try again.",
   "availableCommands": "사용 가능한 명령",
-  "typeSlashToSeeCommands": "/ 를 입력하여 명령 보기"
+  "typeSlashToSeeCommands": "/를 입력하여 명령 보기"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -4083,5 +4083,7 @@
   "agentDiffInsertBefore": "在此内容前插入",
   "agentDiffInsertAfter": "在此内容后插入",
   "agentDiffAppend": "追加内容",
-  "agentDiffDelete": "删除内容"
+  "agentDiffDelete": "删除内容",
+  "availableCommands": "可用命令",
+  "typeSlashToSeeCommands": "输入 / 查看命令"
 }

--- a/lib/widgets/ai/slash_commands_menu.dart
+++ b/lib/widgets/ai/slash_commands_menu.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../models/ai_workflow_descriptor.dart';
+import 'package:thoughtecho/gen_l10n/app_localizations.dart';
 
 /// Slash Commands菜单项
 class SlashCommandsMenu extends StatefulWidget {
@@ -119,7 +120,7 @@ class _SlashCommandsMenuState extends State<SlashCommandsMenu>
               Padding(
                 padding: const EdgeInsets.all(12),
                 child: Text(
-                  '可用命令',
+                  AppLocalizations.of(context).availableCommands,
                   style: theme.textTheme.labelMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -365,7 +366,8 @@ class _SlashCommandsInputFieldState extends State<SlashCommandsInputField> {
           controller: widget.controller,
           focusNode: widget.focusNode,
           decoration: InputDecoration(
-            hintText: widget.hintText ?? '输入 / 查看命令',
+            hintText: widget.hintText ??
+                AppLocalizations.of(context).typeSlashToSeeCommands,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
             ),


### PR DESCRIPTION
提取 `lib/widgets/ai/slash_commands_menu.dart` 中的硬编码中文字符串：
- `'可用命令'` -> `availableCommands` ("Available Commands")
- `'输入 / 查看命令'` -> `typeSlashToSeeCommands` ("Type / to see commands")

更新了所有 `app_*.arb` 多语言包文件，并替换了代码中的引用。
遵循极简风格规范，并更新了 `translator.md` 日志。
已格式化代码并通过静态检查。

---
*PR created automatically by Jules for task [7217828871439273528](https://jules.google.com/task/7217828871439273528) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 Slash Commands 菜单的中文硬编码提取为本地化词条，支持 zh/en/ja/ko/fr/es/de。同步优化德/法/西/韩译文，统一多语言体验。

- **Refactors**
  - 抽取「可用命令」「输入 / 查看命令」为 `availableCommands`、`typeSlashToSeeCommands`。
  - 为 zh/en/ja/ko/fr/es/de 添加词条，优化德/法/西/韩译文。
  - 在 `lib/widgets/ai/slash_commands_menu.dart` 使用 `AppLocalizations` 替代硬编码；更新 `.jules/translator.md`。

<sup>Written for commit a4aab80c4a83a16d91f213aa43c21fea0e069a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * AI 命令菜单新增多语言支持。
  * 命令菜单标题及输入提示已适配德语、英语、西班牙语、法语、日语、韩语和中文。
* **改进**
  * 用户可根据当前应用语言查看“可用命令”及输入 `/` 查看命令的提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->