### PR TITLE
⚡ 提升: 优化标签选择组件的列表查找性能

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,6 +77,7 @@
 ## 2026-07-24 - 优化笔记多选操作的时间复杂度
 **Learning:** 在 UI 交互中，如果有针对 `Set` 中多个 ID 进行全量查找的操作（例如在 `List` 中循环使用 `firstWhere` 或者 `firstWhereOrNull`），这会导致 O(M*N) 的时间复杂度（N 是列表长度，M 是选中的 ID 数量）。当列表较大且选中大量项目时，会导致 UI 线程阻塞。
 **Action:** 在 `lib/widgets/note_list/note_list_items.dart` 的 `_selectSameMonthNotes` 和 `_selectSameCategoryNotes` 方法中，将 `for (final id in _selectedExportNoteIds)` 内部的 `_quotes.firstWhereOrNull` 查找逻辑，替换为先遍历 `_quotes` 并使用 `_selectedExportNoteIds.contains(quote.id)` 收集月份/分类，再遍历 `_quotes` 按收集结果筛选；通过常数次遍历避免 O(M*N) 的嵌套线性查找，分类筛选还会遍历每条笔记的 `tagIds`。
-## $(date +%Y-%m-%d) - [避免 O(M*N) 的嵌套循环查找]
+
+## 2026-07-25 - [避免 O(M*N) 的嵌套循环查找]
 **Learning:** 在 Flutter UI 渲染循环中，对 `List<T>` 数组调用 `.map()` 并内部嵌套 `List.firstWhere()` 查找对象时，会导致 O(M*N) 复杂度。在涉及重绘动画的地方，这种隐式的线性查找会积少成多，进而带来不必要的卡顿和 GC。
 **Action:** 在执行对一组 ID 进行列表元素的映射操作之前，提前将 `List` 转化为基于 ID 为键的哈希映射表（即 `final map = { for(var item in list) item.id: item };`），然后在循环体中使用 `map[id]` 进行 O(1) 取值。

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,6 @@
 ## 2026-07-24 - 优化笔记多选操作的时间复杂度
 **Learning:** 在 UI 交互中，如果有针对 `Set` 中多个 ID 进行全量查找的操作（例如在 `List` 中循环使用 `firstWhere` 或者 `firstWhereOrNull`），这会导致 O(M*N) 的时间复杂度（N 是列表长度，M 是选中的 ID 数量）。当列表较大且选中大量项目时，会导致 UI 线程阻塞。
 **Action:** 在 `lib/widgets/note_list/note_list_items.dart` 的 `_selectSameMonthNotes` 和 `_selectSameCategoryNotes` 方法中，将 `for (final id in _selectedExportNoteIds)` 内部的 `_quotes.firstWhereOrNull` 查找逻辑，替换为先遍历 `_quotes` 并使用 `_selectedExportNoteIds.contains(quote.id)` 收集月份/分类，再遍历 `_quotes` 按收集结果筛选；通过常数次遍历避免 O(M*N) 的嵌套线性查找，分类筛选还会遍历每条笔记的 `tagIds`。
+## $(date +%Y-%m-%d) - [避免 O(M*N) 的嵌套循环查找]
+**Learning:** 在 Flutter UI 渲染循环中，对 `List<T>` 数组调用 `.map()` 并内部嵌套 `List.firstWhere()` 查找对象时，会导致 O(M*N) 复杂度。在涉及重绘动画的地方，这种隐式的线性查找会积少成多，进而带来不必要的卡顿和 GC。
+**Action:** 在执行对一组 ID 进行列表元素的映射操作之前，提前将 `List` 转化为基于 ID 为键的哈希映射表（即 `final map = { for(var item in list) item.id: item };`），然后在循环体中使用 `map[id]` 进行 O(1) 取值。

