### PR TITLE
🧹 移除 NoteFilterSortSheet 中的死代码

### DIFF
--- a/lib/widgets/note_filter_sort_sheet.dart
+++ b/lib/widgets/note_filter_sort_sheet.dart
@@ -23,7 +23,8 @@ class NoteFilterSortSheet extends StatefulWidget {
     bool sortAscending,
     List<String> selectedWeathers,
     List<String> selectedDayPeriods,
-  ) onApply;
+  )
+  onApply;
 
   const NoteFilterSortSheet({
     super.key,
@@ -115,7 +116,9 @@ class _NoteFilterSortSheetState extends State<NoteFilterSortSheet> {
   /// 获取本地化的天气筛选分类标签
   String _getWeatherFilterLabel(BuildContext context, String filterCategory) {
     return WeatherService.getLocalizedFilterCategoryLabel(
-        context, filterCategory);
+      context,
+      filterCategory,
+    );
   }
 
   /// 获取本地化的时间段标签
@@ -141,10 +144,7 @@ class _NoteFilterSortSheetState extends State<NoteFilterSortSheet> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    l10n.filterAndSort,
-                    style: theme.textTheme.titleMedium,
-                  ),
+                  Text(l10n.filterAndSort, style: theme.textTheme.titleMedium),
                   TextButton(
                     onPressed: () {
                       setState(() {
@@ -246,10 +246,7 @@ class _NoteFilterSortSheetState extends State<NoteFilterSortSheet> {
           children: [
             Row(
               children: [
-                Text(
-                  title,
-                  style: theme.textTheme.bodyLarge,
-                ),
+                Text(title, style: theme.textTheme.bodyLarge),
                 if (showScrollHint) ...[
                   const SizedBox(width: 8),
                   Icon(
@@ -333,9 +330,7 @@ class _NoteFilterSortSheetState extends State<NoteFilterSortSheet> {
             if (tag.iconName != null && tag.iconName!.isNotEmpty)
               isEmoji
                   ? Text(tag.iconName!, style: const TextStyle(fontSize: 16))
-                  : (tagIcon is IconData)
-                      ? Icon(tagIcon, size: 16)
-                      : const SizedBox.shrink(),
+                  : Icon(tagIcon, size: 16),
             const SizedBox(width: 4),
             Flexible(
               child: Text(
@@ -384,9 +379,9 @@ class _NoteFilterSortSheetState extends State<NoteFilterSortSheet> {
 
       if (!authenticated) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(l10n.biometricAuthFailed)),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(l10n.biometricAuthFailed)));
         }
         return;
       }

--- a/lib/widgets/note_filter_sort_sheet.dart
+++ b/lib/widgets/note_filter_sort_sheet.dart
@@ -23,8 +23,7 @@ class NoteFilterSortSheet extends StatefulWidget {
     bool sortAscending,
     List<String> selectedWeathers,
     List<String> selectedDayPeriods,
-  )
-  onApply;
+  ) onApply;
 
   const NoteFilterSortSheet({
     super.key,


### PR DESCRIPTION
🎯 **What:** 移除了 `lib/widgets/note_filter_sort_sheet.dart` 中的冗余类型检查 `tagIcon is IconData` 及其导致的三元表达式死代码，直接替换为 `Icon(tagIcon, size: 16)`。
💡 **Why:** `IconUtils.getIconData` 始终返回 `IconData` 类型的对象，因此 `tagIcon is IconData` 永远为 `true`。移除这个无用的判断可以减少 Dart analyzer 警告，提升代码的简洁度和可读性。
✅ **Verification:** 运行了 `dart format` 和 `flutter analyze` 验证无任何问题。检查发现没有破坏原有逻辑。
✨ **Result:** 成功消除了一处死代码警告，精简了条件渲染逻辑。

---
*PR created automatically by Jules for task [10840478579032408476](https://jules.google.com/task/10840478579032408476) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
移除 `lib/widgets/note_filter_sort_sheet.dart` 中的死代码：删去始终为真的 `tagIcon is IconData` 判断，直接使用 `Icon(tagIcon, size: 16)` 渲染图标。同步按 `dart format` 调整若干文本与调用格式（如 `SnackBar`/`ScaffoldMessenger`），消除 analyzer 警告，不影响现有行为。

<sup>Written for commit e6e0fd955522ab3475698526a24e61b1b6503ec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

