### PR TITLE
🗃️ 黑匣: [完善 FeatureGuideService 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -39,3 +39,6 @@
 ## 2025-05-18 - 🗃️ 黑匣: [完善 MediaCleanupService 模块的结构化日志]
 **异常:** [MediaCleanupService 模块在初始化、清理、迁移和统计媒体文件等任务发生错误时，仅使用了 `logDebug` 进行粗糙的字符串拼接打印。这不仅掩盖了底层 `FileSystemException` 或 `StateError` 等导致错误的真实原因，还丢失了完整的异常堆栈轨迹 (stackTrace)，导致排查本地文件系统的读写异常极其困难。]
 **拦截:** [已将上述所有流程中的 `catch (e)` 替换为结构化的 `catch (e, stackTrace)`，并使用 `AppLogger.e` 进行记录。注入了描述信息、具体的错误对象 `error: e`、堆栈轨迹 `stackTrace: stackTrace`，并指定了明确的日志来源模块 `source: 'MediaCleanupService'`。确认所有的错误记录仅涉及本地存储系统与数据库交互时的 IO/状态异常，未记录任何用户笔记的正文或凭证数据。]
+## 2025-10-25 - 🗃️ 黑匣: [完善 FeatureGuideService 模块的结构化日志]
+**异常:** [MMKV读取/写入抛出异常且只使用了粗糙的debugPrint记录，丢失了错误栈与模块上下文]
+**拦截:** [使用 catch (e, stackTrace) 和 logError 封装 MMKV 异常，附带 error, stackTrace 和 source: 'FeatureGuideService' 参数，保存完整的堆栈上下文信息。]

--- a/lib/services/feature_guide_service.dart
+++ b/lib/services/feature_guide_service.dart
@@ -15,7 +15,8 @@ class FeatureGuideService extends ChangeNotifier {
     try {
       return _storage.getBool('$_keyPrefix$guideId') ?? false;
     } catch (e, stackTrace) {
-      logError('读取引导状态失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
+      logError('读取引导状态失败',
+          error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
       return false;
     }
   }
@@ -27,7 +28,8 @@ class FeatureGuideService extends ChangeNotifier {
       notifyListeners();
       debugPrint('功能引导已标记: $guideId');
     } catch (e, stackTrace) {
-      logError('保存引导状态失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
+      logError('保存引导状态失败',
+          error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
     }
   }
 
@@ -38,7 +40,8 @@ class FeatureGuideService extends ChangeNotifier {
       notifyListeners();
       debugPrint('功能引导已重置: $guideId');
     } catch (e, stackTrace) {
-      logError('重置引导状态失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
+      logError('重置引导状态失败',
+          error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
     }
   }
 
@@ -54,7 +57,8 @@ class FeatureGuideService extends ChangeNotifier {
       notifyListeners();
       debugPrint('所有功能引导已重置');
     } catch (e, stackTrace) {
-      logError('重置所有引导失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
+      logError('重置所有引导失败',
+          error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
     }
   }
 
@@ -67,7 +71,8 @@ class FeatureGuideService extends ChangeNotifier {
           .map((key) => key.substring(_keyPrefix.length))
           .toList();
     } catch (e, stackTrace) {
-      logError('获取已显示引导列表失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
+      logError('获取已显示引导列表失败',
+          error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
       return [];
     }
   }

--- a/lib/services/feature_guide_service.dart
+++ b/lib/services/feature_guide_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import '../utils/app_logger.dart';
 import '../utils/mmkv_ffi_fix.dart';
 
 /// 功能引导服务
@@ -13,8 +14,8 @@ class FeatureGuideService extends ChangeNotifier {
   bool hasShown(String guideId) {
     try {
       return _storage.getBool('$_keyPrefix$guideId') ?? false;
-    } catch (e) {
-      debugPrint('读取引导状态失败: $e');
+    } catch (e, stackTrace) {
+      logError('读取引导状态失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
       return false;
     }
   }
@@ -25,8 +26,8 @@ class FeatureGuideService extends ChangeNotifier {
       await _storage.setBool('$_keyPrefix$guideId', true);
       notifyListeners();
       debugPrint('功能引导已标记: $guideId');
-    } catch (e) {
-      debugPrint('保存引导状态失败: $e');
+    } catch (e, stackTrace) {
+      logError('保存引导状态失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
     }
   }
 
@@ -36,8 +37,8 @@ class FeatureGuideService extends ChangeNotifier {
       await _storage.remove('$_keyPrefix$guideId');
       notifyListeners();
       debugPrint('功能引导已重置: $guideId');
-    } catch (e) {
-      debugPrint('重置引导状态失败: $e');
+    } catch (e, stackTrace) {
+      logError('重置引导状态失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
     }
   }
 
@@ -52,8 +53,8 @@ class FeatureGuideService extends ChangeNotifier {
       }
       notifyListeners();
       debugPrint('所有功能引导已重置');
-    } catch (e) {
-      debugPrint('重置所有引导失败: $e');
+    } catch (e, stackTrace) {
+      logError('重置所有引导失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
     }
   }
 
@@ -65,8 +66,8 @@ class FeatureGuideService extends ChangeNotifier {
           .where((key) => key.startsWith(_keyPrefix))
           .map((key) => key.substring(_keyPrefix.length))
           .toList();
-    } catch (e) {
-      debugPrint('获取已显示引导列表失败: $e');
+    } catch (e, stackTrace) {
+      logError('获取已显示引导列表失败', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');
       return [];
     }
   }


### PR DESCRIPTION
**异常:** `FeatureGuideService` 的 5 处异常处理通过简单的 `debugPrint` 记录，丢失了错误来源以及导致错误的栈追踪，在 MMKV 读取写入错误时难以排查。
**拦截:** 已将 `debugPrint('...失败: $e');` 替换为使用 `../utils/app_logger.dart` 的 `logError('...', error: e, stackTrace: stackTrace, source: 'FeatureGuideService');`，提供完整的错误栈追踪。确认修改不包含任何敏感数据。

---
*PR created automatically by Jules for task [360216126920181509](https://jules.google.com/task/360216126920181509) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `FeatureGuideService` 的错误记录从 `debugPrint` 切换为结构化日志 `logError`。现在 MMKV 读写相关异常会带完整堆栈和来源，定位更快。

- **Refactors**
  - 5 处 `catch (e, stackTrace)` 调用 `logError(error: e, stackTrace: stackTrace, source: 'FeatureGuideService')`。
  - 引入 `../utils/app_logger.dart`；不改业务逻辑。
  - 更新黑匣记录，确认不含敏感信息。

<sup>Written for commit 50483d91d216f175f1b167923536452514ebec15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **问题修复**
  * 改进功能引导相关操作的错误记录。
  * 异常日志现在包含完整堆栈和来源信息，便于定位读取、保存及重置失败问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->