### PR TITLE
🧪 补充 JankDetector 模块的单元测试

### DIFF
--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -588,8 +588,8 @@ class NoteListViewState extends State<NoteListView> {
       }
 
       // 判断是否仅为排序变化（不影响列表内容，只影响顺序）
-      final bool isOnlySortChange =
-          oldWidget.searchQuery == widget.searchQuery &&
+      final bool isOnlySortChange = oldWidget.searchQuery ==
+              widget.searchQuery &&
           _areListsEqual(oldWidget.selectedTagIds, widget.selectedTagIds) &&
           _areListsEqual(oldWidget.selectedWeathers, widget.selectedWeathers) &&
           _areListsEqual(
@@ -799,14 +799,12 @@ class NoteListViewState extends State<NoteListView> {
       if (_initialDataCompleter == null) {
         const maxWaitMs = 500;
         const stepMs = 50;
-        for (
-          var waited = 0;
-          waited < maxWaitMs &&
-              mounted &&
-              !_initialDataLoaded &&
-              _initialDataCompleter == null;
-          waited += stepMs
-        ) {
+        for (var waited = 0;
+            waited < maxWaitMs &&
+                mounted &&
+                !_initialDataLoaded &&
+                _initialDataCompleter == null;
+            waited += stepMs) {
           await Future<void>.delayed(const Duration(milliseconds: stepMs));
         }
       }

--- a/test/unit/utils/jank_detector_test.dart
+++ b/test/unit/utils/jank_detector_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/jank_detector.dart';
+import 'package:thoughtecho/services/unified_log_service.dart';
+
+class FakeUnifiedLogService implements UnifiedLogService {
+  final List<String> warnings = [];
+
+  @override
+  void warning(String message,
+      {dynamic error, String? source, StackTrace? stackTrace}) {
+    warnings.add(message);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  testWidgets('JankDetector normal, jank, throttle and session tests',
+      (WidgetTester tester) async {
+    final fakeLogService = FakeUnifiedLogService();
+    UnifiedLogService.instanceForTesting = fakeLogService;
+
+    JankDetector.init();
+
+    // init 再次调用，应该直接返回 (由于 _initialized)
+    JankDetector.init();
+
+    // Normal frame: build 16ms, raster 16ms (under 32ms)
+    tester.binding.platformDispatcher.onReportTimings?.call([
+      FrameTiming(
+        vsyncStart: 0,
+        buildStart: 0,
+        buildFinish: 16000,
+        rasterStart: 16000,
+        rasterFinish: 32000,
+        rasterFinishWallTime: 32000,
+      )
+    ]);
+
+    expect(fakeLogService.warnings.isEmpty, isTrue,
+        reason: 'Normal frame should not trigger log');
+
+    // Jank frame: build 40ms, raster 10ms (build > 32ms)
+    tester.binding.platformDispatcher.onReportTimings?.call([
+      FrameTiming(
+        vsyncStart: 0,
+        buildStart: 0,
+        buildFinish: 40000,
+        rasterStart: 40000,
+        rasterFinish: 50000,
+        rasterFinishWallTime: 50000,
+      )
+    ]);
+
+    expect(fakeLogService.warnings.length, 1,
+        reason: 'Jank frame should trigger log');
+    expect(fakeLogService.warnings.last, contains('UI构建: 40ms'));
+
+    // Consecutive Jank frame (within 2s throttle duration): should not log
+    tester.binding.platformDispatcher.onReportTimings?.call([
+      FrameTiming(
+        vsyncStart: 0,
+        buildStart: 0,
+        buildFinish: 50000,
+        rasterStart: 50000,
+        rasterFinish: 60000,
+        rasterFinishWallTime: 60000,
+      )
+    ]);
+
+    expect(fakeLogService.warnings.length, 1,
+        reason: 'Consecutive jank frame should be throttled');
+
+    // Wait for throttle duration to pass using runAsync to avoid FakeAsync deadlocks
+    await tester.runAsync(() async {
+      await Future.delayed(const Duration(milliseconds: 2100));
+    });
+
+    // Test with session
+    JankDetector.beginSession('test_session_123');
+
+    // Jank frame again, should log now with session (raster > 32ms)
+    tester.binding.platformDispatcher.onReportTimings?.call([
+      FrameTiming(
+        vsyncStart: 0,
+        buildStart: 0,
+        buildFinish: 10000,
+        rasterStart: 10000,
+        rasterFinish: 50000,
+        rasterFinishWallTime: 50000,
+      )
+    ]);
+
+    expect(fakeLogService.warnings.length, 2,
+        reason: 'Jank frame after throttle duration should log');
+    expect(fakeLogService.warnings.last, contains('session=test_session_123'));
+    expect(fakeLogService.warnings.last, contains('GPU渲染: 40ms'));
+
+    // End session correctly
+    JankDetector.endSession('test_session_123');
+
+    // Begin new session
+    JankDetector.beginSession('test_session_456');
+    // Try to end with wrong session ID, should not clear
+    JankDetector.endSession('wrong_session');
+
+    // Wait for throttle duration
+    await tester.runAsync(() async {
+      await Future.delayed(const Duration(milliseconds: 2100));
+    });
+
+    // Jank frame again, should log with session 456
+    tester.binding.platformDispatcher.onReportTimings?.call([
+      FrameTiming(
+        vsyncStart: 0,
+        buildStart: 0,
+        buildFinish: 33000,
+        rasterStart: 33000,
+        rasterFinish: 40000,
+        rasterFinishWallTime: 40000,
+      )
+    ]);
+
+    expect(fakeLogService.warnings.length, 3);
+    expect(fakeLogService.warnings.last, contains('session=test_session_456'));
+
+    // Properly end it
+    JankDetector.endSession('test_session_456');
+
+    // Wait for throttle
+    await tester.runAsync(() async {
+      await Future.delayed(const Duration(milliseconds: 2100));
+    });
+
+    // Jank frame, no session
+    tester.binding.platformDispatcher.onReportTimings?.call([
+      FrameTiming(
+        vsyncStart: 0,
+        buildStart: 0,
+        buildFinish: 35000,
+        rasterStart: 35000,
+        rasterFinish: 40000,
+        rasterFinishWallTime: 40000,
+      )
+    ]);
+
+    expect(fakeLogService.warnings.length, 4);
+    expect(fakeLogService.warnings.last, isNot(contains('session=')));
+  });
+}


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for `JankDetector` (`lib/utils/jank_detector.dart`).
📊 **Coverage:**
  - Tested normal frame rendering under threshold (16ms build, 16ms raster) to ensure no false-positive logs.
  - Tested jank frame rendering over threshold (e.g., 40ms build) to ensure a warning is emitted correctly via `UnifiedLogService`.
  - Tested consecutive jank frames within the 2-second throttle duration to ensure the anti-log-storm mechanism works.
  - Tested jank frames after the throttle duration has expired using `tester.runAsync` to reliably simulate real-world time.
  - Tested the `beginSession` and `endSession` behaviors, verifying that the session ID gets appropriately logged during active sessions, and correctly cleared (or maintained if a mismatch ID is sent) during session ending.
✨ **Result:** Enhanced the test suite coverage, making `JankDetector`'s complex throttling and session logic fully tested and robust against regressions.

---
*PR created automatically by Jules for task [13656140320789865743](https://jules.google.com/task/13656140320789865743) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
补充 `JankDetector` 的单元测试，覆盖正常/卡顿帧、2 秒节流与会话 begin/end，确保仅在真实卡顿时上报并携带正确 session，防止日志风暴与回归。新增 `test/unit/utils/jank_detector_test.dart`，使用 `FakeUnifiedLogService` 校验告警内容。

- **Refactors**
  - 格式化 `lib/widgets/note_list_view.dart`（仅排版/换行），无功能改动。

<sup>Written for commit 5823db2b1e2c48008e04ae777c2d60f0dc87c8b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

