### PR TITLE
🧪 添加 DioPerformanceInterceptor 的边界情况测试

### DIFF
--- a/test/unit/utils/dio_performance_interceptor_test.dart
+++ b/test/unit/utils/dio_performance_interceptor_test.dart
@@ -131,6 +131,17 @@ void main() {
       expect(logRecord["message"], contains("(错误: Connection timeout)"));
     });
 
+    test("onResponse does not log if start_time is missing", () async {
+      final options = RequestOptions(path: "/missing_start_time");
+      final response = Response(requestOptions: options, statusCode: 200);
+      final handler = FakeResponseInterceptorHandler();
+
+      interceptor.onResponse(response, handler);
+
+      expect(handler.calledResponses.length, 1);
+      expect(fakeLogService.logRecords.length, 0);
+    });
+
     test("URL length is truncated if too long", () async {
       final longPath = "/${'a' * 100}";
       final options = RequestOptions(path: longPath);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing branch coverage for `DioPerformanceInterceptor.onResponse` when `startTime` is null.
📊 **Coverage:** Added test scenario: `onResponse does not log if start_time is missing`.
✨ **Result:** Increased branch test coverage for `DioPerformanceInterceptor`, handling cases where start time is stripped from the options due to other interceptors or mock behavior.

---
*PR created automatically by Jules for task [10041372926825690158](https://jules.google.com/task/10041372926825690158) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
补充对 DioPerformanceInterceptor 的边界测试：当 onResponse 遇到缺失 request_start_time 时，不记录慢请求日志并正常透传响应。
提高该拦截器的分支覆盖率，避免因其他拦截器或 mock 移除起始时间导致的误报。

<sup>Written for commit dca05ab6b02729c7425391d9f3568db7354f8792. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

