### PR TITLE
🌐 译者: [提取硬编码]

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -51,3 +51,6 @@
 ## 2026-07-20 - [提取 tool_call_card.dart 重试按钮硬编码]
 **发现:** 在 lib/widgets/ai/tool_call_card.dart 中存在硬编码 '重试'
 **规则:** 采用极简风格翻译，复用已存在的 `retry` 键值。
+## 2023-10-24 - [提取 '重试' 硬编码]
+**发现:** `NoteListView` 中 `SnackBarAction` 标签硬编码为中文 `'重试'`
+**规则:** 将 `'重试'` 统一替换为 `AppLocalizations.of(context)!.retry`

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -615,8 +615,8 @@ class NoteListViewState extends State<NoteListView> {
       }
 
       // 判断是否仅为排序变化（不影响列表内容，只影响顺序）
-      final bool isOnlySortChange =
-          oldWidget.searchQuery == widget.searchQuery &&
+      final bool isOnlySortChange = oldWidget.searchQuery ==
+              widget.searchQuery &&
           _areListsEqual(oldWidget.selectedTagIds, widget.selectedTagIds) &&
           _areListsEqual(oldWidget.selectedWeathers, widget.selectedWeathers) &&
           _areListsEqual(
@@ -639,14 +639,14 @@ class NoteListViewState extends State<NoteListView> {
       // 标签/天气/时间段筛选变化：新结果到达后回到列表顶部。
       final bool isFilterChange =
           !_areListsEqual(oldWidget.selectedTagIds, widget.selectedTagIds) ||
-          !_areListsEqual(
-            oldWidget.selectedWeathers,
-            widget.selectedWeathers,
-          ) ||
-          !_areListsEqual(
-            oldWidget.selectedDayPeriods,
-            widget.selectedDayPeriods,
-          );
+              !_areListsEqual(
+                oldWidget.selectedWeathers,
+                widget.selectedWeathers,
+              ) ||
+              !_areListsEqual(
+                oldWidget.selectedDayPeriods,
+                widget.selectedDayPeriods,
+              );
 
       // 更新流订阅，传入是否仅为排序变化
       _updateStreamSubscription(
@@ -667,7 +667,7 @@ class NoteListViewState extends State<NoteListView> {
         duration: AppConstants.snackBarDurationNormal,
         behavior: SnackBarBehavior.floating,
         action: SnackBarAction(
-          label: AppLocalizations.of(context)!.retry,
+          label: AppLocalizations.of(context).retry,
           onPressed: () => _updateStreamSubscription(),
         ),
       ),
@@ -905,14 +905,12 @@ class NoteListViewState extends State<NoteListView> {
       if (_initialDataCompleter == null) {
         const maxWaitMs = 500;
         const stepMs = 50;
-        for (
-          var waited = 0;
-          waited < maxWaitMs &&
-              mounted &&
-              !_initialDataLoaded &&
-              _initialDataCompleter == null;
-          waited += stepMs
-        ) {
+        for (var waited = 0;
+            waited < maxWaitMs &&
+                mounted &&
+                !_initialDataLoaded &&
+                _initialDataCompleter == null;
+            waited += stepMs) {
           await Future<void>.delayed(const Duration(milliseconds: stepMs));
         }
       }

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -615,8 +615,8 @@ class NoteListViewState extends State<NoteListView> {
       }
 
       // 判断是否仅为排序变化（不影响列表内容，只影响顺序）
-      final bool isOnlySortChange = oldWidget.searchQuery ==
-              widget.searchQuery &&
+      final bool isOnlySortChange =
+          oldWidget.searchQuery == widget.searchQuery &&
           _areListsEqual(oldWidget.selectedTagIds, widget.selectedTagIds) &&
           _areListsEqual(oldWidget.selectedWeathers, widget.selectedWeathers) &&
           _areListsEqual(
@@ -637,12 +637,12 @@ class NoteListViewState extends State<NoteListView> {
       final bool isSearchChange = oldEffectiveQuery != newEffectiveQuery;
 
       // 标签/天气/时间段筛选变化：新结果到达后回到列表顶部。
-      final bool isFilterChange = !_areListsEqual(
-            oldWidget.selectedTagIds,
-            widget.selectedTagIds,
-          ) ||
+      final bool isFilterChange =
+          !_areListsEqual(oldWidget.selectedTagIds, widget.selectedTagIds) ||
           !_areListsEqual(
-              oldWidget.selectedWeathers, widget.selectedWeathers) ||
+            oldWidget.selectedWeathers,
+            widget.selectedWeathers,
+          ) ||
           !_areListsEqual(
             oldWidget.selectedDayPeriods,
             widget.selectedDayPeriods,
@@ -667,7 +667,7 @@ class NoteListViewState extends State<NoteListView> {
         duration: AppConstants.snackBarDurationNormal,
         behavior: SnackBarBehavior.floating,
         action: SnackBarAction(
-          label: '重试',
+          label: AppLocalizations.of(context)!.retry,
           onPressed: () => _updateStreamSubscription(),
         ),
       ),
@@ -905,12 +905,14 @@ class NoteListViewState extends State<NoteListView> {
       if (_initialDataCompleter == null) {
         const maxWaitMs = 500;
         const stepMs = 50;
-        for (var waited = 0;
-            waited < maxWaitMs &&
-                mounted &&
-                !_initialDataLoaded &&
-                _initialDataCompleter == null;
-            waited += stepMs) {
+        for (
+          var waited = 0;
+          waited < maxWaitMs &&
+              mounted &&
+              !_initialDataLoaded &&
+              _initialDataCompleter == null;
+          waited += stepMs
+        ) {
           await Future<void>.delayed(const Duration(milliseconds: stepMs));
         }
       }


### PR DESCRIPTION
**发现:** `NoteListView` 中存在硬编码中文 `'重试'`。
**动作:** 提取硬编码并替换为 `AppLocalizations.of(context)!.retry`。

**中英对照:**
中文: 重试
英文: Retry

---
*PR created automatically by Jules for task [7390246997752946404](https://jules.google.com/task/7390246997752946404) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `NoteListView` 的 `SnackBarAction` 标签从硬编码“重试”改为 `AppLocalizations.of(context).retry`，修复 i18n 并消除非空断言告警。同步更新 `.jules/translator.md` 规则，并整理长条件判断的格式以提升可读性。

<sup>Written for commit 3a95ee6c474fb08bb089dbbf7e1c17f8ceee459d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

