### PR TITLE
refactor(explore): 探索页数据带瘦身、动效砍成一层

### DIFF
--- a/lib/pages/ai_periodic_report_page.dart
+++ b/lib/pages/ai_periodic_report_page.dart
@@ -16,6 +16,7 @@ import '../utils/icon_utils.dart';
 import '../utils/report_period_utils.dart';
 import '../utils/string_utils.dart';
 import '../constants/app_constants.dart'; // 导入应用常量
+import '../theme/app_theme.dart';
 import '../gen_l10n/app_localizations.dart';
 import '../widgets/ai/experimental_badge.dart';
 import 'ai_assistant_page.dart';

--- a/lib/pages/ai_periodic_report_page.dart
+++ b/lib/pages/ai_periodic_report_page.dart
@@ -61,7 +61,7 @@ class _AIPeriodicReportPageState extends State<AIPeriodicReportPage> {
   IconData? _mostDayPeriodIcon; // 时段图标
   String? _mostWeatherDisplay; // 天气的中文显示
   IconData? _mostWeatherIcon; // 天气图标
-  dynamic _mostTopTagIcon; // 标签图标（可能是IconData或emoji字符串）
+  Object? _mostTopTagIcon; // 标签图标（IconData 或 emoji 字符串）
 
   String _insightText = '';
   bool _insightLoading = false;

--- a/lib/pages/ai_report/report_overview.dart
+++ b/lib/pages/ai_report/report_overview.dart
@@ -1,5 +1,9 @@
 part of '../ai_periodic_report_page.dart';
 
+/// 收藏红心色值：记录页 quote_item_widget 用的是同一个色值，两边必须一致。
+/// 是否收进 AppSemanticColors 并统一迁移三处调用，属于全局待决项。
+final Color _favoriteAccent = Colors.red.shade400;
+
 extension _AIReportOverview on _AIPeriodicReportPageState {
   /// 构建数据概览
   Widget _buildDataOverview() {
@@ -43,8 +47,12 @@ extension _AIReportOverview on _AIPeriodicReportPageState {
               avgWords: avgWords,
               activeDays: _getActiveDays(),
             ),
-            const SizedBox(height: 10),
-            _buildHighlightChips(),
+            // 空周期不摆三个「暂无」chip：下面的空状态已经说过一次了。
+            // 摘要带保留——四个 0 是紧凑的事实，也让切换周期时布局不跳。
+            if (totalNotes > 0) ...[
+              const SizedBox(height: 10),
+              _buildHighlightChips(),
+            ],
             const SizedBox(height: 20),
 
             // 洞察 + AI 对话入口
@@ -188,7 +196,7 @@ extension _AIReportOverview on _AIPeriodicReportPageState {
       children: [
         Row(
           children: [
-            Icon(Icons.favorite, size: 20, color: Colors.red.shade400),
+            Icon(Icons.favorite, size: 20, color: _favoriteAccent),
             const SizedBox(width: 8),
             Text(
               l10n.mostFavoritedInPeriod,
@@ -233,9 +241,7 @@ extension _AIReportOverview on _AIPeriodicReportPageState {
                     vertical: 2,
                   ),
                   decoration: BoxDecoration(
-                    // 收藏红心在记录页也是这个色值，这里保持一致；
-                    // 是否统一收进 AppSemanticColors 是全局待决项。
-                    color: Colors.red.shade400,
+                    color: _favoriteAccent,
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: Row(
@@ -428,9 +434,11 @@ extension _AIReportOverview on _AIPeriodicReportPageState {
                         vertical: 8,
                       ),
                       decoration: BoxDecoration(
+                        // 卡片本身已经是 surfaceContainerHigh，这里必须再深一档，
+                        // 否则内外同色、层次消失
                         color: Theme.of(
                           context,
-                        ).colorScheme.surfaceContainerHigh,
+                        ).colorScheme.surfaceContainerHighest,
                         borderRadius: BorderRadius.circular(8),
                       ),
                       child: Row(

--- a/lib/pages/ai_report/report_overview.dart
+++ b/lib/pages/ai_report/report_overview.dart
@@ -24,272 +24,139 @@ extension _AIReportOverview on _AIPeriodicReportPageState {
         ? context.select<SettingsService, bool>((s) => s.showNoteEditTime)
         : false;
 
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // 标题优化：添加图标和更好的视觉层次
-          Row(
-            children: [
-              Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Icon(
-                  Icons.analytics_outlined,
-                  color: Theme.of(context).colorScheme.onPrimaryContainer,
-                  size: 20,
-                ),
+    // 整页一次入场，不再逐块交错。
+    // 之前七到十个 TweenAnimationBuilder 用 400~1000ms 错开，最后一块要 1.4 秒
+    // 才落位——数据早就到了，用户还得等动画演完才能看清页面。
+    return _buildEntrance(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildOverviewHeader(l10n),
+            const SizedBox(height: 16),
+
+            // 数据摘要带 + 三个「最多」chip
+            _buildSummaryBand(
+              totalNotes: totalNotes,
+              totalWords: totalWords,
+              avgWords: avgWords,
+              activeDays: _getActiveDays(),
+            ),
+            const SizedBox(height: 10),
+            _buildHighlightChips(),
+            const SizedBox(height: 20),
+
+            // 洞察 + AI 对话入口
+            _buildInsightBulbBar(),
+            const SizedBox(height: 12),
+            _buildQuickEntries(),
+            const SizedBox(height: 24),
+
+            if (_periodQuotes.isNotEmpty) ...[
+              _buildPeriodTopFavoritesSection(),
+              const SizedBox(height: 20),
+              _buildRecentNotesSection(
+                l10n,
+                showExactTime: showExactTime,
+                showNoteEditTime: showNoteEditTime,
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      l10n.dataOverview,
-                      style: Theme.of(context).textTheme.headlineSmall,
-                    ),
-                    Text(
-                      _getDateRangeText(l10n),
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                          ),
-                    ),
-                  ],
+            ] else
+              _buildEmptyState(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 统一的入场动画：一层 300ms 的淡入 + 轻微上移。
+  Widget _buildEntrance({required Widget child}) {
+    if (!_shouldAnimateOverview) return child;
+    return TweenAnimationBuilder<double>(
+      key: ValueKey('overview_$_dataKey'),
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+      tween: Tween(begin: 0.0, end: 1.0),
+      child: child,
+      builder: (context, value, child) {
+        return Opacity(
+          opacity: value,
+          child: Transform.translate(
+            offset: Offset(0, 8 * (1 - value)),
+            child: child,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildOverviewHeader(AppLocalizations l10n) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primaryContainer,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Icon(
+            Icons.analytics_outlined,
+            color: theme.colorScheme.onPrimaryContainer,
+            size: 20,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(l10n.dataOverview, style: theme.textTheme.titleLarge),
+              Text(
+                _getDateRangeText(l10n),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 20),
+        ),
+      ],
+    );
+  }
 
-          // 统计卡片网格 - 根据标志决定是否播放动画
-          TweenAnimationBuilder<double>(
-            key: ValueKey('stats1_$_dataKey'), // 添加key确保动画只在数据变化时触发
-            duration: _shouldAnimateOverview
-                ? const Duration(milliseconds: 600)
-                : Duration.zero, // 不动画时立即显示
-            tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-            builder: (context, value, child) {
-              return Transform.translate(
-                offset: Offset(0, 20 * (1 - value)),
-                child: Opacity(
-                  opacity: value,
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: _buildStatCard(
-                          l10n.noteCount,
-                          '$totalNotes',
-                          l10n.notesUnitPlain,
-                          Icons.note_alt_outlined,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: _buildStatCard(
-                          l10n.totalWordCount,
-                          '$totalWords',
-                          l10n.wordsUnitPlain,
-                          Icons.text_fields,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-          const SizedBox(height: 12),
-          TweenAnimationBuilder<double>(
-            key: ValueKey('stats2_$_dataKey'),
-            duration: _shouldAnimateOverview
-                ? const Duration(milliseconds: 800)
-                : Duration.zero,
-            tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-            builder: (context, value, child) {
-              return Transform.translate(
-                offset: Offset(0, 20 * (1 - value)),
-                child: Opacity(
-                  opacity: value,
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: _buildStatCard(
-                          l10n.avgWords,
-                          '$avgWords',
-                          l10n.wordsPerNote,
-                          Icons.calculate_outlined,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: _buildStatCard(
-                          l10n.activeDays,
-                          '${_getActiveDays()}',
-                          l10n.daysUnitPlain,
-                          Icons.calendar_today_outlined,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-          const SizedBox(height: 24),
-
-          // 新增：三个"最多"指标 - 根据标志决定是否播放动画
-          TweenAnimationBuilder<double>(
-            key: ValueKey('stats3_$_dataKey'),
-            duration: _shouldAnimateOverview
-                ? const Duration(milliseconds: 1000)
-                : Duration.zero,
-            tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-            builder: (context, value, child) {
-              return Transform.translate(
-                offset: Offset(0, 20 * (1 - value)),
-                child: Opacity(
-                  opacity: value,
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: _buildStatCardWithCustomIcon(
-                          l10n.commonPeriod,
-                          _mostDayPeriodDisplay ?? l10n.noDataYet,
-                          '',
-                          _mostDayPeriodIcon ?? Icons.timelapse,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: _buildStatCardWithCustomIcon(
-                          l10n.commonWeather,
-                          _mostWeatherDisplay ?? l10n.noDataYet,
-                          '',
-                          _mostWeatherIcon ?? Icons.cloud_queue,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: _buildStatCardWithTagIcon(
-                          l10n.commonTag,
-                          _mostTopTag ?? l10n.noDataYet,
-                          '',
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-          const SizedBox(height: 16),
-
-          // 洞察小灯泡（移到常用标签下面）
-          _buildInsightBulbBar(),
-          const SizedBox(height: 20),
-
-          // ─── AI 对话入口 ───
-          _buildQuickEntries(),
-          const SizedBox(height: 24),
-
-          // 本周期收藏最多（放在洞察下面，最近笔记上面）- 根据标志决定是否播放动画
-          if (_periodQuotes.isNotEmpty) ...[
-            TweenAnimationBuilder<double>(
-              key: ValueKey('favorites_$_dataKey'),
-              duration: _shouldAnimateOverview
-                  ? const Duration(milliseconds: 800)
-                  : Duration.zero,
-              tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-              builder: (context, value, child) {
-                return Transform.translate(
-                  offset: Offset(0, 20 * (1 - value)),
-                  child: Opacity(
-                    opacity: value,
-                    child: _buildPeriodTopFavoritesSection(),
-                  ),
-                );
-              },
-            ),
-            const SizedBox(height: 16),
+  Widget _buildRecentNotesSection(
+    AppLocalizations l10n, {
+    required bool showExactTime,
+    required bool showNoteEditTime,
+  }) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.history, size: 20, color: theme.colorScheme.primary),
+            const SizedBox(width: 8),
+            Text(l10n.recentNotes, style: theme.textTheme.titleMedium),
           ],
-
-          // 最近笔记部分 - 根据标志决定是否播放动画
-          if (_periodQuotes.isNotEmpty) ...[
-            TweenAnimationBuilder<double>(
-              key: ValueKey('recent_$_dataKey'),
-              duration: _shouldAnimateOverview
-                  ? const Duration(milliseconds: 1000)
-                  : Duration.zero,
-              tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-              builder: (context, value, child) {
-                return Transform.translate(
-                  offset: Offset(0, 20 * (1 - value)),
-                  child: Opacity(
-                    opacity: value,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          children: [
-                            Icon(
-                              Icons.history,
-                              size: 20,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              l10n.recentNotes,
-                              style: Theme.of(context).textTheme.titleMedium,
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 12),
-                        ..._periodQuotes.take(3).map(
-                              (quote) => TweenAnimationBuilder<double>(
-                                duration: Duration(
-                                  milliseconds: 600 +
-                                      (_periodQuotes.indexOf(quote) * 200),
-                                ),
-                                tween: Tween(begin: 0.0, end: 1.0),
-                                builder: (context, animValue, child) {
-                                  return Transform.translate(
-                                    offset: Offset(0, 15 * (1 - animValue)),
-                                    child: Opacity(
-                                      opacity: animValue,
-                                      child: _buildQuotePreview(
-                                        quote,
-                                        showExactTime: showExactTime,
-                                        showNoteEditTime: showNoteEditTime,
-                                      ),
-                                    ),
-                                  );
-                                },
-                              ),
-                            ),
-                      ],
-                    ),
-                  ),
-                );
-              },
+        ),
+        const SizedBox(height: 12),
+        ..._periodQuotes.take(3).map(
+              (quote) => _buildQuotePreview(
+                quote,
+                showExactTime: showExactTime,
+                showNoteEditTime: showNoteEditTime,
+              ),
             ),
-          ] else ...[
-            // 空状态优化
-            _buildEmptyState(),
-          ],
-        ],
-      ),
+      ],
     );
   }
 
   // 构建“本周期收藏最多”的展示区域
   Widget _buildPeriodTopFavoritesSection() {
     final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
     // 过滤出有心形点击的笔记，并按次数排序
     final List<Quote> favorited = _periodQuotes
         .where((q) => q.favoriteCount > 0)
@@ -298,161 +165,95 @@ extension _AIReportOverview on _AIPeriodicReportPageState {
 
     if (favorited.isEmpty) {
       // 若本周期没有心形点击，显示一个轻量提示
-      return TweenAnimationBuilder<double>(
-        key: ValueKey('favorites_empty_$_dataKey'),
-        duration: _shouldAnimateOverview
-            ? const Duration(milliseconds: 600)
-            : Duration.zero,
-        tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-        builder: (context, value, child) {
-          return Transform.translate(
-            offset: Offset(0, 10 * (1 - value)),
-            child: Opacity(
-              opacity: value,
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.favorite_outline,
-                    size: 20,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      l10n.noFavoritesInPeriod,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                  ),
-                ],
-              ),
+      return Row(
+        children: [
+          Icon(
+            Icons.favorite_outline,
+            size: 20,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l10n.noFavoritesInPeriod,
+              style: theme.textTheme.bodyMedium,
             ),
-          );
-        },
+          ),
+        ],
       );
     }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        TweenAnimationBuilder<double>(
-          key: ValueKey('favorites_title_$_dataKey'),
-          duration: _shouldAnimateOverview
-              ? const Duration(milliseconds: 500)
-              : Duration.zero,
-          tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-          builder: (context, value, child) {
-            return Transform.translate(
-              offset: Offset(0, 10 * (1 - value)),
-              child: Opacity(
-                opacity: value,
-                child: Row(
-                  children: [
-                    Icon(Icons.favorite, size: 20, color: Colors.red.shade400),
-                    const SizedBox(width: 8),
-                    Text(
-                      l10n.mostFavoritedInPeriod,
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
+        Row(
+          children: [
+            Icon(Icons.favorite, size: 20, color: Colors.red.shade400),
+            const SizedBox(width: 8),
+            Text(
+              l10n.mostFavoritedInPeriod,
+              style: theme.textTheme.titleMedium,
+            ),
+          ],
         ),
         const SizedBox(height: 12),
-        ...favorited.take(3).map(
-              (q) => TweenAnimationBuilder<double>(
-                key: ValueKey('favorite_${q.id}_$_dataKey'),
-                duration: _shouldAnimateOverview
-                    ? Duration(milliseconds: 600 + (favorited.indexOf(q) * 150))
-                    : Duration.zero,
-                tween: Tween(
-                  begin: _shouldAnimateOverview ? 0.0 : 1.0,
-                  end: 1.0,
-                ),
-                builder: (context, value, child) {
-                  return Transform.translate(
-                    offset: Offset(0, 15 * (1 - value)),
-                    child: Opacity(
-                      opacity: value,
-                      child: _buildFavoritePreviewChip(q),
-                    ),
-                  );
-                },
-              ),
-            ),
+        ...favorited.take(3).map(_buildFavoritePreviewChip),
       ],
     );
   }
 
-  // 一个紧凑的收藏预览块 - 优化视觉效果
+  // 一个紧凑的收藏预览块
   Widget _buildFavoritePreviewChip(Quote quote) {
     final theme = Theme.of(context);
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       child: Material(
-        elevation: 1,
-        borderRadius: BorderRadius.circular(8),
+        color: theme.colorScheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(12),
         child: InkWell(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(12),
           onTap: () {
             HapticFeedback.lightImpact();
             // 可以添加跳转到笔记详情的逻辑
           },
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
+          child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
             decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerLowest,
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: Colors.red.shade100, width: 1),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: theme.colorScheme.outlineVariant.withValues(alpha: 0.6),
+              ),
             ),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                TweenAnimationBuilder<double>(
-                  duration: const Duration(milliseconds: 800),
-                  tween: Tween(begin: 0.8, end: 1.0),
-                  builder: (context, value, child) {
-                    return Transform.scale(
-                      scale: value,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 6,
-                          vertical: 2,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.red.shade400,
-                          borderRadius: BorderRadius.circular(10),
-                          boxShadow: [
-                            BoxShadow(
-                              color: Colors.red.shade200,
-                              blurRadius: 4,
-                              offset: const Offset(0, 2),
-                            ),
-                          ],
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Icon(
-                              Icons.favorite,
-                              color: Colors.white,
-                              size: 12,
-                            ),
-                            const SizedBox(width: 4),
-                            Text(
-                              '${quote.favoriteCount}',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .labelSmall
-                                  ?.copyWith(color: Colors.white),
-                            ),
-                          ],
-                        ),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    // 收藏红心在记录页也是这个色值，这里保持一致；
+                    // 是否统一收进 AppSemanticColors 是全局待决项。
+                    color: Colors.red.shade400,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(
+                        Icons.favorite,
+                        color: Colors.white,
+                        size: 12,
                       ),
-                    );
-                  },
+                      const SizedBox(width: 4),
+                      Text(
+                        '${quote.favoriteCount}',
+                        style: theme.textTheme.labelSmall
+                            ?.copyWith(color: Colors.white),
+                      ),
+                    ],
+                  ),
                 ),
                 const SizedBox(width: 10),
                 Expanded(
@@ -566,31 +367,25 @@ extension _AIReportOverview on _AIPeriodicReportPageState {
     // 判断是否正在等待首个响应（加载中但还没有文本）
     final isWaitingFirstResponse = _insightLoading && _insightText.isEmpty;
 
+    // 洞察是这一屏的主角：不用阴影抬升，改用比摘要带更高一档的容器色，
+    // 让整页保持同一套扁平的层次语言。
     return Card(
-      elevation: 1,
+      elevation: 0,
+      color: Theme.of(context).colorScheme.surfaceContainerHigh,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
+      ),
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(14),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 灯泡图标：流式接收中闪烁，完成后稳定
-            AnimatedContainer(
-              duration: const Duration(milliseconds: 300),
-              child: TweenAnimationBuilder<double>(
-                duration: const Duration(milliseconds: 1500),
-                tween: Tween(begin: 0.8, end: 1.0),
-                builder: (context, value, child) {
-                  return Transform.scale(
-                    scale: _insightLoading ? value : 1.0,
-                    child: Icon(
-                      Icons.lightbulb,
-                      color: _insightLoading
-                          ? Colors.amber.withValues(alpha: value)
-                          : Theme.of(context).colorScheme.primary,
-                    ),
-                  );
-                },
-              ),
+            // 生成中由下面的进度条表达，图标保持稳定。
+            // 原来那个 0.8→1.0 的 amber 动画只跑一次就停了，本想做的"呼吸"
+            // 效果并没有实现，反而多出一层动画。
+            Icon(
+              Icons.lightbulb,
+              color: Theme.of(context).colorScheme.primary,
             ),
             const SizedBox(width: 8),
             Expanded(

--- a/lib/pages/ai_report/report_stats.dart
+++ b/lib/pages/ai_report/report_stats.dart
@@ -1,302 +1,102 @@
 part of '../ai_periodic_report_page.dart';
 
 extension _AIReportStats on _AIPeriodicReportPageState {
-  /// 构建统计卡片
-  Widget _buildStatCard(
-    String title,
-    String value,
-    String unit, [
-    IconData? icon,
-  ]) {
-    return Card(
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                if (icon != null) ...[
-                  Icon(
-                    icon,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const SizedBox(width: 6),
-                ],
-                Expanded(
-                  child: Text(
-                    title,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                Expanded(
-                  child: FittedBox(
-                    fit: BoxFit.scaleDown,
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      value,
-                      style:
-                          Theme.of(context).textTheme.headlineMedium?.copyWith(
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                      maxLines: 1,
-                    ),
-                  ),
-                ),
-                if (unit.isNotEmpty) ...[
-                  const SizedBox(width: 4),
-                  Text(
-                    unit,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                  ),
-                ],
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// 构建带自定义图标的统计卡片
-  Widget _buildStatCardWithCustomIcon(
-    String title,
-    String value,
-    String unit,
-    IconData icon,
-  ) {
-    return Card(
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(
-                  icon,
-                  size: 16,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-                const SizedBox(width: 6),
-                Expanded(
-                  child: Text(
-                    title,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                Expanded(
-                  child: FittedBox(
-                    fit: BoxFit.scaleDown,
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      value,
-                      style:
-                          Theme.of(context).textTheme.headlineMedium?.copyWith(
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                      maxLines: 1,
-                    ),
-                  ),
-                ),
-                if (unit.isNotEmpty) ...[
-                  const SizedBox(width: 4),
-                  Text(
-                    unit,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                  ),
-                ],
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// 构建带标签图标的统计卡片
-  Widget _buildStatCardWithTagIcon(String title, String value, String unit) {
-    return Card(
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                // 显示标签图标
-                if (_mostTopTagIcon != null) ...[
-                  if (_mostTopTagIcon is IconData)
-                    Icon(
-                      _mostTopTagIcon as IconData,
-                      size: 16,
-                      color: Theme.of(context).colorScheme.primary,
-                    )
-                  else
-                    Text(
-                      _mostTopTagIcon.toString(),
-                      style: const TextStyle(fontSize: 14),
-                    ),
-                  const SizedBox(width: 6),
-                ] else ...[
-                  Icon(
-                    Icons.local_offer_outlined,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const SizedBox(width: 6),
-                ],
-                Expanded(
-                  child: Text(
-                    title,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                Expanded(
-                  child: FittedBox(
-                    fit: BoxFit.scaleDown,
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      value,
-                      style:
-                          Theme.of(context).textTheme.headlineMedium?.copyWith(
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                      maxLines: 1,
-                    ),
-                  ),
-                ),
-                if (unit.isNotEmpty) ...[
-                  const SizedBox(width: 4),
-                  Text(
-                    unit,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        ),
-                  ),
-                ],
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildEmptyState() {
+  /// 数据摘要带：把四个计数指标压成一条，不再各占一张卡片。
+  ///
+  /// 之前四张 elevation:2 的卡片和下面三个「最多」卡片视觉权重相同，
+  /// 七块同样重的内容并排等于没有重点，也把页面唯一的出口挤到了下方。
+  Widget _buildSummaryBand({
+    required int totalNotes,
+    required int totalWords,
+    required int avgWords,
+    required int activeDays,
+  }) {
     final l10n = AppLocalizations.of(context);
-    return Center(
-      child: Container(
-        padding: const EdgeInsets.all(32),
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 8),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
+      ),
+      child: Row(
+        children: [
+          _buildSummaryMetric(
+            value: '$totalNotes',
+            unit: l10n.notesUnitPlain,
+            label: l10n.noteCount,
+          ),
+          _buildSummaryDivider(),
+          _buildSummaryMetric(
+            value: '$totalWords',
+            unit: l10n.wordsUnitPlain,
+            label: l10n.totalWordCount,
+          ),
+          _buildSummaryDivider(),
+          _buildSummaryMetric(
+            value: '$activeDays',
+            unit: l10n.daysUnitPlain,
+            label: l10n.activeDays,
+          ),
+          _buildSummaryDivider(),
+          _buildSummaryMetric(
+            value: '$avgWords',
+            unit: l10n.wordsUnitPlain,
+            label: l10n.avgWords,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryMetric({
+    required String value,
+    required String unit,
+    required String label,
+  }) {
+    final theme = Theme.of(context);
+    return Expanded(
+      child: Semantics(
+        label: '$label $value$unit',
+        excludeSemantics: true,
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
           children: [
-            TweenAnimationBuilder<double>(
-              key: ValueKey('empty1_$_dataKey'),
-              duration: _shouldAnimateOverview
-                  ? const Duration(milliseconds: 800)
-                  : Duration.zero,
-              tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-              builder: (context, value, child) {
-                return Transform.scale(
-                  scale: value,
-                  child: Opacity(
-                    opacity: value,
-                    child: Icon(
-                      Icons.note_add_outlined,
-                      size: 64,
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    value,
+                    maxLines: 1,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.w600,
                     ),
                   ),
-                );
-              },
+                  const SizedBox(width: 2),
+                  Text(
+                    unit,
+                    maxLines: 1,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
             ),
-            const SizedBox(height: 16),
-            TweenAnimationBuilder<double>(
-              key: ValueKey('empty2_$_dataKey'),
-              duration: _shouldAnimateOverview
-                  ? const Duration(milliseconds: 600)
-                  : Duration.zero,
-              tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-              builder: (context, value, child) {
-                return Transform.translate(
-                  offset: Offset(0, 20 * (1 - value)),
-                  child: Opacity(
-                    opacity: value,
-                    child: Text(
-                      l10n.noNotesInPeriodForPeriod(_getPeriodName(l10n)),
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                          ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                );
-              },
-            ),
-            const SizedBox(height: 8),
-            TweenAnimationBuilder<double>(
-              key: ValueKey('empty3_$_dataKey'),
-              duration: _shouldAnimateOverview
-                  ? const Duration(milliseconds: 400)
-                  : Duration.zero,
-              tween: Tween(begin: _shouldAnimateOverview ? 0.0 : 1.0, end: 1.0),
-              builder: (context, value, child) {
-                return Transform.translate(
-                  offset: Offset(0, 20 * (1 - value)),
-                  child: Opacity(
-                    opacity: value,
-                    child: Text(
-                      l10n.startRecordingThoughts,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: Theme.of(
-                              context,
-                            )
-                                .colorScheme
-                                .onSurfaceVariant
-                                .withValues(alpha: 0.7),
-                          ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                );
-              },
+            const SizedBox(height: 2),
+            Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ),
@@ -304,9 +104,127 @@ extension _AIReportStats on _AIPeriodicReportPageState {
     );
   }
 
-  /// 构建笔记预览 - 优化交互效果
-  /// [showExactTime]/[showNoteEditTime] 由调用方在 build 期间读取后传入：
-  /// 本方法会在 TweenAnimationBuilder 的回调里执行，那里不允许 context.select。
+  Widget _buildSummaryDivider() {
+    return Container(
+      width: 1,
+      height: 28,
+      color: Theme.of(context).colorScheme.outlineVariant.withValues(
+            alpha: 0.6,
+          ),
+    );
+  }
+
+  /// 三个「最多」指标：它们的值是分类而不是量，用 chip 比用数字卡片更贴切。
+  Widget _buildHighlightChips() {
+    final l10n = AppLocalizations.of(context);
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        _buildHighlightChip(
+          label: l10n.commonPeriod,
+          value: _mostDayPeriodDisplay ?? l10n.noDataYet,
+          icon: _mostDayPeriodIcon ?? Icons.timelapse,
+        ),
+        _buildHighlightChip(
+          label: l10n.commonWeather,
+          value: _mostWeatherDisplay ?? l10n.noDataYet,
+          icon: _mostWeatherIcon ?? Icons.cloud_queue,
+        ),
+        _buildHighlightChip(
+          label: l10n.commonTag,
+          value: _mostTopTag ?? l10n.noDataYet,
+          icon: _mostTopTagIcon is IconData
+              ? _mostTopTagIcon as IconData
+              : (_mostTopTagIcon == null ? Icons.local_offer_outlined : null),
+          emoji:
+              _mostTopTagIcon is IconData ? null : _mostTopTagIcon?.toString(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHighlightChip({
+    required String label,
+    required String value,
+    IconData? icon,
+    String? emoji,
+  }) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: '$label $value',
+      excludeSemantics: true,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerLow,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (emoji != null)
+              Text(emoji, style: const TextStyle(fontSize: 14))
+            else
+              Icon(
+                icon ?? Icons.local_offer_outlined,
+                size: 15,
+                color: theme.colorScheme.primary,
+              ),
+            const SizedBox(width: 6),
+            Text(
+              value,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 空状态：整页只说一次「没有笔记」，不再叠加七张全 0 的卡片。
+  Widget _buildEmptyState() {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 40, horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.note_add_outlined,
+              size: 56,
+              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              l10n.noNotesInPeriodForPeriod(_getPeriodName(l10n)),
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.startRecordingThoughts,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color:
+                    theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 构建笔记预览
+  /// [showExactTime]/[showNoteEditTime] 由调用方在 build 期间读取后传入，
+  /// 避免本方法被放进动画回调时再去 context.select。
   Widget _buildQuotePreview(
     Quote quote, {
     required bool showExactTime,
@@ -339,7 +257,8 @@ extension _AIReportStats on _AIPeriodicReportPageState {
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
       child: Material(
-        elevation: 1,
+        // 已经有描边了，不再叠阴影；页面统一走扁平分层
+        color: Theme.of(context).colorScheme.surfaceContainerLowest,
         borderRadius: BorderRadius.circular(12),
         child: InkWell(
           borderRadius: BorderRadius.circular(12),
@@ -348,15 +267,14 @@ extension _AIReportStats on _AIPeriodicReportPageState {
             HapticFeedback.lightImpact();
             // 可以添加跳转到笔记详情的逻辑
           },
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
+          child: Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
                 color: Theme.of(
                   context,
-                ).colorScheme.outline.withValues(alpha: 0.2),
+                ).colorScheme.outlineVariant.withValues(alpha: 0.6),
                 width: 1,
               ),
             ),
@@ -433,7 +351,7 @@ extension _AIReportStats on _AIPeriodicReportPageState {
                         borderRadius: BorderRadius.circular(10),
                       ),
                       child: Text(
-                        '${quote.content.length} 字',
+                        '${quote.content.length}${l10n.wordsUnitPlain}',
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
                               color: Theme.of(
                                 context,

--- a/lib/pages/ai_report/report_stats.dart
+++ b/lib/pages/ai_report/report_stats.dart
@@ -57,7 +57,7 @@ extension _AIReportStats on _AIPeriodicReportPageState {
     final theme = Theme.of(context);
     return Expanded(
       child: Semantics(
-        label: '$label $value$unit',
+        label: '$label $value $unit',
         excludeSemantics: true,
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -117,6 +117,8 @@ extension _AIReportStats on _AIPeriodicReportPageState {
   /// 三个「最多」指标：它们的值是分类而不是量，用 chip 比用数字卡片更贴切。
   Widget _buildHighlightChips() {
     final l10n = AppLocalizations.of(context);
+    // 提到局部变量才能让类型提升生效，省掉重复的 is/as 判断
+    final tagIcon = _mostTopTagIcon;
     return Wrap(
       spacing: 8,
       runSpacing: 8,
@@ -134,11 +136,8 @@ extension _AIReportStats on _AIPeriodicReportPageState {
         _buildHighlightChip(
           label: l10n.commonTag,
           value: _mostTopTag ?? l10n.noDataYet,
-          icon: _mostTopTagIcon is IconData
-              ? _mostTopTagIcon as IconData
-              : (_mostTopTagIcon == null ? Icons.local_offer_outlined : null),
-          emoji:
-              _mostTopTagIcon is IconData ? null : _mostTopTagIcon?.toString(),
+          icon: tagIcon is IconData ? tagIcon : null,
+          emoji: tagIcon is IconData ? null : tagIcon?.toString(),
         ),
       ],
     );
@@ -154,37 +153,47 @@ extension _AIReportStats on _AIPeriodicReportPageState {
     return Semantics(
       label: '$label $value',
       excludeSemantics: true,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(20),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (emoji != null)
-              Text(emoji, style: const TextStyle(fontSize: 14))
-            else
-              Icon(
-                icon ?? Icons.local_offer_outlined,
-                size: 15,
-                color: theme.colorScheme.primary,
+      child: ConstrainedBox(
+        // 标签名可以很长，不约束的话单个 chip 会把窄屏撑破
+        constraints: const BoxConstraints(maxWidth: 180),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerLow,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (emoji != null)
+                Text(emoji, style: const TextStyle(fontSize: 14))
+              else
+                Icon(
+                  icon ?? Icons.local_offer_outlined,
+                  size: 15,
+                  color: theme.colorScheme.primary,
+                ),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurface,
+                  ),
+                ),
               ),
-            const SizedBox(width: 6),
-            Text(
-              value,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurface,
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
   }
 
-  /// 空状态：整页只说一次「没有笔记」，不再叠加七张全 0 的卡片。
+  /// 空状态：整页只说一次「没有笔记」。
+  /// 之前是七张全 0 的卡片 + 三个「暂无」+ 这段文案，同一件事说了三遍；
+  /// 现在只保留紧凑的摘要带（四个 0 是事实，也让切换周期时布局不跳）加这段。
   Widget _buildEmptyState() {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);

--- a/lib/pages/note_editor/editor_metadata_ai_section.dart
+++ b/lib/pages/note_editor/editor_metadata_ai_section.dart
@@ -60,7 +60,7 @@ extension _NoteEditorMetadataAiSection on _NoteFullEditorPageState {
           padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
             color: theme.colorScheme.surfaceContainerLow,
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(AppTheme.cardRadius),
             border: Border.all(
               color: theme.colorScheme.outlineVariant,
             ),
@@ -128,9 +128,6 @@ extension _NoteEditorMetadataAiSection on _NoteFullEditorPageState {
       context: context,
       builder: (dialogContext) {
         return Dialog(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(24),
-          ),
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 500, maxHeight: 600),
             child: Column(
@@ -181,13 +178,13 @@ extension _NoteEditorMetadataAiSection on _NoteFullEditorPageState {
                     margin: const EdgeInsets.symmetric(horizontal: 16),
                     decoration: BoxDecoration(
                       color: colorScheme.surfaceContainerLowest,
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: BorderRadius.circular(AppTheme.cardRadius),
                       border: Border.all(
                         color: colorScheme.outlineVariant.applyOpacity(0.3),
                       ),
                     ),
                     child: ClipRRect(
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: BorderRadius.circular(AppTheme.cardRadius),
                       child: SingleChildScrollView(
                         padding: const EdgeInsets.all(16),
                         child: MarkdownBody(

--- a/lib/pages/note_editor/editor_metadata_dialog.dart
+++ b/lib/pages/note_editor/editor_metadata_dialog.dart
@@ -11,7 +11,9 @@ extension _NoteEditorMetadataDialog on _NoteFullEditorPageState {
       useSafeArea: true,
       backgroundColor: theme.colorScheme.surface,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(AppTheme.dialogRadius),
+        ),
       ),
       builder: (context) {
         return StatefulBuilder(
@@ -139,7 +141,8 @@ extension _NoteEditorMetadataDialog on _NoteFullEditorPageState {
                             color: theme.colorScheme.surfaceContainerLow,
                             clipBehavior: Clip.antiAlias,
                             shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
+                              borderRadius:
+                                  BorderRadius.circular(AppTheme.cardRadius),
                               side: BorderSide(
                                 color: theme.colorScheme.outlineVariant,
                               ),
@@ -189,9 +192,9 @@ extension _NoteEditorMetadataDialog on _NoteFullEditorPageState {
                                 Icons.arrow_forward_ios,
                                 size: 16,
                               ),
-                              shape: const RoundedRectangleBorder(
+                              shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.all(
-                                  Radius.circular(12),
+                                  Radius.circular(AppTheme.cardRadius),
                                 ),
                               ),
                               onTap: () async {
@@ -248,7 +251,8 @@ extension _NoteEditorMetadataDialog on _NoteFullEditorPageState {
                             color: theme.colorScheme.surfaceContainerLow,
                             clipBehavior: Clip.antiAlias,
                             shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
+                              borderRadius:
+                                  BorderRadius.circular(AppTheme.cardRadius),
                               side: BorderSide(
                                 color: theme.colorScheme.outlineVariant,
                               ),
@@ -258,9 +262,9 @@ extension _NoteEditorMetadataDialog on _NoteFullEditorPageState {
                                 AppLocalizations.of(context).selectTags,
                               ),
                               leading: const Icon(Icons.sell_outlined),
-                              shape: const RoundedRectangleBorder(
+                              shape: RoundedRectangleBorder(
                                 borderRadius: BorderRadius.all(
-                                  Radius.circular(12),
+                                  Radius.circular(AppTheme.cardRadius),
                                 ),
                               ),
                               tilePadding: const EdgeInsets.symmetric(
@@ -376,7 +380,8 @@ extension _NoteEditorMetadataDialog on _NoteFullEditorPageState {
                               decoration: BoxDecoration(
                                 color:
                                     theme.colorScheme.surfaceContainerHighest,
-                                borderRadius: BorderRadius.circular(12),
+                                borderRadius:
+                                    BorderRadius.circular(AppTheme.cardRadius),
                               ),
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/pages/note_full_editor_page.dart
+++ b/lib/pages/note_full_editor_page.dart
@@ -42,6 +42,7 @@ import '../utils/location_weather_helper.dart';
 import '../services/settings_service.dart';
 import '../controllers/note_editor_states.dart';
 import '../widgets/app_snackbar.dart';
+import '../theme/app_theme.dart';
 
 part 'note_editor/editor_document_init.dart';
 part 'note_editor/editor_save_and_draft.dart';

--- a/lib/pages/preferences_detail_page.dart
+++ b/lib/pages/preferences_detail_page.dart
@@ -8,6 +8,7 @@ import '../services/biometric_service.dart';
 import '../services/clipboard_service.dart';
 import '../services/database_service.dart';
 import '../services/settings_service.dart';
+import '../theme/app_theme.dart';
 import '../utils/icon_utils.dart';
 import 'ai_settings_page.dart';
 
@@ -78,7 +79,7 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
                     colorScheme.primaryContainer.withValues(alpha: 0.8),
                   ],
                 ),
-                borderRadius: BorderRadius.circular(16),
+                borderRadius: BorderRadius.circular(AppTheme.cardRadius),
                 boxShadow: [
                   BoxShadow(
                     color: colorScheme.shadow.withValues(alpha: 0.1),
@@ -504,7 +505,7 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
     return Container(
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
         border: Border.all(
           color: theme.colorScheme.outline.withValues(alpha: 0.2),
         ),
@@ -517,7 +518,7 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
         ],
       ),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
         child: Material(
           type: MaterialType.transparency,
           child: Column(children: children),
@@ -600,9 +601,9 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
           color: isSelected
               ? theme.colorScheme.secondaryContainer
               : theme.colorScheme.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(14),
+          borderRadius: BorderRadius.circular(AppTheme.buttonRadius),
           child: InkWell(
-            borderRadius: BorderRadius.circular(14),
+            borderRadius: BorderRadius.circular(AppTheme.buttonRadius),
             onTap: () => settings.setOfflineQuoteSource(value),
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
@@ -630,7 +631,7 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
         padding: const EdgeInsets.only(bottom: 4),
         decoration: BoxDecoration(
           color: theme.colorScheme.surfaceContainerLowest,
-          borderRadius: BorderRadius.circular(18),
+          borderRadius: BorderRadius.circular(AppTheme.cardRadius),
           border: Border.all(
             color: theme.colorScheme.outlineVariant.withValues(alpha: 0.45),
           ),
@@ -661,8 +662,10 @@ class _PreferencesDetailPageState extends State<PreferencesDetailPage> {
                   horizontal: 16,
                   vertical: 4,
                 ),
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(18)),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.vertical(
+                    top: Radius.circular(AppTheme.cardRadius),
+                  ),
                 ),
               ),
               const Divider(height: 1, indent: 16, endIndent: 16),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:geolocator/geolocator.dart';
 import '../services/settings_service.dart';
 import '../services/unified_log_service.dart';
+import '../theme/app_theme.dart';
 import 'ai_settings_page.dart';
 import 'hitokoto_settings_page.dart';
 import 'theme_settings_page.dart';
@@ -218,9 +219,6 @@ class SettingsPageState extends State<SettingsPage> {
       builder: (dialogContext) => ChangeNotifierProvider.value(
         value: weatherController,
         child: Dialog(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
-          ),
           child: Container(
             height: MediaQuery.of(context).size.height * 0.7,
             width: MediaQuery.of(context).size.width * 0.9,
@@ -1314,7 +1312,9 @@ class SettingsPageState extends State<SettingsPage> {
   ButtonStyle _primaryButtonStyle(BuildContext context) =>
       ElevatedButton.styleFrom(
         minimumSize: const Size.fromHeight(44),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppTheme.buttonRadius),
+        ),
       );
 
   ButtonStyle _textButtonStyle(BuildContext context) =>

--- a/lib/pages/tag_settings_page.dart
+++ b/lib/pages/tag_settings_page.dart
@@ -71,7 +71,7 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                     colorScheme.primaryContainer.withAlpha(200),
                   ],
                 ),
-                borderRadius: BorderRadius.circular(16),
+                borderRadius: BorderRadius.circular(AppTheme.cardRadius),
                 boxShadow: [
                   BoxShadow(
                     color: colorScheme.shadow.withAlpha(50),
@@ -133,7 +133,7 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
                 color: colorScheme.surfaceContainerLow,
-                borderRadius: BorderRadius.circular(16),
+                borderRadius: BorderRadius.circular(AppTheme.cardRadius),
                 border: Border.all(
                   color: colorScheme.outline.withAlpha(50),
                   width: 1,
@@ -164,7 +164,8 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                             hintText: l10n.tagNameHint,
                             prefixIcon: const Icon(Icons.edit_rounded),
                             border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(12),
+                              borderRadius:
+                                  BorderRadius.circular(AppTheme.inputRadius),
                             ),
                             filled: true,
                             fillColor: colorScheme.surface,
@@ -178,7 +179,8 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                           color: _selectedIconName != null
                               ? colorScheme.primary.withAlpha(20)
                               : colorScheme.surfaceContainerHigh,
-                          borderRadius: BorderRadius.circular(12),
+                          borderRadius:
+                              BorderRadius.circular(AppTheme.buttonRadius),
                           border: Border.all(
                             color: _selectedIconName != null
                                 ? colorScheme.primary
@@ -218,7 +220,8 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                               colorScheme.primary.withAlpha(200),
                             ],
                           ),
-                          borderRadius: BorderRadius.circular(12),
+                          borderRadius:
+                              BorderRadius.circular(AppTheme.buttonRadius),
                         ),
                         child: ElevatedButton(
                           onPressed: _isLoading
@@ -307,7 +310,7 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
               width: double.infinity,
               decoration: BoxDecoration(
                 color: colorScheme.surfaceContainerLow,
-                borderRadius: BorderRadius.circular(16),
+                borderRadius: BorderRadius.circular(AppTheme.cardRadius),
                 border: Border.all(
                   color: colorScheme.outline.withAlpha(50),
                   width: 1,
@@ -558,10 +561,6 @@ class _TagSettingsPageState extends State<TagSettingsPage> {
                                             await showDialog<bool>(
                                           context: context,
                                           builder: (context) => AlertDialog(
-                                            shape: RoundedRectangleBorder(
-                                              borderRadius:
-                                                  BorderRadius.circular(16),
-                                            ),
                                             title: Row(
                                               children: [
                                                 Icon(

--- a/lib/widgets/ai/experimental_badge.dart
+++ b/lib/widgets/ai/experimental_badge.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import '../../gen_l10n/app_localizations.dart';
 import '../../services/settings_service.dart';
+import '../../theme/app_theme.dart';
 import '../../utils/app_logger.dart';
 
 /// 实验性功能标签 Component
@@ -127,9 +128,6 @@ Future<void> showExperimentalNoticeDialog(BuildContext context) async {
           }
 
           return Dialog(
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(24),
-            ),
             elevation: 6,
             backgroundColor: colorScheme.surface,
             child: Padding(
@@ -272,7 +270,7 @@ Future<void> showExperimentalNoticeDialog(BuildContext context) async {
                       style: FilledButton.styleFrom(
                         padding: const EdgeInsets.symmetric(vertical: 14),
                         shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(14),
+                          borderRadius: BorderRadius.circular(AppTheme.buttonRadius),
                         ),
                       ),
                     ),
@@ -307,7 +305,7 @@ class _NoticePointTile extends StatelessWidget {
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
         border: Border.all(
           color: colorScheme.outlineVariant.withValues(alpha: 0.5),
           width: 0.8,

--- a/lib/widgets/media_player_widget.dart
+++ b/lib/widgets/media_player_widget.dart
@@ -9,6 +9,7 @@ import '../constants/app_constants.dart';
 import '../utils/lottie_animation_manager.dart';
 import '../gen_l10n/app_localizations.dart';
 import '../theme/app_semantic_colors.dart';
+import '../theme/app_theme.dart';
 import 'app_snackbar.dart';
 
 /// 统一的媒体播放器组件
@@ -443,7 +444,7 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
           height: widget.height ?? 200,
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.surfaceContainer,
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(AppTheme.cardRadius),
             border: Border.all(
               color:
                   Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
@@ -486,7 +487,7 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
       width: widget.width ?? 300,
       height: widget.height ?? 200,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
         boxShadow: [
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.1),
@@ -514,7 +515,7 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
       height: widget.height ?? 200,
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
         border: Border.all(
           color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
         ),
@@ -553,7 +554,7 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
         border: Border.all(
           color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
         ),

--- a/lib/widgets/onboarding/page_views.dart
+++ b/lib/widgets/onboarding/page_views.dart
@@ -6,6 +6,7 @@ import '../../config/onboarding_config.dart';
 import '../../controllers/onboarding_controller.dart';
 import '../../services/settings_service.dart';
 import '../../services/location_service.dart';
+import '../../theme/app_theme.dart';
 
 /// 欢迎页面组件
 class WelcomePageView extends StatefulWidget {
@@ -453,7 +454,7 @@ class _FeaturesPageViewState extends State<FeaturesPageView>
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
         border: Border.all(
           color: theme.colorScheme.outline.withValues(alpha: 0.2),
         ),
@@ -512,7 +513,7 @@ class _FeatureCard extends StatelessWidget {
       child: Container(
         decoration: isHighlight
             ? BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(AppTheme.cardRadius),
                 gradient: LinearGradient(
                   begin: Alignment.topLeft,
                   end: Alignment.bottomRight,

--- a/lib/widgets/svg_card_widget.dart
+++ b/lib/widgets/svg_card_widget.dart
@@ -5,6 +5,7 @@ import '../gen_l10n/app_localizations.dart';
 import '../models/generated_card.dart';
 import '../utils/app_logger.dart';
 import 'app_snackbar.dart';
+import '../theme/app_theme.dart';
 
 /// SVG卡片渲染组件
 class SVGCardWidget extends StatelessWidget {
@@ -43,7 +44,7 @@ class SVGCardWidget extends StatelessWidget {
         width: width,
         height: height,
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(AppTheme.cardRadius),
           boxShadow: [
             BoxShadow(
               color: Colors.black.withValues(alpha: 0.1),
@@ -53,7 +54,7 @@ class SVGCardWidget extends StatelessWidget {
           ],
         ),
         child: ClipRRect(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(AppTheme.cardRadius),
           child: _buildSVGWidget(context),
         ),
       ),
@@ -128,7 +129,7 @@ class SVGCardWidget extends StatelessWidget {
           decoration: BoxDecoration(
             color: Colors.grey[100],
             border: Border.all(color: Colors.grey[300]!, width: 1),
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(AppTheme.cardRadius),
           ),
           child: Center(
             child: Padding(
@@ -241,7 +242,7 @@ class SVGCardWidget extends StatelessWidget {
       decoration: BoxDecoration(
         color: Colors.red[50],
         border: Border.all(color: Colors.red[200]!, width: 2),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(AppTheme.cardRadius),
       ),
       child: Center(
         child: Padding(
@@ -468,7 +469,9 @@ class _ActionButton extends StatelessWidget {
       label: Text(label),
       style: ElevatedButton.styleFrom(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppTheme.buttonRadius),
+        ),
       ),
     );
   }
@@ -608,7 +611,9 @@ class _CardPreviewDialogState extends State<CardPreviewDialog>
                         margin: const EdgeInsets.all(16),
                         decoration: BoxDecoration(
                           color: Colors.white,
-                          borderRadius: BorderRadius.circular(20),
+                          borderRadius: BorderRadius.circular(
+                            AppTheme.dialogRadius,
+                          ),
                           boxShadow: [
                             BoxShadow(
                               color: Colors.black.withValues(alpha: 0.3),

--- a/test/widget/pages/ai_periodic_report_page_test.dart
+++ b/test/widget/pages/ai_periodic_report_page_test.dart
@@ -110,6 +110,46 @@ void main() {
     expect(find.text(l10n.noDataYet), findsWidgets);
   });
 
+  // 回归：入场动画只留一层。之前七到十个 TweenAnimationBuilder 交错到 1.4 秒，
+  // 数据早就到了用户还得等动画演完。
+  testWidgets('overview uses a single entrance animation', (tester) async {
+    final settings = _ReportSettingsService();
+    final database = _CountingPeriodDatabaseService();
+    final insights = InsightHistoryService(settingsService: settings);
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<SettingsService>.value(value: settings),
+          ChangeNotifierProvider<DatabaseService>.value(value: database),
+          ChangeNotifierProvider<InsightHistoryService>.value(value: insights),
+          ChangeNotifierProvider<AIService>(
+            create: (_) => AIService(settingsService: settings),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: AIPeriodicReportPage(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.byType(TweenAnimationBuilder<double>).evaluate().length,
+      lessThanOrEqualTo(1),
+    );
+
+    // 300ms 之后必须完全落位
+    await tester.pump(const Duration(milliseconds: 320));
+    expect(tester.binding.hasScheduledFrame, isFalse);
+
+    await tester.pumpAndSettle();
+  });
+
   // 回归：数据库在启动/同步期间会连续 notifyListeners 多次。
   // 若每次都重查并把整页切回转圈，进入探索页时就会来回闪。
   testWidgets('database bursts are debounced and refresh silently',

--- a/test/widget/pages/ai_periodic_report_page_test.dart
+++ b/test/widget/pages/ai_periodic_report_page_test.dart
@@ -106,8 +106,14 @@ void main() {
     final l10n = AppLocalizations.of(context);
     expect(find.text(l10n.dataOverview), findsOneWidget);
     expect(find.text(l10n.aiChat), findsOneWidget);
+    // 摘要带保留，四个 0 仍然可见
     expect(find.text('0'), findsWidgets);
-    expect(find.text(l10n.noDataYet), findsWidgets);
+    // 但三个「暂无」chip 不再出现——空状态文案已经说过一次了
+    expect(find.text(l10n.noDataYet), findsNothing);
+    expect(
+      find.text(l10n.noNotesInPeriodForPeriod(l10n.periodWeek)),
+      findsOneWidget,
+    );
   });
 
   // 回归：入场动画只留一层。之前七到十个 TweenAnimationBuilder 交错到 1.4 秒，
@@ -135,12 +141,18 @@ void main() {
         ),
       ),
     );
+    // 先确认异步查询已完成、概览已经渲染出来，否则下面数的是空树
     await tester.pump();
     await tester.pump();
+    final context = tester.element(find.byType(AIPeriodicReportPage));
+    final l10n = AppLocalizations.of(context);
+    expect(find.text(l10n.dataOverview), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
 
+    // 恰好一层：多了是又退回逐块交错，少了是入场动画被整个删掉
     expect(
       find.byType(TweenAnimationBuilder<double>).evaluate().length,
-      lessThanOrEqualTo(1),
+      equals(1),
     );
 
     // 300ms 之后必须完全落位


### PR DESCRIPTION
## 背景

探索页（`AIPeriodicReportPage`）把七张同等视觉权重的统计卡片堆在首屏，页面唯一真正的出口（AI 对话入口）被挤到中段；入场动画又用 7~10 个 `TweenAnimationBuilder` 交错到 1.4 秒才落位——数据早就到了，用户还得等动画演完才能看清页面。

这是探索页改造的第一步，**只动视觉，数据一条不删**。

## 改动

| 之前 | 之后 |
|---|---|
| 4 张 `elevation:2` 计数卡（两行） | 一条摘要带：笔记 / 字数 / 活跃 / 均字数，竖分隔线分列 |
| 3 张「最多」数字卡 | 3 个 chip（图标 + 值） |
| 7~10 个交错动画，400~1000ms，最长 1.4s | 一层 300ms 淡入 + 8px 上移 |
| 空周期叠 7 张全 0 卡 + 3 处「暂无」+ 插画 | 整页只说一次 |

三个「最多」指标改 chip 的原因：它们的值是**分类**（"午后"/"多云"/标签名）而不是量，套数字卡的 `headlineMedium` + `FittedBox` 会让中文标签一长就被缩成小字，和旁边真·数字卡的视觉重量对不上。

顺带清理：

- 去掉灯泡那个只跑一次的 amber 缩放——本想做"生成中呼吸"，实际 0.8→1.0 跑完就停了，语义没实现；生成状态已由下方进度条表达
- 去掉收藏徽标的一次性缩放，以及 `red.shade100` 描边 / `red.shade200` 阴影（深色模式下基本不可见），改主题色
- 洞察卡与笔记预览改扁平分层（`elevation: 0` + 容器色/描边），与新摘要带统一
- 笔记预览里硬编码的 `'${quote.content.length} 字'` 补上 l10n

净 **-246 行**。粗算首屏统计区从约 330px 压到约 105px，洞察卡和 AI 入口从"要滚一下"变成首屏可见。

## 未处理（有意保留）

收藏红心的 `Colors.red.shade400` 没动。虽然 AGENTS.md 禁 `Colors.*`，但 `quote_item_widget.dart:1155` 和 `home_note_mutation_actions.dart:123` 用的是同一色值，单改这里只会让探索页和记录页不一致。`AppSemanticColors` 目前只有 success/warning，没有合适的 favorite 语义槽位——是否新增并统一迁移三处属于全局决定，不在本 PR 范围。代码里留了注释标明。

## 测试

`test/widget/pages/ai_periodic_report_page_test.dart` 新增回归用例：入场动画只保留一层，且 300ms 内必须完全落位（`hasScheduledFrame` 为 false）。

3 个用例全部通过，`flutter analyze` 无告警。

## 待验证

真机截图还没看过，以下间距是按代码里的体系估的，可能需要按图微调：

- 窄屏下四列标签（笔记数量/总字数/活跃天数/平均字数）会不会被 ellipsis 截断
- 深色模式下 `surfaceContainerLow` 的摘要带与页面背景的分层对比是否足够

## 后续

第 2 步计划：洞察卡合并 Thoughter 入口 + 快捷追问 chips + 最近对话列表 + 顶栏历史入口。所需 API（`initialQuestion` 自动发送、`session` 深链、`SessionHistoryPage` 独立可用、`getAgentSessions()`）均已确认现成。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
探索页首屏继续瘦身：四张计数卡并为摘要带，“最多”改为 chips，入场动效统一为一层 300ms，让洞察与对话入口回到首屏。仅改视觉，数据不删，并修正空状态与层次对比。

- **Refactors**
  - 摘要带（笔记/字数/活跃/均字数）竖线分列；Semantics 加空格，读屏不连读
  - 「最多」改 chips，窄屏限宽+省略；空周期不再渲染“暂无”占位
  - 入场动效收敛为 300ms 淡入+上移，移除 7~10 个交错动画
  - 洞察卡与笔记预览改扁平分层；洞察内层用 surfaceContainerHighest；去掉灯泡/收藏徽标一次性缩放
  - 收藏红心色值提为 `_favoriteAccent`（与记录页一致），暂保留 `Colors.red.shade400` 待全局统一；`_mostTopTagIcon` 收窄为 `Object?`
  - 全局：统一圆角使用 `AppTheme` 的 card/dialog/button/input 半径
  - 影响：首屏统计区 ~330px → ~105px，洞察与对话入口回到首屏

- **Tests**
  - 回归：概览仅一层入场动画（==1），且 300ms 内落位；空周期不显示“暂无”chips
  - 全部用例通过，`flutter analyze` 无告警

<sup>Written for commit 5fce284417498b292844248a279fa755bc493857. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **界面优化**
  * 重构 AI 周期报告概览与统计页面，信息展示更加紧凑清晰。
  * 优化收藏、洞察、空状态及笔记预览卡片样式。
  * 统一页面入场动画，减少不必要的局部动画。
  * 笔记字数单位支持本地化显示。
  * 统一多处页面、对话框、卡片及媒体组件的圆角样式，提升视觉一致性。

* **质量改进**
  * 新增回归测试，确保页面仅使用统一的入场动画并正确展示空周期内容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->