### PR TITLE
🧪 增加 WeatherService API 响应格式错误测试

### DIFF
--- a/test/unit/services/weather_service_test.dart
+++ b/test/unit/services/weather_service_test.dart
@@ -267,7 +267,7 @@ void main() {
     });
 
     test(
-        'refreshWeather should throw exception on malformed API response (missing current)',
+        'refreshWeather should enter error state on malformed API response (missing current)',
         () async {
       // Arrange
       const latitude = 39.9042;

--- a/test/unit/services/weather_service_test.dart
+++ b/test/unit/services/weather_service_test.dart
@@ -265,5 +265,37 @@ void main() {
       expect(weatherService.temperatureValue, equals(15.0));
       expect(weatherService.lastError, isNotNull);
     });
+
+    test(
+        'refreshWeather should throw exception on malformed API response (missing current)',
+        () async {
+      // Arrange
+      const latitude = 39.9042;
+      const longitude = 116.4074;
+
+      when(mockCacheManager.initialize()).thenAnswer((_) async => {});
+
+      // Simulate API success but malformed response
+      when(mockNetworkService.get(
+        any,
+        timeoutSeconds: anyNamed('timeoutSeconds'),
+      )).thenAnswer((_) async =>
+          HttpResponse('{"other_key": "no_current_here"}', 200, headers: {}));
+
+      // In case fallback is triggered, return null (no cache)
+      when(mockCacheManager.loadWeatherDataIgnoreExpiry(
+        latitude: anyNamed('latitude'),
+        longitude: anyNamed('longitude'),
+      )).thenAnswer((_) async => null);
+
+      // Act
+      await weatherService.refreshWeather(latitude, longitude);
+
+      // Assert
+      // Because we returned null from cache, state will be error.
+      expect(weatherService.state, equals(WeatherServiceState.error));
+      expect(weatherService.hasData, isFalse);
+      expect(weatherService.lastError, contains('API响应格式错误: 缺少 current 数据'));
+    });
   });
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `WeatherService` handling malformed JSON structures (missing `current` data map) has been addressed.
📊 **Coverage:** A test scenario covering malformed HTTP success responses lacking the expected `current` JSON element is now tested, validating that the exact `Exception('API响应格式错误: 缺少 current 数据')` message is captured and that the `WeatherService` enters the correct `error` state instead of breaking down silently.
✨ **Result:** Enhanced test coverage guarantees robust error handling when interacting with real-world, potentially unstable external weather API responses.

---
*PR created automatically by Jules for task [3276058691292330604](https://jules.google.com/task/3276058691292330604) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `WeatherService` 增加单元测试，验证当 API 返回 200 但 JSON 缺少 `current` 字段时，会进入 `error` 状态并记录准确的错误信息。并调整测试用例名称，使其清晰表达“进入错误状态”的预期行为。

<sup>Written for commit bb9e8473ae08ad044e8a3b90882a9b0cfdcc6967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增天气服务异常响应场景的测试，验证 API 缺少必要天气数据时，系统会进入错误状态并正确显示错误信息。
  * 验证无可用缓存时不会错误地显示天气数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->