### PR TITLE
🧪 标尺: [补充 CardGenerationUtils 测试]

### DIFF
--- a/test/unit/services/ai_card_generation_strategies/card_generation_utils_test.dart
+++ b/test/unit/services/ai_card_generation_strategies/card_generation_utils_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/services/ai_card_generation_strategies/card_generation_utils.dart';
+
+void main() {
+  group('CardGenerationUtils', () {
+    group('localizeWeather', () {
+      test('should localize basic weather to Chinese by default', () {
+        expect(CardGenerationUtils.localizeWeather('clear'), '晴');
+        expect(CardGenerationUtils.localizeWeather('Clear'), '晴');
+        expect(CardGenerationUtils.localizeWeather(' partly cloudy '), '少云');
+        expect(CardGenerationUtils.localizeWeather('partly_cloudy'), '少云');
+      });
+
+      test('should localize weather to target language', () {
+        expect(CardGenerationUtils.localizeWeather('sunny', languageCode: 'en'),
+            'Sunny');
+        expect(CardGenerationUtils.localizeWeather('sunny', languageCode: 'ja'),
+            '晴れ');
+        expect(CardGenerationUtils.localizeWeather('sunny', languageCode: 'fr'),
+            'Ensoleillé');
+      });
+
+      test('should return original if weather not found', () {
+        expect(CardGenerationUtils.localizeWeather('unknown_weather'),
+            'unknown_weather');
+      });
+
+      test('should return null or original for empty/null inputs', () {
+        expect(CardGenerationUtils.localizeWeather(null), null);
+        expect(CardGenerationUtils.localizeWeather(''), null);
+        expect(CardGenerationUtils.localizeWeather('   '), null);
+      });
+    });
+
+    group('localizeDayPeriod', () {
+      test('should localize basic day periods to Chinese by default', () {
+        expect(CardGenerationUtils.localizeDayPeriod('morning'), '晨间');
+        expect(CardGenerationUtils.localizeDayPeriod('moring'),
+            '晨间'); // testing typo handling
+        expect(CardGenerationUtils.localizeDayPeriod(' Noon '), '正午');
+        expect(CardGenerationUtils.localizeDayPeriod('late night'), '深夜');
+      });
+
+      test('should localize day period to target language', () {
+        expect(
+            CardGenerationUtils.localizeDayPeriod('afternoon',
+                languageCode: 'en'),
+            'Afternoon');
+        expect(
+            CardGenerationUtils.localizeDayPeriod('afternoon',
+                languageCode: 'ja'),
+            '午後');
+        expect(
+            CardGenerationUtils.localizeDayPeriod('afternoon',
+                languageCode: 'fr'),
+            'Après-midi');
+      });
+
+      test('should return original if day period not found', () {
+        expect(CardGenerationUtils.localizeDayPeriod('unknown_period'),
+            'unknown_period');
+      });
+
+      test('should return null for empty/null inputs', () {
+        expect(CardGenerationUtils.localizeDayPeriod(null), null);
+        expect(CardGenerationUtils.localizeDayPeriod(''), null);
+        expect(CardGenerationUtils.localizeDayPeriod('   '), null);
+      });
+    });
+
+    group('formatDate', () {
+      test('should format valid date to Chinese/Japanese style', () {
+        expect(CardGenerationUtils.formatDate('2026-01-22', languageCode: 'zh'),
+            '2026年1月22日');
+        expect(CardGenerationUtils.formatDate('2026-01-22', languageCode: 'ja'),
+            '2026年1月22日');
+      });
+
+      test('should format valid date to French style', () {
+        expect(CardGenerationUtils.formatDate('2026-01-22', languageCode: 'fr'),
+            '22/01/2026');
+      });
+
+      test('should format valid date to English style (default)', () {
+        expect(CardGenerationUtils.formatDate('2026-01-22', languageCode: 'en'),
+            'Jan 22, 2026');
+      });
+
+      test('should format valid date to Chinese style by default', () {
+        expect(CardGenerationUtils.formatDate('2026-01-22'), '2026年1月22日');
+      });
+
+      test('should return original string for invalid date formats', () {
+        expect(CardGenerationUtils.formatDate('invalid-date'), 'invalid-date');
+        expect(CardGenerationUtils.formatDate('2026/01/22', languageCode: 'zh'),
+            '2026/01/22'); // Assuming DateTime.parse fails
+      });
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** The `CardGenerationUtils` class was missing unit tests, leaving its localization and formatting logic uncovered. This PR adds a comprehensive test suite for `localizeWeather`, `localizeDayPeriod`, and `formatDate`.

📊 **Coverage:** The tests cover the happy paths (e.g., successful localization to Chinese, English, French, Japanese), fallback logic (defaulting to English or returning the original string when not found), edge cases (ignoring typos like 'moring', handling whitespace and null inputs), and invalid date parsing formats.

✨ **Result:** Improved test coverage for `ai_card_generation_strategies`, ensuring robust and regression-free localized card generation features in the future.

---
*PR created automatically by Jules for task [18091964279429271896](https://jules.google.com/task/18091964279429271896) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
补齐 CardGenerationUtils 的单元测试，覆盖天气与时间段本地化、日期格式化。提升覆盖率，避免本地化相关回归。

- **测试范围**
  - localizeWeather：默认中文；支持 en/ja/fr；未知值返回原文；空/空白/null 处理
  - localizeDayPeriod：默认中文；容错如“moring”；支持 en/ja/fr；空输入返回 null
  - formatDate：zh/ja 为“YYYY年M月D日”；fr 为“DD/MM/YYYY”；en 为“Mon DD, YYYY”；默认中文；非法日期原样返回

<sup>Written for commit 2f079f2dca29a15085a527791c340944d38b7e38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

