### PR TITLE
🧪 标尺: [补充 simple_provider 的单元测试]

### DIFF
--- a/test/unit/services/localsend/utils/simple_provider_test.dart
+++ b/test/unit/services/localsend/utils/simple_provider_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/services/localsend/utils/simple_provider.dart';
+
+class CounterNotifier extends Notifier<int> {
+  @override
+  int init() => 0;
+
+  void increment() {
+    state++;
+  }
+}
+
+void main() {
+  group('Notifier', () {
+    test('init and state', () {
+      final notifier = CounterNotifier();
+      notifier.state = notifier.init();
+      expect(notifier.state, 0);
+
+      notifier.increment();
+      expect(notifier.state, 1);
+    });
+
+    test('stream emits new states', () async {
+      final notifier = CounterNotifier();
+      notifier.state = notifier.init();
+
+      final states = <int>[];
+      final subscription = notifier.stream.listen(states.add);
+
+      notifier.increment();
+      notifier.increment();
+
+      await Future.delayed(Duration.zero);
+      expect(states, [1, 2]);
+
+      subscription.cancel();
+      notifier.dispose();
+    });
+  });
+
+  group('NotifierProvider', () {
+    test('creates and caches instance', () {
+      final provider =
+          NotifierProvider<CounterNotifier, int>(() => CounterNotifier());
+
+      final instance1 = provider();
+      expect(instance1.state, 0);
+
+      instance1.increment();
+      expect(instance1.state, 1);
+
+      final instance2 = provider();
+      expect(identical(instance1, instance2), true);
+      expect(instance2.state, 1);
+    });
+
+    test('dispose clears instance', () {
+      final provider =
+          NotifierProvider<CounterNotifier, int>(() => CounterNotifier());
+
+      final instance1 = provider();
+      provider.dispose();
+
+      final instance2 = provider();
+      expect(identical(instance1, instance2), false);
+    });
+  });
+
+  group('SimpleRef', () {
+    test('read returns state and caches provider', () {
+      final ref = SimpleRef();
+      final provider =
+          NotifierProvider<CounterNotifier, int>(() => CounterNotifier());
+
+      final state1 = ref.read(provider);
+      expect(state1, 0);
+
+      final notifier = ref.notifier(provider) as CounterNotifier;
+      notifier.increment();
+
+      final state2 = ref.read(provider);
+      expect(state2, 1);
+    });
+
+    test('notifier returns cached instance', () {
+      final ref = SimpleRef();
+      final provider =
+          NotifierProvider<CounterNotifier, int>(() => CounterNotifier());
+
+      final notifier1 = ref.notifier(provider);
+      final notifier2 = ref.notifier(provider);
+
+      expect(identical(notifier1, notifier2), true);
+    });
+
+    test('dispose clears all instances', () {
+      final ref = SimpleRef();
+      final provider =
+          NotifierProvider<CounterNotifier, int>(() => CounterNotifier());
+
+      final notifier1 = ref.notifier(provider) as CounterNotifier;
+
+      ref.dispose();
+
+      // After ref.dispose, the stream controller inside the notifier is closed.
+      // Trying to update the state should throw a StateError.
+      expect(() => notifier1.increment(), throwsStateError);
+    });
+  });
+}


### PR DESCRIPTION
💡 **What:** 补充了针对 `lib/services/localsend/utils/simple_provider.dart` 的单元测试。
🎯 **Coverage:** 对 `Notifier`, `NotifierProvider`, 以及 `SimpleRef` 进行了全面的单元测试。验证了状态更新、stream 事件发送、实例缓存以及资源清理（dispose）等逻辑的健壮性。同时补充了调用 dispose 后抛出异常等的异常情况断言。
✨ **Result:** 增加了 `simple_provider` 核心依赖管理工具类的单元测试用例，提高了 LocalSend 功能相关代码的测试覆盖率和代码稳定性。

---
*PR created automatically by Jules for task [7901899812796898077](https://jules.google.com/task/7901899812796898077) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
新增 `test/unit/services/localsend/utils/simple_provider_test.dart`，为 `Notifier`、`NotifierProvider`、`SimpleRef` 补充单元测试，提升 LocalSend 依赖管理的可靠性与覆盖率。
覆盖状态初始化与更新、stream 事件发送、实例缓存与释放，并断言 `dispose` 后的异常行为。

<sup>Written for commit 3324895fd9c73ee0bb3e537a84d4874db7c13e1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

