### PR TITLE
🌐 译者: 提取硬编码

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -48,3 +48,6 @@
 **发现:** 在 `lib/widgets/ai/slash_commands_menu.dart` 中发现了硬编码的中文提示语：`'可用命令'` 和 `'输入 / 查看命令'`
 **规则:**
 - 采用极简风格进行国际化翻译，分别新增 `availableCommands` 和 `typeSlashToSeeCommands` 到所有 `app_*.arb` 语言包中。
+## 2026-07-20 - [提取 tool_call_card.dart 重试按钮硬编码]
+**发现:** 在 lib/widgets/ai/tool_call_card.dart 中存在硬编码 '重试'
+**规则:** 采用极简风格翻译，复用已存在的 `retry` 键值。

--- a/lib/widgets/ai/tool_call_card.dart
+++ b/lib/widgets/ai/tool_call_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:thoughtecho/gen_l10n/app_localizations.dart';
 
 /// Tool调用状态
 enum ToolCallStatus {
@@ -315,7 +316,7 @@ class _ToolCallProgressCardState extends State<ToolCallProgressCard>
                           child: ElevatedButton.icon(
                             onPressed: widget.onRetry,
                             icon: const Icon(Icons.refresh, size: 18),
-                            label: const Text('重试'),
+                            label: Text(AppLocalizations.of(context).retry),
                           ),
                         ),
                     ],


### PR DESCRIPTION
🎯 **What:** 
提取 `lib/widgets/ai/tool_call_card.dart` 中的硬编码中文字符串，推进国际化。

💡 **Why:**
为了支持无国界体验，需要将所有的硬编码 UI 字符串替换为多语言词条。

🔍 **词条对照:**
- `"retry": "重试"` (中文)
- `"retry": "Retry"` (英文)

✅ **Verification:**
- 代码已通过 `flutter analyze` 静态检查。
- 未引入新依赖，且翻译风格符合极简主义规范。
- 修改已控制在极少行数内。

---
*PR created automatically by Jules for task [141787294662087681](https://jules.google.com/task/141787294662087681) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
从 `lib/widgets/ai/tool_call_card.dart` 提取“重试”硬编码，改用本地化键 `retry`，统一多语言体验。无功能变化。

- **Refactors**
  - 引入 `AppLocalizations`，将按钮文本改为 `retry`。
  - 更新 `.jules/translator.md`，补充对应提取规则。

<sup>Written for commit 03b73c223ee8978e063aaf6ec8d7b28764d8d852. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * “重试”按钮现已支持本地化显示，提升多语言环境下的使用体验。
  * 保留原有错误状态下显示按钮及触发重试操作的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->