### PR TITLE
🔒 修复 ChatSessionService 中的 SQL 注入漏洞

### DIFF
--- a/lib/services/chat_session_service.dart
+++ b/lib/services/chat_session_service.dart
@@ -451,6 +451,12 @@ class ChatSessionService extends ChangeNotifier {
       throw ArgumentError.value(
           columnName, 'columnName', 'Invalid column name');
     }
+    final definitionRegex =
+        RegExp(r"^[a-zA-Z0-9_ ]+(?:DEFAULT (?:'[a-zA-Z0-9_]*'|[0-9]+))?$");
+    if (!definitionRegex.hasMatch(definition.trim())) {
+      throw ArgumentError.value(
+          definition, 'definition', 'Invalid column definition');
+    }
 
     final columns =
         await db.rawQuery('SELECT * FROM pragma_table_info(?)', [tableName]);

--- a/lib/services/chat_session_service.dart
+++ b/lib/services/chat_session_service.dart
@@ -360,25 +360,25 @@ class ChatSessionService extends ChangeNotifier {
       )
     ''');
 
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_sessions',
       columnName: 'session_type',
       definition: "TEXT NOT NULL DEFAULT 'note'",
     );
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_sessions',
       columnName: 'note_id',
       definition: 'TEXT',
     );
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_sessions',
       columnName: 'title',
       definition: "TEXT NOT NULL DEFAULT ''",
     );
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_sessions',
       columnName: 'last_active_at',
@@ -389,31 +389,31 @@ class ChatSessionService extends ChangeNotifier {
       SET last_active_at = COALESCE(NULLIF(last_active_at, ''), created_at)
       WHERE last_active_at IS NULL OR last_active_at = ''
     ''');
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_sessions',
       columnName: 'is_pinned',
       definition: 'INTEGER NOT NULL DEFAULT 0',
     );
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_messages',
       columnName: 'included_in_context',
       definition: 'INTEGER NOT NULL DEFAULT 1',
     );
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_messages',
       columnName: 'meta_json',
       definition: 'TEXT',
     );
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_messages',
       columnName: 'content_format',
       definition: 'TEXT',
     );
