### PR TITLE
🗃️ 黑匣: [完善 HomePage 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -42,3 +42,6 @@
 ## 2025-10-25 - 🗃️ 黑匣: [完善 FeatureGuideService 模块的结构化日志]
 **异常:** [MMKV读取/写入抛出异常且只使用了粗糙的debugPrint记录，丢失了错误栈与模块上下文]
 **拦截:** [使用 catch (e, stackTrace) 和 logError 封装 MMKV 异常，附带 error, stackTrace 和 source: 'FeatureGuideService' 参数，保存完整的堆栈上下文信息。]
+## 2024-05-27 - [完善 HomePage 模块的结构化日志]
+**异常:** `HomePage` 中在恢复草稿、加载标签等操作时，异常被直接捕获并仅通过 `logDebug` 记录，丢失了错误的完整堆栈信息 (stackTrace) 和上下文。
+**拦截:** 确立将重要业务流程中的 `catch (e)` 统一升级为 `catch (e, stackTrace)`，使用 `logError('描述', error: e, stackTrace: stackTrace, source: 'ModuleName')` 替换 `logDebug` 进行规范日志记录。

--- a/lib/pages/ai_assistant/ai_assistant_page_quick_edit.dart
+++ b/lib/pages/ai_assistant/ai_assistant_page_quick_edit.dart
@@ -124,7 +124,8 @@ extension _AIAssistantPageQuickEdit on _AIAssistantPageState {
                                   decoration: InputDecoration(
                                     labelText: l10n.author,
                                     isDense: true,
-                                    prefixIcon: const Icon(Icons.person_outline),
+                                    prefixIcon:
+                                        const Icon(Icons.person_outline),
                                     border: const OutlineInputBorder(),
                                   ),
                                 ),

--- a/lib/pages/ai_report/report_overview.dart
+++ b/lib/pages/ai_report/report_overview.dart
@@ -509,7 +509,8 @@ extension _AIReportOverview on _AIPeriodicReportPageState {
                     ),
                   ),
                   const SizedBox(width: 4),
-                  const ExperimentalBadge(compact: true, enableTapNotice: false),
+                  const ExperimentalBadge(
+                      compact: true, enableTapNotice: false),
                 ],
               ),
               const SizedBox(height: 4),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -491,8 +491,13 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
             } else {
               logDebug('恢复草稿时发现原始笔记已删除，将作为新笔记处理');
             }
-          } catch (e) {
-            logDebug('恢复草稿时获取原始笔记失败: $e');
+          } catch (e, stackTrace) {
+            logError(
+              '恢复草稿时获取原始笔记失败',
+              error: e,
+              stackTrace: stackTrace,
+              source: 'HomePage',
+            );
           }
         }
 
@@ -582,8 +587,13 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
         context.read<DatabaseService>().getCategories,
       );
       if (mounted) logDebug('标签加载完成，共 ${_pageController.tags.length} 个标签');
-    } catch (e) {
-      logDebug('加载标签时出错: $e');
+    } catch (e, stackTrace) {
+      logError(
+        '加载标签时出错',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'HomePage',
+      );
     }
   }
 
@@ -594,8 +604,13 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       await Future.microtask(() async {
         await _loadTags();
       });
-    } catch (e) {
-      logDebug('预加载标签失败: $e');
+    } catch (e, stackTrace) {
+      logError(
+        '预加载标签失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'HomePage',
+      );
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1328,10 +1328,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1344,10 +1344,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: "direct main"
     description:
@@ -2213,26 +2213,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.17"
   timezone:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1328,10 +1328,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1344,10 +1344,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: "direct main"
     description:
@@ -2213,26 +2213,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.15"
   timezone:
     dependency: "direct main"
     description:


### PR DESCRIPTION
**封装前:**
```dart
} catch (e) {
  logDebug('恢复草稿时获取原始笔记失败: $e');
}
```
**封装后:**
```dart
} catch (e, stackTrace) {
  logError(
    '恢复草稿时获取原始笔记失败',
    error: e,
    stackTrace: stackTrace,
    source: 'HomePage',
  );
}
```
**说明:**
已完善 `HomePage` 中三处隐蔽错误的结构化日志上报，并确保在添加的日志中未包含任何用户隐私敏感数据（如笔记内容等）。已更新 `.jules/blackbox.md`。

---
*PR created automatically by Jules for task [1593687374876162384](https://jules.google.com/task/1593687374876162384) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
在 HomePage 引入结构化错误日志，将恢复草稿、加载标签、预加载标签中的 logDebug 全部替换为带 error、stackTrace、source: 'HomePage' 的 logError。同步完善黑匣文档，并修复两处仅影响格式的换行。

- **重构**
  - 统一使用 catch (e, stackTrace)，通过 logError 上报完整上下文；不记录任何敏感数据。
  - 更新 `.jules/blackbox.md`，补充 HomePage 的日志策略与拦截记录。

- **Bug Fixes**
  - 修复 `ai_assistant_page_quick_edit.dart` 与 `report_overview.dart` 的格式化问题（仅换行），不影响功能。

<sup>Written for commit 988eda5105c3d07da80908ef116eb52dd73da3f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误处理**
  * 改进首页草稿恢复和标签加载相关异常的日志记录。
  * 错误日志现在包含更完整的堆栈信息和来源标识，便于问题排查。
  * 保持原有的回退和后续处理流程不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->