### PR TITLE
🎨 Palette: 补充 AI 助手与界面按钮的无障碍提示 (Tooltips)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,6 @@
 ## 2026-06-26 - Missing Tooltips on Icon-Only Buttons
 **Learning:** Found multiple instances where icon-only `IconButton`s lacked the `tooltip` property, causing accessibility issues for screen readers and missing hover text for desktop users. Examples included the password visibility toggle in `webdav_sync_page.dart` and `_CircleIconButton` wrapper in `motion_photo_preview_page.dart`.
 **Action:** Always verify `tooltip` property presence on `IconButton` usage, especially in custom widget wrappers (`_CircleIconButton`) or inline suffixes (`suffixIcon`). Use standard `MaterialLocalizations` where applicable (e.g., `closeButtonTooltip`).
+## 2026-06-27 - [Fix Missing Tooltips for AI Assistant Action Buttons]
+**Learning:** IconButtons used for core actions in AI feature UIs (like "thinking" toggles, clear search icons, and stop generating buttons) often lack accessibility labels, making them unusable for screen reader users and missing hover cues on desktop.
+**Action:** When implementing or modifying AI chat interfaces and session histories, ensure that all `IconButton`s include dynamic tooltips (e.g. toggling between 'Show/Hide Thinking', or 'Send/Stop') localized via `AppLocalizations`.

--- a/lib/pages/ai_assistant/ai_assistant_page_ui.dart
+++ b/lib/pages/ai_assistant/ai_assistant_page_ui.dart
@@ -621,6 +621,9 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                             ? theme.colorScheme.secondary
                             : theme.colorScheme.onSurfaceVariant,
                       ),
+                      tooltip: _enableThinking
+                          ? l10n.hideThinking
+                          : l10n.showThinking,
                       onPressed: _isLoading
                           ? null
                           : () {
@@ -640,6 +643,7 @@ extension _AIAssistantPageUI on _AIAssistantPageState {
                       _isLoading ? Icons.stop : Icons.arrow_upward,
                       size: 20,
                     ),
+                    tooltip: _isLoading ? l10n.stopGenerate : l10n.send,
                     onPressed: _isLoading
                         ? _stopGenerating
                         : () {

--- a/lib/pages/ai_assistant/session_history_page.dart
+++ b/lib/pages/ai_assistant/session_history_page.dart
@@ -201,6 +201,7 @@ class _SessionHistoryPageState extends State<SessionHistoryPage> {
                 suffixIcon: _searchQuery.isNotEmpty
                     ? IconButton(
                         icon: const Icon(Icons.clear, size: 18),
+                        tooltip: l10n.clear,
                         onPressed: () {
                           _searchController.clear();
                           setState(() {


### PR DESCRIPTION
💡 **What:**
在 AI 助手交互界面中，为“显示/隐藏思考过程”的切换按钮，以及“发送/停止”按钮和“清除搜索”按钮补充了原先缺失的 `tooltip` 属性。

🎯 **Why:**
纯图标按钮如果缺乏 `tooltip`，屏幕阅读器无法读取该按钮的功能，使得依赖无障碍功能的用户难以进行正常操作。此外，缺乏悬停提示也降低了桌面端用户的操作直观性。

♿ **Accessibility:**
新增的 `tooltip` 使得这些关键操作按键在屏幕阅读器中具备了相应的语意（如“隐藏思考过程”、“停止生成”等）。通过重用现有的 `AppLocalizations` 词条，确保了这些提示语能够正确适配多语言环境。

影响范围：
- `lib/pages/ai_assistant/ai_assistant_page_ui.dart`
- `lib/pages/ai_assistant/session_history_page.dart`

---
*PR created automatically by Jules for task [17032792794554126638](https://jules.google.com/task/17032792794554126638) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为助手与会话历史中的纯图标按钮补充 `tooltip`，提升无障碍和桌面悬停提示体验。提示文案来自 `AppLocalizations`，并随按钮状态动态切换。

- **New Features**
  - “显示/隐藏思考过程”切换按钮新增 `tooltip`（随 `_enableThinking` 切换）。
  - “发送/停止”按钮新增 `tooltip`（随 `_isLoading` 切换）。
  - 搜索框“清除”按钮新增 `tooltip`。

<sup>Written for commit 573ff99c3b74a88806277d65b7efc4136d9574ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

