### PR TITLE
🗃️ 黑匣: [完善 InsightsPage 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -39,3 +39,7 @@
 ## 2025-05-18 - 🗃️ 黑匣: [完善 MediaCleanupService 模块的结构化日志]
 **异常:** [MediaCleanupService 模块在初始化、清理、迁移和统计媒体文件等任务发生错误时，仅使用了 `logDebug` 进行粗糙的字符串拼接打印。这不仅掩盖了底层 `FileSystemException` 或 `StateError` 等导致错误的真实原因，还丢失了完整的异常堆栈轨迹 (stackTrace)，导致排查本地文件系统的读写异常极其困难。]
 **拦截:** [已将上述所有流程中的 `catch (e)` 替换为结构化的 `catch (e, stackTrace)`，并使用 `AppLogger.e` 进行记录。注入了描述信息、具体的错误对象 `error: e`、堆栈轨迹 `stackTrace: stackTrace`，并指定了明确的日志来源模块 `source: 'MediaCleanupService'`。确认所有的错误记录仅涉及本地存储系统与数据库交互时的 IO/状态异常，未记录任何用户笔记的正文或凭证数据。]
+
+## 2025-10-24 - 🗃️ 黑匣: [完善 InsightsPage 模块的结构化日志]
+**异常:** [InsightsPage 模块在数据库连接测试、保存 AI 分析、保存为笔记、分享分析结果以及生成洞察时，如果遇到错误，仅使用了 `logDebug` 进行粗糙的打印或直接未传入堆栈参数 `stack` 进行拦截，这不仅隐藏了关键的错误堆栈信息，也没有统一标记日志的来源模块，从而增加故障排查难度。]
+**拦截:** [已将上述流程中的 `catch (e)` 统一升级为 `catch (e, stack)` 或者利用已有的 `stackTrace`，并用结构化的 `logError('...', error: e, stackTrace: stack, source: 'InsightsPage')` 替换了原有的 `logDebug` 调用。确认所有修改仅记录错误对象和执行阶段描述，没有在日志中记录分析内容正文、API 密钥等用户的隐私数据。]

--- a/lib/pages/insights_page.dart
+++ b/lib/pages/insights_page.dart
@@ -146,8 +146,9 @@ class _InsightsPageState extends State<InsightsPage> {
 
         await _testSaveAnalysis();
       }
-    } catch (e) {
-      logDebug('AI analysis database connection test failed: $e');
+    } catch (e, stack) {
+      logError('AI analysis database connection test failed',
+          error: e, stackTrace: stack, source: 'InsightsPage');
     }
   }
 
@@ -178,8 +179,9 @@ class _InsightsPageState extends State<InsightsPage> {
       } else {
         logDebug('Test verification failed');
       }
-    } catch (e) {
-      logDebug('Test save analysis failed: $e');
+    } catch (e, stack) {
+      logError('Test save analysis failed',
+          error: e, stackTrace: stack, source: 'InsightsPage');
     }
   }
 
@@ -237,8 +239,9 @@ class _InsightsPageState extends State<InsightsPage> {
       try {
         await _aiAnalysisDatabaseService!.database;
         logDebug('Database connection test successful');
-      } catch (dbError) {
-        logDebug('Database connection test failed: $dbError');
+      } catch (dbError, stack) {
+        logError('Database connection test failed',
+            error: dbError, stackTrace: stack, source: 'InsightsPage');
         throw Exception('Database connection failed: $dbError');
       }
 
@@ -278,8 +281,8 @@ class _InsightsPageState extends State<InsightsPage> {
         ),
       );
     } catch (e, stackTrace) {
-      logDebug('Failed to save AI analysis: $e');
-      logDebug('Stack trace: $stackTrace');
+      logError('Failed to save AI analysis',
+          error: e, stackTrace: stackTrace, source: 'InsightsPage');
 
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -326,7 +329,9 @@ class _InsightsPageState extends State<InsightsPage> {
           duration: AppConstants.snackBarDurationImportant,
         ),
       );
-    } catch (e) {
+    } catch (e, stack) {
+      logError('Save as note failed',
+          error: e, stackTrace: stack, source: 'InsightsPage');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -358,7 +363,9 @@ class _InsightsPageState extends State<InsightsPage> {
 
       // 使用share_plus分享
       await SharePlus.instance.share(ShareParams(text: content));
-    } catch (e) {
+    } catch (e, stack) {
+      logError('Share analysis failed',
+          error: e, stackTrace: stack, source: 'InsightsPage');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -509,8 +516,9 @@ class _InsightsPageState extends State<InsightsPage> {
         },
         cancelOnError: true,
       );
-    } catch (e) {
-      logDebug('Failed to generate insights (setup): $e');
+    } catch (e, stack) {
+      logError('Failed to generate insights (setup)',
+          error: e, stackTrace: stack, source: 'InsightsPage');
       if (mounted) {
         String errorMessage = l10n.generateInsightsSetupError(e.toString());
 


### PR DESCRIPTION
已将 `InsightsPage` 模块中的异常捕获拦截点（如测试数据库连接、保存/分享洞察及生成报错时）升级。
1. 使用了 `logError(..., error: e, stackTrace: stack, source: 'InsightsPage')` 代替原有的粗糙 `logDebug` 和空 `stack` 捕获。
2. 明确补充了缺失的 `stackTrace` 等结构化日志信息并添加了模块溯源信息。
3. **安全确认：** 修改内容已核实，仅记录操作异常对象和节点描述信息，**绝未包含任何用户日记、API密钥或其他敏感隐私数据。**

---
*PR created automatically by Jules for task [16635982989816952975](https://jules.google.com/task/16635982989816952975) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 InsightsPage 引入结构化错误日志，统一使用 logError 记录 error、stackTrace 和来源。提升排障效率并保留完整堆栈，同时不记录任何隐私数据。

- **Refactors**
  - 在数据库连接测试、保存分析、保存为笔记、分享、生成洞察初始化等处，改用 catch (e, stack) + logError(..., error, stackTrace, source: 'InsightsPage')。
  - 移除分散的 logDebug 与分离堆栈打印，统一消息格式与来源标记。
  - 更新 `.jules/blackbox.md`，补充本模块改动与安全说明；仅记录异常对象与阶段描述，不含用户内容或 API 密钥。

<sup>Written for commit d0adf1ce9a917d718f1e795b802251a8f876610d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 改进 InsightsPage 多项操作的错误记录，补充统一来源和堆栈信息。
  * 覆盖数据库连接、保存分析、生成洞察、保存笔记及分享等失败场景。
  * 保持现有界面提示和回退行为不变，并避免记录分析内容及 API 密钥等隐私信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->