-    await _addColumnIfMissing(
+    await addColumnIfMissing(
       db,
       tableName: 'chat_messages',
       columnName: 'delta_json',
@@ -437,7 +437,8 @@ class ChatSessionService extends ChangeNotifier {
     );
   }
 
-  Future<void> _addColumnIfMissing(
+  @visibleForTesting
+  Future<void> addColumnIfMissing(
     DatabaseExecutor db, {
     required String tableName,
     required String columnName,

--- a/test/unit/services/chat_session_service_security_test.dart
+++ b/test/unit/services/chat_session_service_security_test.dart
@@ -20,34 +20,25 @@ void main() {
       // Access the private method via dynamic for testing
       final service = ChatSessionService(openOwnDatabase: false);
 
-      await expectLater(
-        () async => await service.addColumnIfMissing(
-          db,
-          tableName: 'dummy',
-          columnName: 'col1',
-          definition: "TEXT NOT NULL DEFAULT 'note'",
-        ),
-        returnsNormally,
+      await service.addColumnIfMissing(
+        db,
+        tableName: 'dummy',
+        columnName: 'col1',
+        definition: "TEXT NOT NULL DEFAULT 'note'",
       );
 
-      await expectLater(
-        () async => await service.addColumnIfMissing(
-          db,
-          tableName: 'dummy',
-          columnName: 'col2',
-          definition: 'INTEGER NOT NULL DEFAULT 0',
-        ),
-        returnsNormally,
+      await service.addColumnIfMissing(
+        db,
+        tableName: 'dummy',
+        columnName: 'col2',
+        definition: 'INTEGER NOT NULL DEFAULT 0',
       );
 
-      await expectLater(
-        () async => await service.addColumnIfMissing(
-          db,
-          tableName: 'dummy',
-          columnName: 'col3',
-          definition: 'TEXT',
-        ),
-        returnsNormally,
+      await service.addColumnIfMissing(
+        db,
+        tableName: 'dummy',
+        columnName: 'col3',
+        definition: 'TEXT',
       );
 
       await db.close();

--- a/test/unit/services/chat_session_service_security_test.dart
+++ b/test/unit/services/chat_session_service_security_test.dart
@@ -54,7 +54,8 @@ void main() {
       await db.close();
     });
 
-    test('invalid definitions with SQL injection payload are rejected', () async {
+    test('invalid definitions with SQL injection payload are rejected',
+        () async {
       final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
       await db.execute('CREATE TABLE dummy(id TEXT)');
 
@@ -68,7 +69,8 @@ void main() {
           columnName: 'col4',
           definition: "TEXT; DROP TABLE dummy;",
         ),
-        throwsA(isA<ArgumentError>().having((e) => e.message, 'message', 'Invalid column definition')),
+        throwsA(isA<ArgumentError>()
+            .having((e) => e.message, 'message', 'Invalid column definition')),
       );
 
       await expectLater(

--- a/test/unit/services/chat_session_service_security_test.dart
+++ b/test/unit/services/chat_session_service_security_test.dart
@@ -12,48 +12,48 @@ void main() {
   });
 
   group('ChatSessionService definition regex tests', () {
-    test('valid definitions are allowed', () async {
-      final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    Database? db;
+    late ChatSessionService service;
+
+    setUp(() async {
+      db = await databaseFactory.openDatabase(inMemoryDatabasePath);
       // Create dummy table to avoid missing table error
-      await db.execute('CREATE TABLE dummy(id TEXT)');
+      await db!.execute('CREATE TABLE dummy(id TEXT)');
+      service = ChatSessionService(openOwnDatabase: false);
+    });
 
-      // Access the private method via dynamic for testing
-      final service = ChatSessionService(openOwnDatabase: false);
+    tearDown(() async {
+      await db?.close();
+    });
 
+    test('valid definitions are allowed', () async {
       await service.addColumnIfMissing(
-        db,
+        db!,
         tableName: 'dummy',
         columnName: 'col1',
         definition: "TEXT NOT NULL DEFAULT 'note'",
       );
 
       await service.addColumnIfMissing(
-        db,
+        db!,
         tableName: 'dummy',
         columnName: 'col2',
         definition: 'INTEGER NOT NULL DEFAULT 0',
       );
 
       await service.addColumnIfMissing(
-        db,
+        db!,
         tableName: 'dummy',
         columnName: 'col3',
         definition: 'TEXT',
       );
-
-      await db.close();
     });
 
     test('invalid definitions with SQL injection payload are rejected',
         () async {
-      final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
-      await db.execute('CREATE TABLE dummy(id TEXT)');
-
-      final service = ChatSessionService(openOwnDatabase: false);
-
       await expectLater(
         () async => await service.addColumnIfMissing(
-          db,
+          db!,
           tableName: 'dummy',
           columnName: 'col4',
           definition: "TEXT; DROP TABLE dummy;",
@@ -64,26 +64,19 @@ void main() {
 
       await expectLater(
         () async => await service.addColumnIfMissing(
-          db,
+          db!,
           tableName: 'dummy',
           columnName: 'col5',
           definition: "TEXT DEFAULT 'a'; --",
         ),
         throwsA(isA<ArgumentError>()),
       );
-
-      await db.close();
     });
 
     test('empty string or blank string definitions are rejected', () async {
-      final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
-      await db.execute('CREATE TABLE dummy(id TEXT)');
-
-      final service = ChatSessionService(openOwnDatabase: false);
-
       await expectLater(
         () async => await service.addColumnIfMissing(
-          db,
+          db!,
           tableName: 'dummy',
           columnName: 'col6',
           definition: "",
@@ -93,15 +86,13 @@ void main() {
 
       await expectLater(
         () async => await service.addColumnIfMissing(
-          db,
+          db!,
           tableName: 'dummy',
           columnName: 'col7',
           definition: "   ",
         ),
         throwsA(isA<ArgumentError>()),
       );
-
-      await db.close();
     });
   });
 }

--- a/test/unit/services/chat_session_service_security_test.dart
+++ b/test/unit/services/chat_session_service_security_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:thoughtecho/services/chat_session_service.dart';
+
+// ignore: depend_on_referenced_packages
+import 'package:sqflite_common/sqlite_api.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  group('ChatSessionService definition regex tests', () {
+    test('valid definitions are allowed', () async {
+      final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+      // Create dummy table to avoid missing table error
+      await db.execute('CREATE TABLE dummy(id TEXT)');
+
+      // Access the private method via dynamic for testing
+      final service = ChatSessionService(openOwnDatabase: false);
+      dynamic dynamicService = service;
+
+      await expectLater(
+        () async => await dynamicService._addColumnIfMissing(
+          db,
+          tableName: 'dummy',
+          columnName: 'col1',
+          definition: "TEXT NOT NULL DEFAULT 'note'",
+        ),
+        returnsNormally,
+      );
+
+      await expectLater(
+        () async => await dynamicService._addColumnIfMissing(
+          db,
+          tableName: 'dummy',
+          columnName: 'col2',
+          definition: 'INTEGER NOT NULL DEFAULT 0',
+        ),
+        returnsNormally,
+      );
+
+      await expectLater(
+        () async => await dynamicService._addColumnIfMissing(
+          db,
+          tableName: 'dummy',
+          columnName: 'col3',
+          definition: 'TEXT',
+        ),
+        returnsNormally,
+      );
+
+      await db.close();
+    });
+
+    test('invalid definitions with SQL injection payload are rejected', () async {
+      final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+      await db.execute('CREATE TABLE dummy(id TEXT)');
+
+      final service = ChatSessionService(openOwnDatabase: false);
+      dynamic dynamicService = service;
+
+      await expectLater(
+        () async => await dynamicService._addColumnIfMissing(
+          db,
+          tableName: 'dummy',
+          columnName: 'col4',
+          definition: "TEXT; DROP TABLE dummy;",
+        ),
+        throwsA(isA<ArgumentError>().having((e) => e.message, 'message', 'Invalid column definition')),
+      );
+
+      await expectLater(
+        () async => await dynamicService._addColumnIfMissing(
+          db,
+          tableName: 'dummy',
+          columnName: 'col5',
+          definition: "TEXT DEFAULT 'a'; --",
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await db.close();
+    });
+
+    test('empty string or blank string definitions are rejected', () async {
+      final db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+      await db.execute('CREATE TABLE dummy(id TEXT)');
+
+      final service = ChatSessionService(openOwnDatabase: false);
+      dynamic dynamicService = service;
+
+      await expectLater(
+        () async => await dynamicService._addColumnIfMissing(
+          db,
+          tableName: 'dummy',
+          columnName: 'col6',
+          definition: "",
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await expectLater(
+        () async => await dynamicService._addColumnIfMissing(
+          db,
+          tableName: 'dummy',
+          columnName: 'col7',
+          definition: "   ",
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      await db.close();
+    });
+  });
+}

--- a/test/unit/services/chat_session_service_security_test.dart
+++ b/test/unit/services/chat_session_service_security_test.dart
@@ -19,10 +19,9 @@ void main() {
 
       // Access the private method via dynamic for testing
       final service = ChatSessionService(openOwnDatabase: false);
-      dynamic dynamicService = service;
 
       await expectLater(
-        () async => await dynamicService._addColumnIfMissing(
+        () async => await service.addColumnIfMissing(
           db,
           tableName: 'dummy',
           columnName: 'col1',
@@ -32,7 +31,7 @@ void main() {
       );
 
       await expectLater(
-        () async => await dynamicService._addColumnIfMissing(
+        () async => await service.addColumnIfMissing(
           db,
           tableName: 'dummy',
           columnName: 'col2',
@@ -42,7 +41,7 @@ void main() {
       );
 
       await expectLater(
-        () async => await dynamicService._addColumnIfMissing(
+        () async => await service.addColumnIfMissing(
           db,
           tableName: 'dummy',
           columnName: 'col3',
@@ -60,10 +59,9 @@ void main() {
       await db.execute('CREATE TABLE dummy(id TEXT)');
 
       final service = ChatSessionService(openOwnDatabase: false);
-      dynamic dynamicService = service;
 
       await expectLater(
-        () async => await dynamicService._addColumnIfMissing(
+        () async => await service.addColumnIfMissing(
           db,
           tableName: 'dummy',
           columnName: 'col4',
@@ -74,7 +72,7 @@ void main() {
       );
 
       await expectLater(
-        () async => await dynamicService._addColumnIfMissing(
+        () async => await service.addColumnIfMissing(
           db,
           tableName: 'dummy',
           columnName: 'col5',
@@ -91,10 +89,9 @@ void main() {
       await db.execute('CREATE TABLE dummy(id TEXT)');
 
       final service = ChatSessionService(openOwnDatabase: false);
-      dynamic dynamicService = service;
 
       await expectLater(
-        () async => await dynamicService._addColumnIfMissing(
+        () async => await service.addColumnIfMissing(
           db,
           tableName: 'dummy',
           columnName: 'col6',
@@ -104,7 +101,7 @@ void main() {
       );
 
       await expectLater(
-        () async => await dynamicService._addColumnIfMissing(
+        () async => await service.addColumnIfMissing(
           db,
           tableName: 'dummy',
           columnName: 'col7',


### PR DESCRIPTION
🎯 **What:**
Fixed an SQL injection vulnerability in `lib/services/chat_session_service.dart`. The `definition` parameter (e.g., column types and defaults) was being unsafely interpolated directly into an `ALTER TABLE` query.

⚠️ **Risk:**
While this method is primarily internal schema management, passing unsanitized strings directly to `ALTER TABLE` leaves the door open to SQL injection if future features ever dynamically determine table definitions based on external input. An attacker could potentially break out of the statement and execute destructive SQL payloads (e.g. `DROP TABLE`, data exfiltration).

🛡️ **Solution:**
Added a strict regular expression allowlist check (`RegExp(r"^[a-zA-Z0-9_ ]+(?:DEFAULT (?:'[a-zA-Z0-9_]*'|[0-9]+))?$")`) for the `definition` string inside `_addColumnIfMissing`. This regex ensures that only valid alphanumeric types, spaces, and controlled `DEFAULT` clauses can be interpolated, throwing an `ArgumentError` otherwise.

---
*PR created automatically by Jules for task [873929704783865925](https://jules.google.com/task/873929704783865925) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `ChatSessionService` 在 `ALTER TABLE` 列定义拼接处的 SQL 注入风险，新增严格校验并公开测试入口；完善单测与生命周期管理，保持 CI 绿灯。

- **Bug Fixes**
  - 在 `addColumnIfMissing` 中为 `definition` 增加白名单正则校验：`^[a-zA-Z0-9_ ]+(?:DEFAULT (?:'[a-zA-Z0-9_]*'|[0-9]+))?$`，不匹配即抛出 `ArgumentError`。
  - 将私有 `_addColumnIfMissing` 改为公开且标注 `@visibleForTesting` 的 `addColumnIfMissing`，并更新所有调用。
  - 新增并重构安全单测：覆盖合法/注入/空白输入；使用 `setUp/tearDown` 与直接 `await` 避免 DB 提前关闭；`dart format` 修复 CI。

<sup>Written for commit 7536e4c119f2b4e556dbe85dbd72b3b6fa186b54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 更新聊天会话数据库结构，自动补齐缺失字段，提升数据兼容性。
  * 增强列定义校验，拒绝空值、格式异常及潜在恶意内容，提升数据安全性。
  * 完善相关测试，覆盖合法字段定义和无效输入场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->