### PR TITLE
🧪 标尺: [补充 DioPerformanceInterceptor 的测试]

### DIFF
--- a/lib/services/unified_log_service.dart
+++ b/lib/services/unified_log_service.dart
@@ -282,6 +282,11 @@ class UnifiedLogService with ChangeNotifier, WidgetsBindingObserver {
     return _instance!;
   }
 
+  @visibleForTesting
+  static set instanceForTesting(UnifiedLogService service) {
+    _instance = service;
+  }
+
   /// 创建统一日志服务实例
   UnifiedLogService._();
 

--- a/test/unit/utils/dio_performance_interceptor_test.dart
+++ b/test/unit/utils/dio_performance_interceptor_test.dart
@@ -114,6 +114,7 @@ void main() {
       final err = DioException(
           requestOptions: options,
           error: "Connection timeout",
+          message: "Connection timeout",
           response: Response(requestOptions: options, statusCode: 500));
       final handler = FakeErrorInterceptorHandler();
 

--- a/test/unit/utils/dio_performance_interceptor_test.dart
+++ b/test/unit/utils/dio_performance_interceptor_test.dart
@@ -1,0 +1,152 @@
+import "package:dio/dio.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:thoughtecho/utils/dio_performance_interceptor.dart";
+import "package:thoughtecho/services/unified_log_service.dart";
+import "package:flutter/widgets.dart";
+
+class FakeUnifiedLogService extends ChangeNotifier
+    with WidgetsBindingObserver
+    implements UnifiedLogService {
+  final List<Map<String, dynamic>> logRecords = [];
+
+  @override
+  void warning(String message,
+      {String? source, Object? error, StackTrace? stackTrace}) {
+    logRecords.add({
+      "level": UnifiedLogLevel.warning,
+      "message": message,
+      "source": source,
+      "error": error,
+      "stackTrace": stackTrace,
+    });
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeRequestInterceptorHandler extends RequestInterceptorHandler {
+  final List<RequestOptions> calledOptions = [];
+  @override
+  void next(RequestOptions options) {
+    calledOptions.add(options);
+  }
+}
+
+class FakeResponseInterceptorHandler extends ResponseInterceptorHandler {
+  final List<Response> calledResponses = [];
+  @override
+  void next(Response response) {
+    calledResponses.add(response);
+  }
+}
+
+class FakeErrorInterceptorHandler extends ErrorInterceptorHandler {
+  final List<DioException> calledErrors = [];
+  @override
+  void next(DioException err) {
+    calledErrors.add(err);
+  }
+}
+
+void main() {
+  group("DioPerformanceInterceptor", () {
+    late FakeUnifiedLogService fakeLogService;
+    late DioPerformanceInterceptor interceptor;
+
+    setUp(() {
+      fakeLogService = FakeUnifiedLogService();
+      UnifiedLogService.instanceForTesting = fakeLogService;
+      interceptor = DioPerformanceInterceptor();
+    });
+
+    test("onRequest injects timestamp into extra", () {
+      final options = RequestOptions(path: "/test");
+      final handler = FakeRequestInterceptorHandler();
+
+      interceptor.onRequest(options, handler);
+
+      expect(handler.calledOptions.length, 1);
+      final modifiedOptions = handler.calledOptions.first;
+      expect(modifiedOptions.extra.containsKey("request_start_time"), isTrue);
+      expect(modifiedOptions.extra["request_start_time"], isA<int>());
+    });
+
+    test("onResponse logs when request is slow", () async {
+      final options = RequestOptions(path: "/slow");
+      // Simulate request started 4000ms ago
+      options.extra["request_start_time"] =
+          DateTime.now().millisecondsSinceEpoch - 4000;
+      final response = Response(requestOptions: options, statusCode: 200);
+      final handler = FakeResponseInterceptorHandler();
+
+      interceptor.onResponse(response, handler);
+
+      expect(handler.calledResponses.length, 1);
+      expect(fakeLogService.logRecords.length, 1);
+
+      final logRecord = fakeLogService.logRecords.first;
+      expect(logRecord["level"], UnifiedLogLevel.warning);
+      expect(logRecord["source"], "NetworkPerf");
+      expect(
+          logRecord["message"], contains("[API耗时] GET /slow -> 状态:200, 耗时:"));
+    });
+
+    test("onResponse does not log when request is fast", () async {
+      final options = RequestOptions(path: "/fast");
+      // Simulate request started 100ms ago
+      options.extra["request_start_time"] =
+          DateTime.now().millisecondsSinceEpoch - 100;
+      final response = Response(requestOptions: options, statusCode: 200);
+      final handler = FakeResponseInterceptorHandler();
+
+      interceptor.onResponse(response, handler);
+
+      expect(handler.calledResponses.length, 1);
+      expect(fakeLogService.logRecords.length, 0);
+    });
+
+    test("onError logs regardless of duration if there is an error", () async {
+      final options = RequestOptions(path: "/error_path");
+      // Simulate request started 100ms ago (fast request, but failed)
+      options.extra["request_start_time"] =
+          DateTime.now().millisecondsSinceEpoch - 100;
+      final err = DioException(
+          requestOptions: options,
+          error: "Connection timeout",
+          response: Response(requestOptions: options, statusCode: 500));
+      final handler = FakeErrorInterceptorHandler();
+
+      interceptor.onError(err, handler);
+
+      expect(handler.calledErrors.length, 1);
+      expect(fakeLogService.logRecords.length, 1);
+
+      final logRecord = fakeLogService.logRecords.first;
+      expect(logRecord["level"], UnifiedLogLevel.warning);
+      expect(logRecord["source"], "NetworkPerf");
+      expect(logRecord["message"],
+          contains("[API耗时] GET /error_path -> 状态:500, 耗时:"));
+      expect(logRecord["message"], contains("(错误: Connection timeout)"));
+    });
+
+    test("URL length is truncated if too long", () async {
+      final longPath = "/" + "a" * 100;
+      final options = RequestOptions(path: longPath);
+      options.extra["request_start_time"] =
+          DateTime.now().millisecondsSinceEpoch - 4000;
+      final response = Response(requestOptions: options, statusCode: 200);
+      final handler = FakeResponseInterceptorHandler();
+
+      interceptor.onResponse(response, handler);
+
+      expect(fakeLogService.logRecords.length, 1);
+      final logMessage = fakeLogService.logRecords.first["message"] as String;
+
+      // Expected length: 77 + 3 ("...") = 80 characters from the path
+      final truncatedPath = longPath.substring(0, 77) + "...";
+      expect(logMessage, contains(truncatedPath));
+      expect(logMessage.contains(longPath), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:**
Added a comprehensive test suite for `DioPerformanceInterceptor` to ensure that API requests are appropriately monitored and logged according to performance thresholds and error conditions. Also, exposed a `@visibleForTesting` setter for `UnifiedLogService.instance` to enable clean test dependency injection.

📊 **Coverage:**
- Verified `request_start_time` is correctly injected into `RequestOptions`.
- Verified slow requests (>3000ms) trigger warning logs.
- Verified fast requests (<=3000ms) are completely ignored.
- Verified error requests trigger warning logs regardless of execution time.
- Verified URL truncation logic cleanly shortens excessively long URLs to prevent database bloat.

✨ **Result:**
The interceptor logic is now fully covered by deterministic tests, securing network profiling and error-tracking mechanisms against regression.

---
*PR created automatically by Jules for task [16562378637614315211](https://jules.google.com/task/16562378637614315211) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `DioPerformanceInterceptor` 补充单元测试，确保性能监控与错误日志按预期运行。新增 `@visibleForTesting` 的 `UnifiedLogService.instanceForTesting`，便于在测试中注入假实现。

- **测试范围**
  - 向 `RequestOptions.extra` 注入 `request_start_time`
  - 慢请求（>3000ms）记录 warning
  - 快速请求（<=3000ms）不记录
  - 错误请求始终记录 warning，含错误信息
  - 过长 URL 按策略截断，避免日志膨胀

<sup>Written for commit 08e57e889f4050764221f1b12a9f90a6276055e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

