### PR TITLE
🧪 [testing] improve exception handling coverage for LocationWeatherHelper

### DIFF
--- a/test/unit/utils/location_weather_helper_test.dart
+++ b/test/unit/utils/location_weather_helper_test.dart
@@ -117,6 +117,16 @@ void main() {
     });
 
     group('fetchLocation', () {
+      test('should propagate exception if getCurrentLocation throws', () async {
+        when(mockLocationService.getCurrentLocation())
+            .thenThrow(Exception('Location error'));
+
+        expect(
+          () => LocationWeatherHelper.fetchLocation(mockLocationService),
+          throwsException,
+        );
+      });
+
       test('should return null if position is null', () async {
         when(mockLocationService.getCurrentLocation())
             .thenAnswer((_) async => null);
@@ -160,3 +170,4 @@ void main() {
     });
   });
 }
+// Added missing tests for location_weather_helper.dart


### PR DESCRIPTION
🎯 **What:** The testing suite for `LocationWeatherHelper` was missing coverage for the exception propagation path when `LocationService.getCurrentLocation()` fails unexpectedly.
📊 **Coverage:** Added a test scenario that explicitly mocks an exception thrown by `getCurrentLocation()` and asserts that `LocationWeatherHelper.fetchLocation` propagates the exception upwards using `throwsException`.
✨ **Result:** Enhanced the unit test suite with boundary condition coverage, ensuring that `LocationWeatherHelper` handles failures predictably without swallowing errors.

---
*PR created automatically by Jules for task [10576920463932575013](https://jules.google.com/task/10576920463932575013) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
补充 `LocationWeatherHelper` 的异常传播测试：当 `LocationService.getCurrentLocation()` 抛错时，断言 `LocationWeatherHelper.fetchLocation()` 将异常向上抛出。提升边界用例覆盖，避免静默吞错。

<sup>Written for commit 0cefe4de768aabb58134f47e0fe3c2153825d6b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

