### PR TITLE
🧪 标尺: 补充 stub_implementations 的测试

### DIFF
--- a/test/unit/utils/stub_implementations_test.dart
+++ b/test/unit/utils/stub_implementations_test.dart
@@ -1,0 +1,27 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/stub_implementations.dart';
+
+void main() {
+  group('Gal Stub Implementation', () {
+    test('hasAccess always returns false', () async {
+      expect(await Gal.hasAccess(), isFalse);
+    });
+
+    test('requestAccess always returns false', () async {
+      expect(await Gal.requestAccess(), isFalse);
+    });
+
+    test('putImageBytes throws UnsupportedError', () async {
+      final bytes = Uint8List(0);
+      expect(
+        () => Gal.putImageBytes(bytes, name: 'test.png'),
+        throwsA(isA<UnsupportedError>().having(
+          (e) => e.message,
+          'message',
+          'Gallery access not supported on this platform',
+        )),
+      );
+    });
+  });
+}


### PR DESCRIPTION
🎯 **What:** 补充 `stub_implementations.dart` 中 `Gal` 类的测试用例。
📊 **Coverage:** 覆盖了 `hasAccess`、`requestAccess` 和 `putImageBytes` 方法，以及相关的异常抛出。
✨ **Result:** 提高了代码的测试覆盖率，确保 stub 方法在不支持平台的行为是确定和符合预期的。

---
*PR created automatically by Jules for task [17903721013468330714](https://jules.google.com/task/17903721013468330714) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 stub_implementations.dart 中的 Gal 类新增单元测试，验证在不支持平台时的预期行为，提升测试覆盖率。
覆盖 hasAccess/requestAccess 恒为 false，以及 putImageBytes 抛出 UnsupportedError（包含预期错误信息）。

<sup>Written for commit c47c5a8f148a78855d4167835e0c2a9cd5f259ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 新增针对图库访问桩实现的单元测试。
  * 验证不支持图库访问的平台会正确返回无权限状态，并在尝试保存图片时提示不支持该功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->