--- a/format.sh
+++ b/format.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-git restore lib/widgets/add_note_dialog_parts.dart lib/widgets/note_list/note_list_filters.dart

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+git restore lib/widgets/add_note_dialog_parts.dart lib/widgets/note_list/note_list_filters.dart

--- a/lib/widgets/add_note_dialog_parts.dart
+++ b/lib/widgets/add_note_dialog_parts.dart
@@ -11,8 +11,11 @@ class KeyboardInsetPadding extends StatelessWidget {
   final Widget child;
   final ValueChanged<double>? onInsetBuild;
 
-  const KeyboardInsetPadding(
-      {super.key, required this.child, this.onInsetBuild});
+  const KeyboardInsetPadding({
+    super.key,
+    required this.child,
+    this.onInsetBuild,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -91,9 +94,8 @@ class _TagSelectionSectionState extends State<TagSelectionSection> {
         final l10n = AppLocalizations.of(context);
         _filteredTags = widget.tags
             .where(
-              (tag) => tag.localizedName(l10n).toLowerCase().contains(
-                    lowerQuery,
-                  ),
+              (tag) =>
+                  tag.localizedName(l10n).toLowerCase().contains(lowerQuery),
             )
             .toList();
       }
@@ -283,9 +285,7 @@ class _TagListItem extends StatelessWidget {
         children: [
           leading,
           const SizedBox(width: 8),
-          Flexible(
-            child: Text(displayName, overflow: TextOverflow.ellipsis),
-          ),
+          Flexible(child: Text(displayName, overflow: TextOverflow.ellipsis)),
         ],
       ),
       subtitle: isHiddenTag
@@ -346,12 +346,12 @@ class SelectedTagsDisplay extends StatelessWidget {
           Wrap(
             spacing: 4.0,
             runSpacing: 4.0,
-            children: selectedTagIds.map((tagId) {
-              final tag = allTags.firstWhere(
-                (t) => t.id == tagId,
-                orElse: () => NoteCategory(id: tagId, name: l10n.unknownTag),
-              );
-              final String displayName = tag.localizedName(l10n);
+            children: () {
+              final tagMap = {for (var t in allTags) t.id: t};
+              return selectedTagIds.map((tagId) {
+                final tag = tagMap[tagId] ??
+                    NoteCategory(id: tagId, name: l10n.unknownTag);
+                final String displayName = tag.localizedName(l10n);
 
               return Chip(
                 label: IconUtils.isEmoji(tag.iconName)
@@ -363,8 +363,10 @@ class SelectedTagsDisplay extends StatelessWidget {
                             style: const TextStyle(fontSize: 20),
                           ),
                           const SizedBox(width: 4),
-                          Text(displayName,
-                              style: const TextStyle(fontSize: 12)),
+                          Text(
+                            displayName,
+                            style: const TextStyle(fontSize: 12),
+                          ),
                         ],
                       )
                     : Text(displayName),
@@ -374,7 +376,8 @@ class SelectedTagsDisplay extends StatelessWidget {
                 deleteIcon: const Icon(Icons.cancel, size: 18),
                 onDeleted: () => onRemoveTag(tagId),
               );
-            }).toList(),
+              }).toList();
+            }(),
           ),
         ],
       ),

--- a/lib/widgets/add_note_dialog_parts.dart
+++ b/lib/widgets/add_note_dialog_parts.dart
@@ -11,11 +11,8 @@ class KeyboardInsetPadding extends StatelessWidget {
   final Widget child;
   final ValueChanged<double>? onInsetBuild;
 
-  const KeyboardInsetPadding({
-    super.key,
-    required this.child,
-    this.onInsetBuild,
-  });
+  const KeyboardInsetPadding(
+      {super.key, required this.child, this.onInsetBuild});
 
   @override
   Widget build(BuildContext context) {
@@ -94,8 +91,9 @@ class _TagSelectionSectionState extends State<TagSelectionSection> {
         final l10n = AppLocalizations.of(context);
         _filteredTags = widget.tags
             .where(
-              (tag) =>
-                  tag.localizedName(l10n).toLowerCase().contains(lowerQuery),
+              (tag) => tag.localizedName(l10n).toLowerCase().contains(
+                    lowerQuery,
+                  ),
             )
             .toList();
       }
@@ -285,7 +283,9 @@ class _TagListItem extends StatelessWidget {
         children: [
           leading,
           const SizedBox(width: 8),
-          Flexible(child: Text(displayName, overflow: TextOverflow.ellipsis)),
+          Flexible(
+            child: Text(displayName, overflow: TextOverflow.ellipsis),
+          ),
         ],
       ),
       subtitle: isHiddenTag
@@ -353,29 +353,27 @@ class SelectedTagsDisplay extends StatelessWidget {
                     NoteCategory(id: tagId, name: l10n.unknownTag);
                 final String displayName = tag.localizedName(l10n);
 
-              return Chip(
-                label: IconUtils.isEmoji(tag.iconName)
-                    ? Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            IconUtils.getDisplayIcon(tag.iconName),
-                            style: const TextStyle(fontSize: 20),
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            displayName,
-                            style: const TextStyle(fontSize: 12),
-                          ),
-                        ],
-                      )
-                    : Text(displayName),
-                avatar: !IconUtils.isEmoji(tag.iconName)
-                    ? Icon(IconUtils.getIconData(tag.iconName), size: 18)
-                    : null,
-                deleteIcon: const Icon(Icons.cancel, size: 18),
-                onDeleted: () => onRemoveTag(tagId),
-              );
+                return Chip(
+                  label: IconUtils.isEmoji(tag.iconName)
+                      ? Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              IconUtils.getDisplayIcon(tag.iconName),
+                              style: const TextStyle(fontSize: 20),
+                            ),
+                            const SizedBox(width: 4),
+                            Text(displayName,
+                                style: const TextStyle(fontSize: 12)),
+                          ],
+                        )
+                      : Text(displayName),
+                  avatar: !IconUtils.isEmoji(tag.iconName)
+                      ? Icon(IconUtils.getIconData(tag.iconName), size: 18)
+                      : null,
+                  deleteIcon: const Icon(Icons.cancel, size: 18),
+                  onDeleted: () => onRemoveTag(tagId),
+                );
               }).toList();
             }(),
           ),

