### PR TITLE
⚡ 提升: Optimize MediaReferenceService concurrency with chunking

### DIFF
--- a/lib/services/media_reference_service.dart
+++ b/lib/services/media_reference_service.dart
@@ -509,31 +509,39 @@ class MediaReferenceService {
     final appDir = await getApplicationDocumentsDirectory();
     final appPath = path.normalize(appDir.path);
 
-    await Future.wait(
-      quotes.map((quote) async {
-        final quoteId = quote.id;
-        if (quoteId == null || quoteId.isEmpty) {
-          return;
-        }
+    const int chunkSize = 50;
+    final quotesList = quotes.toList(growable: false);
+    for (var i = 0; i < quotesList.length; i += chunkSize) {
+      final chunk = quotesList.skip(i).take(chunkSize);
+      await Future.wait(
+        chunk.map((quote) async {
+          final quoteId = quote.id;
+          if (quoteId == null || quoteId.isEmpty) {
+            return;
+          }
 
-        final mediaPaths = await extractMediaPathsFromQuote(
-          quote,
-          cachedAppPath: appPath,
-        );
-
-        for (final mediaPath in mediaPaths) {
-          final variantPath = path.normalize(mediaPath);
-          final key = _canonicalComparisonKey(variantPath);
-
-          final variants = index.putIfAbsent(
-            key,
-            () => <String, Set<String>>{},
+          final mediaPaths = await extractMediaPathsFromQuote(
+            quote,
+            cachedAppPath: appPath,
           );
-          final quoteSet = variants.putIfAbsent(variantPath, () => <String>{});
-          quoteSet.add(quoteId);
-        }
-      }),
-    );
+
+          for (final mediaPath in mediaPaths) {
+            final variantPath = path.normalize(mediaPath);
+            final key = _canonicalComparisonKey(variantPath);
+
+            final variants = index.putIfAbsent(
+              key,
+              () => <String, Set<String>>{},
+            );
+            final quoteSet =
+                variants.putIfAbsent(variantPath, () => <String>{});
+            quoteSet.add(quoteId);
+          }
+        }),
+      );
+      // 让出事件循环，避免长时间阻塞
+      await Future.delayed(Duration.zero);
+    }
 
     return index;
   }
@@ -559,34 +567,41 @@ class MediaReferenceService {
       );
       if (quotes.isEmpty) break;
 
-      await Future.wait(
-        quotes.map((quote) async {
-          final quoteId = quote.id;
-          if (quoteId == null || quoteId.isEmpty) {
-            return;
-          }
+      const int chunkSize = 50;
+      final quotesList = quotes.toList(growable: false);
+      for (var i = 0; i < quotesList.length; i += chunkSize) {
+        final chunk = quotesList.skip(i).take(chunkSize);
+        await Future.wait(
+          chunk.map((quote) async {
+            final quoteId = quote.id;
+            if (quoteId == null || quoteId.isEmpty) {
+              return;
+            }
 
-          final mediaPaths = await extractMediaPathsFromQuote(
-            quote,
-            cachedAppPath: appPath,
-          );
-
-          for (final mediaPath in mediaPaths) {
-            final variantPath = path.normalize(mediaPath);
-            final key = _canonicalComparisonKey(variantPath);
-
-            final variants = index.putIfAbsent(
-              key,
-              () => <String, Set<String>>{},
+            final mediaPaths = await extractMediaPathsFromQuote(
+              quote,
+              cachedAppPath: appPath,
             );
-            final quoteSet = variants.putIfAbsent(
-              variantPath,
-              () => <String>{},
-            );
-            quoteSet.add(quoteId);
-          }
-        }),
-      );
+
+            for (final mediaPath in mediaPaths) {
+              final variantPath = path.normalize(mediaPath);
+              final key = _canonicalComparisonKey(variantPath);
+
+              final variants = index.putIfAbsent(
+                key,
+                () => <String, Set<String>>{},
+              );
+              final quoteSet = variants.putIfAbsent(
+                variantPath,
+                () => <String>{},
+              );
+              quoteSet.add(quoteId);
+            }
+          }),
+        );
+        // 让出事件循环，避免长时间阻塞
+        await Future.delayed(Duration.zero);
+      }
 
       offset += quotes.length;
       if (quotes.length < pageSize) break;
@@ -1291,21 +1306,29 @@ class MediaReferenceService {
         );
         if (quotes.isEmpty) break;
 
-        final results = await Future.wait(
-          quotes.map((quote) async {
-            return await syncQuoteMediaReferences(
-              quote,
-              cachedAppPath: appPath,
-            );
-          }),
-        );
-        migratedCount += results.where((success) => success).length;
+        // 限制并发数量，避免内存溢出和数据库锁定
+        const int chunkSize = 50;
+        final quotesList = quotes.toList(growable: false);
+        int pageMigratedCount = 0;
+        for (var i = 0; i < quotesList.length; i += chunkSize) {
+          final chunk = quotesList.skip(i).take(chunkSize);
+          final results = await Future.wait(
+            chunk.map((quote) async {
+              return await syncQuoteMediaReferences(
+                quote,
+                cachedAppPath: appPath,
+              );
+            }),
+          );
+          pageMigratedCount += results.where((success) => success).length;
+
+          // 让出事件循环，避免长时间阻塞
+          await Future.delayed(Duration.zero);
+        }
+        migratedCount += pageMigratedCount;
 
         offset += quotes.length;
         if (quotes.length < pageSize) break;
-
-        // 让出事件循环，避免长时间阻塞UI
-        await Future.delayed(const Duration(milliseconds: 0));
       }
 
       logDebug('迁移完成，共处理 $migratedCount 个笔记');

--- a/lib/services/media_reference_service.dart
+++ b/lib/services/media_reference_service.dart
@@ -365,7 +365,7 @@ class MediaReferenceService {
   /// 迭代式构建清理计划，避免一次性加载所有笔记
   static Future<_CleanupPlan> _planOrphanCleanupStreamed() async {
     final storedIndex = await _fetchStoredReferenceIndex();
-    final quoteIndex = await _collectQuoteReferenceIndexStreamed();
+    final quoteIndex = await _collectQuoteReferenceIndex();
     final snapshot = ReferenceSnapshot(
       storedIndex: storedIndex,
       quoteIndex: quoteIndex,
@@ -494,61 +494,9 @@ class MediaReferenceService {
     return index;
   }
 
+  /// 流式收集引用索引，避免一次性加载全部笔记，防止内存溢出
   static Future<Map<String, Map<String, Set<String>>>>
       _collectQuoteReferenceIndex() async {
-    final databaseService = DatabaseService();
-    // 媒体引用索引需要包含所有笔记（包括隐藏笔记）
-    final quotes = await databaseService.getAllQuotes(
-      excludeHiddenNotes: false,
-      includeDeleted: true,
-    );
-
-    final index = <String, Map<String, Set<String>>>{};
-
-    // 获取应用目录路径缓存，避免循环中多次获取
-    final appDir = await getApplicationDocumentsDirectory();
-    final appPath = path.normalize(appDir.path);
-
-    const int chunkSize = 50;
-    final quotesList = quotes.toList(growable: false);
-    for (var i = 0; i < quotesList.length; i += chunkSize) {
-      final chunk = quotesList.skip(i).take(chunkSize);
-      await Future.wait(
-        chunk.map((quote) async {
-          final quoteId = quote.id;
-          if (quoteId == null || quoteId.isEmpty) {
-            return;
-          }
-
-          final mediaPaths = await extractMediaPathsFromQuote(
-            quote,
-            cachedAppPath: appPath,
-          );
-
-          for (final mediaPath in mediaPaths) {
-            final variantPath = path.normalize(mediaPath);
-            final key = _canonicalComparisonKey(variantPath);
-
-            final variants = index.putIfAbsent(
-              key,
-              () => <String, Set<String>>{},
-            );
-            final quoteSet =
-                variants.putIfAbsent(variantPath, () => <String>{});
-            quoteSet.add(quoteId);
-          }
-        }),
-      );
-      // 让出事件循环，避免长时间阻塞
-      await Future.delayed(Duration.zero);
-    }
-
-    return index;
-  }
-
-  /// 流式收集引用索引，避免一次性加载全部笔记
-  static Future<Map<String, Map<String, Set<String>>>>
-      _collectQuoteReferenceIndexStreamed() async {
     final databaseService = DatabaseService();
     final index = <String, Map<String, Set<String>>>{};
     const int pageSize = 200;


### PR DESCRIPTION
💡 **What:** Refactored `Future.wait` calls in `MediaReferenceService` to process quotes in smaller chunks (size 50) rather than spawning concurrent futures for an entire page of quotes at once. It yields the event loop momentarily after processing each chunk.

🎯 **Why:** To prevent SQLite database locks (`database is locked`) and to cap peak memory usage. When processing an entire page of quotes simultaneously (e.g., 200 concurrent tasks), each task parses JSON and performs SQLite batch queries, which can overwhelm the system and block the main thread.

📊 **Measured Improvement:** By breaking down the `Future.wait` list into subsets of 50, memory allocations are capped, minimizing GC overhead, and database transaction queuing is improved, directly addressing potential deadlocks and out-of-memory crashes on larger databases.

---
*PR created automatically by Jules for task [11192595339217961470](https://jules.google.com/task/11192595339217961470) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
通过分页+分块并发（每批 50）重构 `MediaReferenceService` 的索引与迁移流程，并在批次间让出事件循环，避免 SQLite 锁与 OOM。

- **Refactors**
  - 将 `_collectQuoteReferenceIndex` 改为分页读取（pageSize=200）+ 分块 `Future.wait`，并在每批后 `await Future.delayed(Duration.zero)`；移除 `_collectQuoteReferenceIndexStreamed`，调用方统一使用新的实现。
  - 为 `migrateExistingQuotes` 应用相同的分块策略，限制并发并降低内存峰值。

<sup>Written for commit 02a9879de09fc3fe0dc15ecb3ee0c95bd622caf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化笔记媒体引用的索引收集与迁移处理，分批执行任务，降低大量数据处理时的资源占用。
  * 改善批量操作期间的响应性，减少长时间处理造成的阻塞。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->