### PR TITLE
🧪 [增加 platform_helper_web 的测试]

### DIFF
--- a/test/unit/utils/platform_helper_web_test.dart
+++ b/test/unit/utils/platform_helper_web_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/platform_helper_web.dart';
+
+void main() {
+  group('PlatformHelper (Web)', () {
+    test('isAndroid returns false', () {
+      expect(PlatformHelper.isAndroid, isFalse);
+    });
+
+    test('isIOS returns false', () {
+      expect(PlatformHelper.isIOS, isFalse);
+    });
+
+    test('isWindows returns false', () {
+      expect(PlatformHelper.isWindows, isFalse);
+    });
+
+    test('isMacOS returns false', () {
+      expect(PlatformHelper.isMacOS, isFalse);
+    });
+
+    test('isLinux returns false', () {
+      expect(PlatformHelper.isLinux, isFalse);
+    });
+
+    test('getCpuArchitecture returns web', () async {
+      final architecture = await PlatformHelper.getCpuArchitecture();
+      expect(architecture, 'web');
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** 增加了对 `lib/utils/platform_helper_web.dart` 缺失的单元测试。
📊 **Coverage:** 覆盖了该工具类中所有的静态方法和属性，包括 `isAndroid`, `isIOS`, `isWindows`, `isMacOS`, `isLinux` 和异步方法 `getCpuArchitecture`。
✨ **Result:** 提高了工具类的测试覆盖率，确保了该平台辅助类的返回值行为符合预期且不被意外破坏。

---
*PR created automatically by Jules for task [15613997811744744585](https://jules.google.com/task/15613997811744744585) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `lib/utils/platform_helper_web.dart` 添加缺失的单元测试，覆盖 `isAndroid`/`isIOS`/`isWindows`/`isMacOS`/`isLinux` 以及异步 `getCpuArchitecture`。
确保在 Web 环境下这些方法返回 false/`web`，提升稳定性并防止回归。

<sup>Written for commit 1bdac119945b2aa94e42c5a14d0c2cf29b924d68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增 Web 平台相关测试，验证平台识别结果及 CPU 架构信息返回值的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->