--- a/lib/widgets/note_list/note_list_filters.dart
+++ b/lib/widgets/note_list/note_list_filters.dart
@@ -30,8 +30,8 @@ extension NoteListFiltersExtension on NoteListViewState {
       final tagMap = {for (var t in _effectiveTags) t.id: t};
       allChips.addAll(
         widget.selectedTagIds.map((tagId) {
-          final tag = tagMap[tagId] ??
-              NoteCategory(id: tagId, name: l10n.unknownTag);
+          final tag =
+              tagMap[tagId] ?? NoteCategory(id: tagId, name: l10n.unknownTag);
           return TweenAnimationBuilder<double>(
             key: ValueKey('tag_$tagId'),
             duration: const Duration(milliseconds: 250),
@@ -75,10 +75,8 @@ extension NoteListFiltersExtension on NoteListViewState {
 
       allChips.addAll(
         categorySet.map((cat) {
-          final label = WeatherService.getLocalizedFilterCategoryLabel(
-            context,
-            cat,
-          );
+          final label =
+              WeatherService.getLocalizedFilterCategoryLabel(context, cat);
           final icon = WeatherService.getFilterCategoryIcon(cat);
           return TweenAnimationBuilder<double>(
             key: ValueKey('weather_cat_$cat'),
@@ -328,10 +326,8 @@ extension NoteListFiltersExtension on NoteListViewState {
                 ],
                 Text(
                   label,
-                  style: theme.textTheme.labelMedium?.copyWith(
-                    color: color,
-                    fontSize: 14,
-                  ),
+                  style: theme.textTheme.labelMedium
+                      ?.copyWith(color: color, fontSize: 14),
                 ),
               ],
             ),

--- a/lib/widgets/note_list/note_list_filters.dart
+++ b/lib/widgets/note_list/note_list_filters.dart
@@ -27,12 +27,11 @@ extension NoteListFiltersExtension on NoteListViewState {
 
     // 添加标签chip (带图标支持) - 添加进出场动画
     if (widget.selectedTagIds.isNotEmpty) {
+      final tagMap = {for (var t in _effectiveTags) t.id: t};
       allChips.addAll(
         widget.selectedTagIds.map((tagId) {
-          final tag = _effectiveTags.firstWhere(
-            (tag) => tag.id == tagId,
-            orElse: () => NoteCategory(id: tagId, name: l10n.unknownTag),
-          );
+          final tag = tagMap[tagId] ??
+              NoteCategory(id: tagId, name: l10n.unknownTag);
           return TweenAnimationBuilder<double>(
             key: ValueKey('tag_$tagId'),
             duration: const Duration(milliseconds: 250),
@@ -76,8 +75,10 @@ extension NoteListFiltersExtension on NoteListViewState {
 
       allChips.addAll(
         categorySet.map((cat) {
-          final label =
-              WeatherService.getLocalizedFilterCategoryLabel(context, cat);
+          final label = WeatherService.getLocalizedFilterCategoryLabel(
+            context,
+            cat,
+          );
           final icon = WeatherService.getFilterCategoryIcon(cat);
           return TweenAnimationBuilder<double>(
             key: ValueKey('weather_cat_$cat'),
@@ -327,8 +328,10 @@ extension NoteListFiltersExtension on NoteListViewState {
                 ],
                 Text(
                   label,
-                  style: theme.textTheme.labelMedium
-                      ?.copyWith(color: color, fontSize: 14),
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: color,
+                    fontSize: 14,
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
💡 **What:** 优化了 `SelectedTagsDisplay` 和 `NoteListFilters` 中渲染已选标签列表的查找算法。预先将 `List<NoteCategory>` 转换为 ID 为键的 `Map`，将原来 O(M*N) 复杂度的嵌套 `firstWhere` 查找改为 O(N) 复杂度的哈希表 O(1) 查找。

🎯 **Why:** 在绘制 UI 时，频繁调用 `List.firstWhere` 进行线性查找会导致不必要的性能开销，特别是当标签数量较多且被频繁触发重绘时（例如在动画期间）。通过提前构建哈希表，显著降低了该热路径的算法复杂度。

📊 **Measured Improvement:** 列表循环内的查找复杂度从 O(M*N) 下降到 O(N)。虽然绝对微秒数变化较小，但在大量标签及 UI 频繁构建期间，这能降低主线程阻塞风险并减少无谓的垃圾回收，严格遵循性能规范中“替换导致 O(M*N) 复杂度的 `firstWhere` 为 O(1) 查找”的准则。

---
*PR created automatically by Jules for task [17204416073151240347](https://jules.google.com/task/17204416073151240347) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将标签查找从线性扫描改为基于 `Map` 的 O(1) 查找，降低标签选择与过滤时的渲染开销。在大量标签或动画重绘下，UI 更流畅。

- **Refactors**
  - 在 `SelectedTagsDisplay` 与 `NoteListFilters` 中预构建 `id -> tag` 的 `Map`，用哈希查找替代嵌套 `firstWhere`，将 O(M*N) 降为 O(N)。
  - 更新 `.jules/bolt.md`，记录在渲染循环前构建哈希表的实践。

<sup>Written for commit f58f8cc361d119d982810bc329fd9fc5949beb79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化标签筛选与展示的查找方式，减少大量标签场景下的重复检索。
  * 提升笔记列表及新增笔记对话框中标签渲染的流畅度，降低卡顿风险。
  * 保留未知标签的本地化提示，避免标签缺失时显示异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->