### PR TITLE
fix(thoughter,ai): 只思考也留过程入口，转圈不再拖到回答结束，天气按语言喂给模型

### DIFF
--- a/lib/pages/home/daily_prompt_panel.dart
+++ b/lib/pages/home/daily_prompt_panel.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 
 import '../../gen_l10n/app_localizations.dart';
 import '../../models/thoughter_entry.dart';
+import '../../models/weather_data.dart' show WeatherCodeMapper;
 import '../../services/ai_service.dart';
 import '../../services/insight_history_service.dart';
 import '../../services/location_service.dart';
@@ -60,14 +61,15 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
       final settingsService = context.read<SettingsService>();
 
       final city = locationService.city;
-      final weather = weatherService.currentWeather;
+      // 本地模板按 key 选句子，AI 那条链路要的是人能读的天气名，两者不能混用。
+      final weatherKey = weatherService.currentWeather;
       final temperature = weatherService.temperature;
       final aiEnabledForToday = settingsService.todayThoughtsUseAI;
 
       if (!aiEnabledForToday || !aiService.hasValidApiKey()) {
         _setLocalPrompt(
           city: city,
-          weather: weather,
+          weather: weatherKey,
           temperature: temperature,
         );
         return;
@@ -87,7 +89,9 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
       final promptStream = aiService.streamGenerateDailyPrompt(
         l10n,
         city: city,
-        weather: weather,
+        weather: weatherKey == null
+            ? null
+            : WeatherCodeMapper.getLocalizedDescription(l10n, weatherKey),
         temperature: temperature,
         historicalInsights: recentInsights,
       );
@@ -106,7 +110,7 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
           if (!mounted) return;
           _setLocalPrompt(
             city: city,
-            weather: weather,
+            weather: weatherKey,
             temperature: temperature,
           );
         },
@@ -118,7 +122,7 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
             logDebug('每日提示流结束但内容为空，使用本地生成的提示');
             _setLocalPrompt(
               city: city,
-              weather: weather,
+              weather: weatherKey,
               temperature: temperature,
             );
             return;

--- a/lib/pages/thoughter/thoughter_agent.dart
+++ b/lib/pages/thoughter/thoughter_agent.dart
@@ -44,6 +44,10 @@ extension _ThoughterAgent on _ThoughterPageState {
         isUser: false,
         content: '',
         timestamp: DateTime.now(),
+        // 渲染时 inProgress = isLoading && meta.inProgress，两个标志缺一不可。
+        // 漏掉这个的话，面板建出来的头 50ms（第一次节流更新之前）是静止的，
+        // 明明已经在思考了却显示成一条已完成的记录。
+        isLoading: true,
         metaJson: jsonEncode({
           'type': 'tool_progress',
           'items': [],
@@ -410,6 +414,10 @@ extension _ThoughterAgent on _ThoughterPageState {
     required bool inProgress,
     String? thinkingText,
   }) {
+    // 思考增量走的是 50ms 节流，工具开始/结束和「已经开始回答了」走的是直接写。
+    // 不作废队列里那条旧的思考快照，它会在直接写之后才落地，把 inProgress 顶回
+    // true——现象就是思考早就结束了，转圈却一直转到整段回答生成完。
+    _cancelToolProgressUpdate();
     _setState(() {
       final idx = _messages.indexWhere((m) => m.id == msgId);
       if (idx == -1) return;

--- a/lib/pages/thoughter/thoughter_session.dart
+++ b/lib/pages/thoughter/thoughter_session.dart
@@ -426,10 +426,15 @@ extension _ThoughterSession on _ThoughterPageState {
       if (!mounted) return;
 
       final l10n = AppLocalizations.of(context);
+      // dayPeriod / weather 存的是 key，直接拼进开场白会显示成 morning、clear。
       final insightText = _aiService.buildLocalReportInsight(
         periodLabel: l10n.thisWeek,
-        mostTimePeriod: topPeriod,
-        mostWeather: topWeather,
+        mostTimePeriod: topPeriod == null
+            ? null
+            : TimeUtils.localizedDayPeriodLabel(l10n, topPeriod),
+        mostWeather: topWeather == null
+            ? null
+            : WeatherCodeMapper.getLocalizedDescription(l10n, topWeather),
         topTag: topTag,
         activeDays: activeDays,
         noteCount: noteCount,

--- a/lib/pages/thoughter/thoughter_session.dart
+++ b/lib/pages/thoughter/thoughter_session.dart
@@ -426,15 +426,13 @@ extension _ThoughterSession on _ThoughterPageState {
       if (!mounted) return;
 
       final l10n = AppLocalizations.of(context);
-      // dayPeriod / weather 存的是 key，直接拼进开场白会显示成 morning、clear。
+      // 这里传 key，不要先本地化：formatLocalReportInsight 自己按
+      // SettingsService.localeCode 选模板语言并翻译时段/天气。抢先用界面
+      // l10n 翻一遍，界面语言和语言偏好不一致时标签会和模板语言对不上。
       final insightText = _aiService.buildLocalReportInsight(
         periodLabel: l10n.thisWeek,
-        mostTimePeriod: topPeriod == null
-            ? null
-            : TimeUtils.localizedDayPeriodLabel(l10n, topPeriod),
-        mostWeather: topWeather == null
-            ? null
-            : WeatherCodeMapper.getLocalizedDescription(l10n, topWeather),
+        mostTimePeriod: topPeriod,
+        mostWeather: topWeather,
         topTag: topTag,
         activeDays: activeDays,
         noteCount: noteCount,

--- a/lib/pages/thoughter/thoughter_ui.dart
+++ b/lib/pages/thoughter/thoughter_ui.dart
@@ -595,6 +595,11 @@ extension _ThoughterUI on _ThoughterPageState {
     AppLocalizations l10n,
   ) {
     final toolSnapshot = _toolProcessBefore(message);
+    // 只思考的那轮说「查看思考过程」，调了工具才说「查看过程」——按钮文案
+    // 得对得上点开后看到的东西。
+    final thinkingOnly = toolSnapshot != null && toolSnapshot.items.isEmpty;
+    final processLabel =
+        thinkingOnly ? l10n.showThinking : l10n.viewToolProcess;
     return Padding(
       padding: const EdgeInsets.only(top: 2),
       // 按钮的热区自带 8 的横向留白，整行往左挪回去，第一枚图标才和正文
@@ -616,9 +621,11 @@ extension _ThoughterUI on _ThoughterPageState {
             ),
             if (toolSnapshot != null)
               _MessageAction(
-                icon: Icons.account_tree_outlined,
-                tooltip: l10n.viewToolProcess,
-                label: l10n.viewToolProcess,
+                icon: thinkingOnly
+                    ? Icons.psychology_outlined
+                    : Icons.account_tree_outlined,
+                tooltip: processLabel,
+                label: processLabel,
                 onTap: () => showToolProgressSheet(
                   context,
                   ValueNotifier(toolSnapshot),
@@ -672,18 +679,23 @@ extension _ThoughterUI on _ThoughterPageState {
     await _askAgent(question);
   }
 
-  /// 找出这条回复之前、同一轮里的工具调用进度，用来喂「查看过程」抽屉。
+  /// 找出这条回复之前、同一轮里的过程记录，用来喂「查看过程」抽屉。
+  ///
+  /// 过程不只有工具调用：模型可能这一轮什么都没查，只是想了一会儿再回答。
+  /// 那一样是过程，一样该能翻回去看——否则「只思考」的那轮，回答定稿后正文上方
+  /// 只剩一行折叠标题，下面的操作行却什么都不给，看着像思考被吞了。
   ToolProgressSnapshot? _toolProcessBefore(app_chat.ChatMessage message) {
     final index = _messages.indexWhere((m) => m.id == message.id);
     if (index <= 0) return null;
     for (var i = index - 1; i >= 0; i--) {
       final candidate = _messages[i];
-      // 回到上一条用户提问就说明这一轮没有工具调用
+      // 回到上一条用户提问就说明这一轮没有过程可看
       if (candidate.isUser) return null;
       final meta = candidate.parsedMeta;
       if (meta == null || meta['type'] != 'tool_progress') continue;
       final rawItems = meta['items'] as List<dynamic>? ?? const [];
-      if (rawItems.isEmpty) return null;
+      final thinkingText = meta['thinkingText']?.toString().trim() ?? '';
+      if (rawItems.isEmpty && thinkingText.isEmpty) return null;
       final items = rawItems.map((item) {
         final map = item as Map<String, dynamic>;
         return ToolProgressItem(
@@ -698,10 +710,14 @@ extension _ThoughterUI on _ThoughterPageState {
           narrationText: map['narrationText'] as String?,
         );
       }).toList();
+      final l10n = AppLocalizations.of(context);
       return ToolProgressSnapshot(
-        title: AppLocalizations.of(context).executedNOperations(items.length),
+        // 标题按这一轮实际发生的事说：没调工具就别报「执行了 0 个操作」。
+        title: items.isEmpty
+            ? l10n.thinking
+            : l10n.executedNOperations(items.length),
         items: items,
-        thinkingText: meta['thinkingText'] as String?,
+        thinkingText: thinkingText.isEmpty ? null : thinkingText,
       );
     }
     return null;
@@ -792,8 +808,9 @@ extension _ThoughterUI on _ThoughterPageState {
     // 输入壳比卡片再圆一档：它是一个会长高的容器，方角在多行时显得笨重。
     // 仍然跟着主题的 cardRadius 走，纸/素笺的方正不会被这里拉圆。
     final shellRadius = (shape.cardRadius * 1.4).clamp(0.0, 26.0).toDouble();
+    final focused = _isInputFocused;
     // 描边宽度恒定：聚焦时改宽会让内部文字横跳半个像素。只换颜色。
-    final borderColor = _isInputFocused
+    final borderColor = focused
         ? scheme.primary.withValues(alpha: 0.55)
         : scheme.outlineVariant.withValues(alpha: 0.7);
 
@@ -804,17 +821,21 @@ extension _ThoughterUI on _ThoughterPageState {
         duration: const Duration(milliseconds: 160),
         curve: Curves.easeOut,
         decoration: BoxDecoration(
-          // 壳比对话背景高一层，靠明度自己划出边界，不用重描边和重投影。
-          color: scheme.surfaceContainerHigh,
+          // 壳比对话背景高一层，靠明度自己划出边界；聚焦时再抬一层，
+          // 「正在输入」是被点亮的，不是被托起来的。
+          color: focused
+              ? scheme.surfaceContainerHighest
+              : scheme.surfaceContainerHigh,
           borderRadius: BorderRadius.circular(shellRadius),
           border: Border.all(color: borderColor),
+          // 不投影：输入框不是浮在对话上的一张卡，一圈落地的阴影反而把它和
+          // 消息流割开。聚焦时改画一圈贴边的强调色高光——ChatGPT / Claude /
+          // Gemini 都是这个路子，而且它在纸墨这类零投影的风格下同样成立。
           boxShadow: [
             BoxShadow(
-              color: scheme.shadow.withValues(
-                alpha: theme.brightness == Brightness.dark ? 0.16 : 0.04,
-              ),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
+              color: scheme.primary.withValues(alpha: focused ? 0.14 : 0.0),
+              blurRadius: 0,
+              spreadRadius: focused ? 3 : 0,
             ),
           ],
         ),

--- a/lib/pages/thoughter_page.dart
+++ b/lib/pages/thoughter_page.dart
@@ -168,16 +168,26 @@ class _ThoughterPageState extends State<ThoughterPage> {
 
   void _flushStreamUpdate() {
     final id = _pendingUpdateId;
-    if (id == null) return;
+    if (id == null) {
+      _cancelStreamUpdate();
+      return;
+    }
+    final content = _pendingContent;
+    final isLoading = _pendingIsLoading;
+    final metaJson = _pendingMetaJson;
+    final state = _pendingState;
+    final thinkingChunks = _pendingThinkingChunks;
+    // 先清空待写内容再落盘：_updateMessage 会把还没落地的节流写作废，
+    // 而这次 flush 正是在落地它，不能被自己清掉又当成"还没写"。
+    _cancelStreamUpdate();
     _updateMessage(
       id,
-      _pendingContent,
-      isLoading: _pendingIsLoading,
-      metaJson: _pendingMetaJson,
-      state: _pendingState,
-      thinkingChunks: _pendingThinkingChunks,
+      content,
+      isLoading: isLoading,
+      metaJson: metaJson,
+      state: state,
+      thinkingChunks: thinkingChunks,
     );
-    _streamThrottleTimer = null;
   }
 
   void _cancelStreamUpdate() {
@@ -214,14 +224,21 @@ class _ThoughterPageState extends State<ThoughterPage> {
 
   void _flushToolProgressUpdate() {
     final msgId = _pendingToolProgressMsgId;
-    if (msgId == null || _pendingToolItems == null) return;
+    final items = _pendingToolItems;
+    if (msgId == null || items == null) {
+      _cancelToolProgressUpdate();
+      return;
+    }
+    final inProgress = _pendingToolProgressInProgress;
+    final thinkingText = _pendingToolProgressThinkingText;
+    // 同 _flushStreamUpdate：落地前先摘掉待写状态。
+    _cancelToolProgressUpdate();
     _updateToolProgressMessage(
       msgId,
-      _pendingToolItems!,
-      inProgress: _pendingToolProgressInProgress,
-      thinkingText: _pendingToolProgressThinkingText,
+      items,
+      inProgress: inProgress,
+      thinkingText: thinkingText,
     );
-    _toolProgressThrottleTimer = null;
   }
 
   void _cancelToolProgressUpdate() {
@@ -332,6 +349,10 @@ class _ThoughterPageState extends State<ThoughterPage> {
     app_chat.MessageState? state,
     List<String>? thinkingChunks,
   }) {
+    // 直接写覆盖节流队列里还没落地的那次更新。否则一次「定稿」写完 isLoading=false
+    // 之后，50ms 内攒下的旧快照会晚一步落地，把 isLoading 又推回 true——正文末尾
+    // 的流式光标从此不灭，操作行也不出现。
+    _cancelStreamUpdate();
     _setState(() {
       final idx = _messages.indexWhere((m) => m.id == id);
       if (idx == -1) return;

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -46,6 +46,7 @@ List<AgentTool> _buildAgentTools(
     GetLocationWeatherTool(
       locationService: locationService,
       weatherService: weatherService,
+      settingsService: settingsService,
     ),
     GetNoteDetailTool(db),
     WebSearchTool(settingsService),

--- a/lib/services/agent_tools/get_app_context_tool.dart
+++ b/lib/services/agent_tools/get_app_context_tool.dart
@@ -1,9 +1,12 @@
 import 'dart:convert';
 
+import 'package:thoughtecho/models/weather_data.dart' show WeatherCodeMapper;
 import 'package:thoughtecho/services/database_service.dart';
 import 'package:thoughtecho/services/location_service.dart';
+import 'package:thoughtecho/services/settings_service.dart';
 import 'package:thoughtecho/services/weather_service.dart';
 import 'package:thoughtecho/utils/app_logger.dart';
+import 'package:thoughtecho/utils/localization_resolver.dart';
 
 import '../agent_tool.dart';
 
@@ -96,11 +99,16 @@ class GetLocationWeatherTool extends AgentTool {
   const GetLocationWeatherTool({
     required LocationService locationService,
     required WeatherService weatherService,
+    required SettingsService settingsService,
   })  : _locationService = locationService,
-        _weatherService = weatherService;
+        _weatherService = weatherService,
+        _settingsService = settingsService;
 
   final LocationService _locationService;
   final WeatherService _weatherService;
+
+  /// 只用来读语言设置：天气 key 要按用户的语言翻好再交给模型。
+  final SettingsService _settingsService;
 
   @override
   String get name => 'get_location_weather';
@@ -128,7 +136,13 @@ class GetLocationWeatherTool extends AgentTool {
     try {
       final locationDisplay = _locationService.getLocationDisplayText();
       final locationStorage = _locationService.getFormattedLocation();
-      final weatherDescription = _weatherService.weatherDescription;
+      final weatherKey = _weatherService.currentWeather;
+      // WeatherService.weatherDescription 给的是 'partly_cloudy' 这种存储 key，
+      // 直接交给模型等于让它照抄一个英文标识符；这里按用户语言翻成人话。
+      final l10n = resolveAppLocalizations(_settingsService.localeCode);
+      final weatherDescription = weatherKey == null
+          ? null
+          : WeatherCodeMapper.getLocalizedDescription(l10n, weatherKey);
       final temperature = _weatherService.temperature;
 
       final weatherDisplayParts = <String>[
@@ -140,7 +154,7 @@ class GetLocationWeatherTool extends AgentTool {
       final payload = <String, Object?>{
         'location_display': locationDisplay.isNotEmpty ? locationDisplay : null,
         'location_storage': locationStorage.isNotEmpty ? locationStorage : null,
-        'weather_key': _weatherService.currentWeather,
+        'weather_key': weatherKey,
         'weather_description': weatherDescription,
         'temperature': temperature,
         'weather_display': weatherDisplayParts.isNotEmpty

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -3,6 +3,7 @@ import 'package:openai_dart/openai_dart.dart' as openai;
 import '../models/quote_model.dart';
 import '../models/chat_message.dart';
 import '../models/ai_provider_settings.dart';
+import '../models/weather_data.dart' show WeatherCodeMapper;
 import '../services/settings_service.dart' show SettingsService;
 import '../services/api_key_manager.dart';
 import '../services/openai_stream_service.dart';
@@ -11,7 +12,9 @@ import '../utils/daily_prompt_generator.dart';
 import '../utils/ai_prompt_manager.dart';
 import '../utils/ai_request_helper.dart';
 import '../utils/app_logger.dart';
+import '../utils/localization_resolver.dart';
 import '../utils/string_utils.dart';
+import '../utils/time_utils.dart';
 import '../gen_l10n/app_localizations.dart';
 import 'web_fetch_service.dart';
 
@@ -42,6 +45,25 @@ class AIService extends ChangeNotifier {
 
   /// 会话标题的输出上限（token）。理由同 [_dailyPromptMaxTokens]。
   static const int _sessionTitleMaxTokens = 512;
+
+  /// 笔记的天气和时间段在库里存的是 key（`partly_cloudy` / `morning`）。
+  /// 那是给筛选和图标用的标识符，不是给人读的文案——原样写进提示词，模型只能
+  /// 照抄英文 key 回来，用户看到的界面却是「多云」。交给模型前先按用户语言翻好。
+  String? _localizedWeather(String? weatherKey) {
+    if (weatherKey == null || weatherKey.isEmpty) return null;
+    return WeatherCodeMapper.getLocalizedDescription(
+      resolveAppLocalizations(_settingsService.localeCode),
+      weatherKey,
+    );
+  }
+
+  String? _localizedDayPeriod(String? dayPeriodKey) {
+    if (dayPeriodKey == null || dayPeriodKey.isEmpty) return null;
+    return TimeUtils.localizedDayPeriodLabel(
+      resolveAppLocalizations(_settingsService.localeCode),
+      dayPeriodKey,
+    );
+  }
 
   Future<void> _validateSettings({bool testNetwork = false}) async {
     try {
@@ -391,9 +413,9 @@ class AIService extends ChangeNotifier {
       sourceAuthor: quote.sourceAuthor,
       sourceWork: quote.sourceWork,
       location: quote.location,
-      weather: quote.weather,
+      weather: _localizedWeather(quote.weather),
       temperature: quote.temperature,
-      dayPeriod: quote.dayPeriod,
+      dayPeriod: _localizedDayPeriod(quote.dayPeriod),
       tagNames: tagNames,
     );
 
@@ -1107,9 +1129,9 @@ class AIService extends ChangeNotifier {
       sourceAuthor: quote.sourceAuthor,
       sourceWork: quote.sourceWork,
       location: quote.location,
-      weather: quote.weather,
+      weather: _localizedWeather(quote.weather),
       temperature: quote.temperature,
-      dayPeriod: quote.dayPeriod,
+      dayPeriod: _localizedDayPeriod(quote.dayPeriod),
     );
 
     return _streamViaOpenAI(

--- a/lib/services/smart_push/smart_push_notification.dart
+++ b/lib/services/smart_push/smart_push_notification.dart
@@ -317,23 +317,8 @@ extension SmartPushNotification on SmartPushService {
     return AppSettings.defaultSettings();
   }
 
-  AppLocalizations _resolveDailyQuoteLocalizations(AppSettings settings) {
-    final localeCode = settings.localeCode;
-    final preferredLocale = localeCode == null || localeCode.isEmpty
-        ? WidgetsBinding.instance.platformDispatcher.locale
-        : Locale(localeCode);
-
-    final supportedLanguageCodes = AppLocalizations.supportedLocales
-        .map((locale) => locale.languageCode)
-        .toSet();
-    final effectiveLocale = supportedLanguageCodes.contains(
-      preferredLocale.languageCode,
-    )
-        ? preferredLocale
-        : const Locale('en');
-
-    return lookupAppLocalizations(effectiveLocale);
-  }
+  AppLocalizations _resolveDailyQuoteLocalizations(AppSettings settings) =>
+      resolveAppLocalizations(settings.localeCode);
 
   Future<void> _ensureNotificationReady() async {
     if (_notificationPluginReady) return;

--- a/lib/services/smart_push_service.dart
+++ b/lib/services/smart_push_service.dart
@@ -25,6 +25,7 @@ import 'mmkv_service.dart';
 import 'location_service.dart';
 import 'weather_service.dart';
 import '../utils/app_logger.dart';
+import '../utils/localization_resolver.dart';
 import '../utils/platform_helper.dart';
 import '../utils/string_utils.dart';
 import 'background_push_handler.dart';

--- a/lib/utils/ai_prompt_manager.dart
+++ b/lib/utils/ai_prompt_manager.dart
@@ -1,6 +1,5 @@
 import 'package:meta/meta.dart';
 import 'dart:math' as math;
-import '../models/weather_data.dart';
 
 /// AI提示词管理器
 ///
@@ -721,10 +720,9 @@ $content''';
         envDetails += '地点：$city ';
       }
       if (weather != null && weather.isNotEmpty) {
-        // 将英文天气key转换为中文描述
-        final weatherDesc = WeatherCodeMapper.getDescription(weather);
-        final displayWeather = weatherDesc == '未知' ? weather : weatherDesc;
-        envDetails += '天气：$displayWeather ';
+        // 调用方负责把天气 key 翻成用户语言的描述再传进来：这里拿不到 l10n，
+        // 曾经的 WeatherCodeMapper.getDescription 只会把 key 原样还回来。
+        envDetails += '天气：$weather ';
       }
       if (temperature != null && temperature.isNotEmpty) {
         envDetails += '温度：$temperature°C';

--- a/lib/utils/localization_resolver.dart
+++ b/lib/utils/localization_resolver.dart
@@ -1,0 +1,25 @@
+import 'dart:ui' show Locale, PlatformDispatcher;
+
+import '../gen_l10n/app_localizations.dart';
+
+/// 在没有 `BuildContext` 的地方取一份 [AppLocalizations]。
+///
+/// Service 和 Agent 工具拿不到 context，但它们交给模型的文案（天气、时间段这类
+/// 枚举 key）同样要跟着用户的语言走——否则界面显示「多云」，喂给 AI 的却是
+/// `partly_cloudy`，模型回信时只能照抄那个英文 key。
+///
+/// [localeCode] 传 `SettingsService.localeCode`；为空表示跟随系统。不在支持列表里
+/// 的语言退回英文，和 `MaterialApp` 的 `supportedLocales` 协商结果一致。
+AppLocalizations resolveAppLocalizations(String? localeCode) {
+  final preferred = localeCode == null || localeCode.isEmpty
+      ? PlatformDispatcher.instance.locale
+      : Locale(localeCode);
+
+  final supported = AppLocalizations.supportedLocales
+      .map((locale) => locale.languageCode)
+      .toSet();
+
+  return lookupAppLocalizations(
+    supported.contains(preferred.languageCode) ? preferred : const Locale('en'),
+  );
+}

--- a/lib/utils/localization_resolver.dart
+++ b/lib/utils/localization_resolver.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show Locale, PlatformDispatcher;
 
 import '../gen_l10n/app_localizations.dart';
+import 'i18n_language.dart';
 
 /// 在没有 `BuildContext` 的地方取一份 [AppLocalizations]。
 ///
@@ -11,15 +12,22 @@ import '../gen_l10n/app_localizations.dart';
 /// [localeCode] 传 `SettingsService.localeCode`；为空表示跟随系统。不在支持列表里
 /// 的语言退回英文，和 `MaterialApp` 的 `supportedLocales` 协商结果一致。
 AppLocalizations resolveAppLocalizations(String? localeCode) {
-  final preferred = localeCode == null || localeCode.isEmpty
-      ? PlatformDispatcher.instance.locale
-      : Locale(localeCode);
+  // 设置里存的可能是 'zh_CN' 这种带区域的写法（`SettingsService.setLocale`
+  // 接受它），而 supportedLocales 比的是纯语言子标签。不先归一化，zh_CN 的
+  // 用户会被判成"不支持"一路掉到英文。
+  //
+  // 只借 I18nLanguage.base 做归一化，不用它的 appLanguage：那份 supported
+  // 集合是给地理编码 API 用的，少了 de 和 es，套在这里会把这两种语言的用户
+  // 也送去英文。支持与否一律以 AppLocalizations.supportedLocales 为准。
+  final languageCode = localeCode == null || localeCode.trim().isEmpty
+      ? PlatformDispatcher.instance.locale.languageCode.toLowerCase()
+      : I18nLanguage.base(localeCode);
 
   final supported = AppLocalizations.supportedLocales
       .map((locale) => locale.languageCode)
       .toSet();
 
   return lookupAppLocalizations(
-    supported.contains(preferred.languageCode) ? preferred : const Locale('en'),
+    Locale(supported.contains(languageCode) ? languageCode : 'en'),
   );
 }

--- a/lib/utils/time_utils.dart
+++ b/lib/utils/time_utils.dart
@@ -32,7 +32,12 @@ class TimeUtils {
 
   /// 根据时间段 Key 获取本地化标签（新方法，支持国际化）
   static String getLocalizedDayPeriodLabel(BuildContext context, String key) {
-    final l10n = AppLocalizations.of(context);
+    return localizedDayPeriodLabel(AppLocalizations.of(context), key);
+  }
+
+  /// 同 [getLocalizedDayPeriodLabel]，但直接收 [AppLocalizations]。
+  /// Service 和 Agent 工具没有 context，喂给模型的时间段同样要翻译。
+  static String localizedDayPeriodLabel(AppLocalizations l10n, String key) {
     switch (key) {
       case 'dawn':
         return l10n.dayPeriodDawn;
@@ -50,7 +55,7 @@ class TimeUtils {
         // 如果是旧的中文标签，尝试转换
         final reverseMap = dayPeriodKeyToLabel.map((k, v) => MapEntry(v, k));
         if (reverseMap.containsKey(key)) {
-          return getLocalizedDayPeriodLabel(context, reverseMap[key]!);
+          return localizedDayPeriodLabel(l10n, reverseMap[key]!);
         }
         return key;
     }

--- a/test/live/agent_probe.dart
+++ b/test/live/agent_probe.dart
@@ -447,6 +447,7 @@ class AgentProbe {
         GetLocationWeatherTool(
           locationService: _ProbeLocationService(),
           weatherService: _ProbeWeatherService(),
+          settingsService: settings,
         ),
         GetNoteDetailTool(database),
         WebSearchTool(settings),

--- a/test/unit/services/agent_note_tools_test.dart
+++ b/test/unit/services/agent_note_tools_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/models/note_tag.dart';
 import 'package:thoughtecho/models/note_proposal_artifact.dart';
@@ -10,6 +11,7 @@ import 'package:thoughtecho/services/agent_tools/propose_note_create_tool.dart';
 import 'package:thoughtecho/services/agent_tools/propose_note_edit_tool.dart';
 import 'package:thoughtecho/services/database_service.dart';
 import 'package:thoughtecho/services/location_service.dart';
+import 'package:thoughtecho/services/settings_service.dart';
 import 'package:thoughtecho/services/weather_service.dart';
 
 import '../../test_harness.dart';
@@ -47,24 +49,26 @@ class _TestLocationService extends LocationService {
 }
 
 class _TestWeatherService extends WeatherService {
-  _TestWeatherService({
-    this.weatherKey,
-    this.temperatureText,
-    this.descriptionText,
-  });
+  _TestWeatherService({this.weatherKey, this.temperatureText});
 
   final String? weatherKey;
   final String? temperatureText;
-  final String? descriptionText;
 
   @override
   String? get currentWeather => weatherKey;
 
   @override
   String? get temperature => temperatureText;
+}
+
+class _TestSettingsService extends ChangeNotifier implements SettingsService {
+  _TestSettingsService({this.localeCode});
 
   @override
-  String? get weatherDescription => descriptionText;
+  final String? localeCode;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 void main() {
@@ -454,7 +458,7 @@ void main() {
   });
 
   group('GetLocationWeatherTool', () {
-    test('returns current location and weather snapshot', () async {
+    Future<Map<String, dynamic>> runTool({required String? localeCode}) async {
       final tool = GetLocationWeatherTool(
         locationService: _TestLocationService(
           locationDisplay: '广州市·天河区',
@@ -463,8 +467,8 @@ void main() {
         weatherService: _TestWeatherService(
           weatherKey: 'clear',
           temperatureText: '27°C',
-          descriptionText: '晴',
         ),
+        settingsService: _TestSettingsService(localeCode: localeCode),
       );
 
       final result = await tool.execute(
@@ -476,12 +480,26 @@ void main() {
       );
 
       expect(result.isError, isFalse);
-      final payload = jsonDecode(result.content) as Map<String, dynamic>;
+      return jsonDecode(result.content) as Map<String, dynamic>;
+    }
+
+    test('returns current location and weather snapshot', () async {
+      final payload = await runTool(localeCode: 'zh');
       expect(payload['location_display'], '广州市·天河区');
       expect(payload['location_storage'], '中国,广东省,广州市,天河区');
       expect(payload['weather_key'], 'clear');
       expect(payload['temperature'], '27°C');
       expect(payload['weather_display'], '晴 27°C');
+    });
+
+    test('describes the weather in the user language, not the storage key',
+        () async {
+      // 回归：以前这里交给模型的是 WeatherService 里的存储 key（'clear'），
+      // 界面显示「晴」，模型读到的却是一个英文标识符。
+      final payload = await runTool(localeCode: 'en');
+      expect(payload['weather_key'], 'clear');
+      expect(payload['weather_description'], 'Clear');
+      expect(payload['weather_display'], 'Clear 27°C');
     });
   });
 }

--- a/test/unit/utils/ai_prompt_manager_test.dart
+++ b/test/unit/utils/ai_prompt_manager_test.dart
@@ -189,10 +189,19 @@ void main() {
           testNow: date,
         );
         expect(prompt, contains('地点：Beijing'));
-        // WeatherCodeMapper might transform 'Sunny', assuming it returns same or mapped.
-        // Since we didn't mock WeatherCodeMapper, we test that at least environment section is present.
         expect(prompt, contains('当前环境信息：'));
         expect(prompt, contains('温度：25°C'));
+      });
+
+      test('writes the weather text through verbatim', () {
+        // 调用方负责本地化。这里曾经再做一次 key→描述 映射，把已经翻好的
+        // 「多云」当成未知 key 换成了 'unknown'。
+        final prompt = manager.getDailyPromptSystemPromptWithContext(
+          weather: '多云',
+          testNow: date,
+        );
+        expect(prompt, contains('天气：多云'));
+        expect(prompt, isNot(contains('unknown')));
       });
 
       test('includes historical insights', () {

--- a/test/unit/utils/localization_resolver_test.dart
+++ b/test/unit/utils/localization_resolver_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/localization_resolver.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('resolveAppLocalizations', () {
+    test('honours the configured locale code', () {
+      expect(resolveAppLocalizations('zh').weatherClear, '晴');
+      expect(resolveAppLocalizations('en').weatherClear, 'Clear');
+    });
+
+    test('falls back to English for unsupported languages', () {
+      expect(resolveAppLocalizations('xx').weatherClear, 'Clear');
+    });
+
+    test('follows the platform locale when no code is configured', () {
+      // 跟随系统时至少要拿到一份可用的文案，不能抛。
+      expect(resolveAppLocalizations(null).weatherClear, isNotEmpty);
+      expect(resolveAppLocalizations('').weatherClear, isNotEmpty);
+    });
+  });
+}

--- a/test/unit/utils/localization_resolver_test.dart
+++ b/test/unit/utils/localization_resolver_test.dart
@@ -10,8 +10,17 @@ void main() {
       expect(resolveAppLocalizations('en').weatherClear, 'Clear');
     });
 
+    test('strips the region suffix before matching', () {
+      // SettingsService.setLocale 收得下 'zh_CN'，而 supportedLocales 比的是
+      // 纯语言子标签——不归一化就会被判成不支持然后掉到英文。
+      expect(resolveAppLocalizations('zh_CN').weatherClear, '晴');
+      expect(resolveAppLocalizations('zh-Hans').weatherClear, '晴');
+      expect(resolveAppLocalizations('EN_US').weatherClear, 'Clear');
+    });
+
     test('falls back to English for unsupported languages', () {
       expect(resolveAppLocalizations('xx').weatherClear, 'Clear');
+      expect(resolveAppLocalizations('xx_YY').weatherClear, 'Clear');
     });
 
     test('follows the platform locale when no code is configured', () {

--- a/test/widget/pages/thoughter_page_test.dart
+++ b/test/widget/pages/thoughter_page_test.dart
@@ -190,6 +190,7 @@ class _FakeAgentService extends AgentService {
     this.emitSmartResultCard = false,
     this.proposalMetadata = const <String, Object?>{},
     this.responseContent = 'Agent 响应',
+    this.reasoningChunks = const <String>[],
     this.responseChunks = const <String>[],
     this.responseChunkDelay = const Duration(milliseconds: 12),
     this.preToolText,
@@ -213,6 +214,9 @@ class _FakeAgentService extends AgentService {
   /// 提案 artifact 的 metadata，用来构造带标签的提案。
   final Map<String, Object?> proposalMetadata;
   final String responseContent;
+
+  /// 正文之前的推理增量，用来复现「思考完了转圈不停」那条时序。
+  final List<String> reasoningChunks;
   final List<String> responseChunks;
   final Duration responseChunkDelay;
   final String? preToolText;
@@ -316,6 +320,11 @@ class _FakeAgentService extends AgentService {
         ),
       );
       await _delay(postToolDelay);
+    }
+
+    for (final chunk in reasoningChunks) {
+      _emitEvent(AgentReasoningDeltaEvent(chunk));
+      await _delay(const Duration(milliseconds: 12));
     }
 
     // 真实协议：agent 通过 propose_note_edit 工具产出 NoteProposalArtifact，
@@ -1352,6 +1361,70 @@ void main() {
       expect(find.byKey(const ValueKey('ai_assistant_waiting')), findsNothing);
     });
 
+    testWidgets('thinking spinner stops once the answer starts streaming',
+        (tester) async {
+      // 回归：推理增量走 50ms 节流，正文第一个 token 走直接写。直接写没有作废
+      // 队列里那条旧快照时，它会晚一步落地把 inProgress 顶回 true——思考早就
+      // 结束了，转圈却一直转到整段回答生成完。
+      final agentService = _FakeAgentService(
+        settingsService: settingsService,
+        reasoningChunks: const <String>['先想', '一下'],
+        responseChunks: const <String>['开始回答'],
+        responseChunkDelay: const Duration(milliseconds: 600),
+      );
+      await settingsService.setExploreAiAssistantMode(ThoughterPageMode.agent);
+
+      await tester.pumpWidget(
+        await _buildHarness(
+          settingsService: settingsService,
+          chatSessionService: chatSessionService,
+          agentService: agentService,
+          child: const ThoughterPage(
+            entrySource: ThoughterEntrySource.explore,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 不能用 _submitInput：它以 pumpAndSettle 收尾，而转圈是个永不停的动画。
+      await tester.enterText(find.byType(TextField).last, '你怎么看');
+      await tester.pump();
+      tester
+          .widget<IconButton>(
+            find.byKey(const ValueKey('ai_assistant_send_button')),
+          )
+          .onPressed
+          ?.call();
+      await tester.pump();
+
+      // 推理阶段：面板出现且在转
+      for (var i = 0;
+          i < 20 && find.byType(ToolProgressPanel).evaluate().isEmpty;
+          i++) {
+        await tester.pump(const Duration(milliseconds: 10));
+      }
+      expect(
+        tester
+            .widget<ToolProgressPanel>(find.byType(ToolProgressPanel))
+            .inProgress,
+        isTrue,
+      );
+
+      // 正文已经开始流，且已越过 50ms 节流窗口。这一轮还没结束（回答的下一段
+      // 要 600ms 后才来），但思考已经结束了，面板不该还在转。
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.textContaining('开始回答'), findsOneWidget);
+      expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
+      expect(
+        tester
+            .widget<ToolProgressPanel>(find.byType(ToolProgressPanel))
+            .inProgress,
+        isFalse,
+      );
+
+      await _settleAgentTurn(tester);
+    });
+
     testWidgets('agent tool panel shows human summary instead of raw payload',
         (tester) async {
       final agentService = _FakeAgentService(
@@ -1485,6 +1558,81 @@ void main() {
       await tester.tap(processAction);
       await tester.pumpAndSettle();
       expect(find.text('找到 2 条笔记'), findsOneWidget);
+    });
+
+    // 只思考、一个工具都没调的那一轮：过程记录里只有推理文本
+    void seedThinkingOnlySession(_InMemoryChatSessionService service) {
+      final now = DateTime(2026, 8, 1, 10);
+      service.seedSession(
+        ChatSession(
+          id: 'note-session-thinking-only',
+          sessionType: 'agent',
+          noteId: 'note-1',
+          title: '只想了想',
+          createdAt: now,
+          lastActiveAt: now,
+        ),
+        <app_chat.ChatMessage>[
+          app_chat.ChatMessage(
+            id: 'm-user',
+            content: '你怎么看',
+            isUser: true,
+            role: 'user',
+            timestamp: now,
+          ),
+          app_chat.ChatMessage(
+            id: 'm-thinking',
+            content: '',
+            isUser: false,
+            role: 'assistant',
+            timestamp: now,
+            metaJson: jsonEncode(<String, Object?>{
+              'type': 'tool_progress',
+              'inProgress': false,
+              'items': <Map<String, Object?>>[],
+              'thinkingText': '先想清楚再回答',
+            }),
+          ),
+          app_chat.ChatMessage(
+            id: 'm-answer',
+            content: '我的看法是这样',
+            isUser: false,
+            role: 'assistant',
+            timestamp: now,
+          ),
+        ],
+      );
+    }
+
+    testWidgets('thinking-only turn still exposes its process under the reply',
+        (tester) async {
+      seedThinkingOnlySession(chatSessionService);
+      await settingsService.setNoteAiAssistantMode(ThoughterPageMode.agent);
+
+      await tester.pumpWidget(
+        await _buildHarness(
+          settingsService: settingsService,
+          chatSessionService: chatSessionService,
+          agentService: _FakeAgentService(settingsService: settingsService),
+          child: ThoughterPage(
+            entrySource: ThoughterEntrySource.note,
+            quote: _buildQuote(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = _l10n(tester);
+      // 没有工具就别说「查看过程」，那一轮里能看的只有思考
+      final processAction = find.byTooltip(l10n.showThinking);
+      expect(processAction, findsOneWidget);
+      expect(find.byTooltip(l10n.viewToolProcess), findsNothing);
+
+      await tester.tap(processAction);
+      await tester.pumpAndSettle();
+      expect(find.text('先想清楚再回答'), findsOneWidget);
+      // 一个工具都没调，不该报「执行了 0 个操作」
+      expect(find.text(l10n.executedNOperations(0)), findsNothing);
     });
 
     testWidgets('regenerating drops the old answer and re-asks the question',

--- a/test/widget/pages/thoughter_page_test.dart
+++ b/test/widget/pages/thoughter_page_test.dart
@@ -407,11 +407,18 @@ class _FakeAgentService extends AgentService {
   }
 
   void _emitEvent(AgentEvent event) {
+    // 关掉之后还 add 会抛 "Cannot add event after closing"。放行等待方之后
+    // runAgent 会从 await 处继续跑，谁先到达这里并不由本类决定，所以这里兜一道。
+    if (_eventController.isClosed) return;
     _eventController.add(event);
   }
 
   @override
   void dispose() {
+    // 顺序和语义都要和 requestStop 对齐：先立起停止标志，再放行等待方。
+    // 只 cancel 不置标志的话，恢复执行的 runAgent 会一路穿过所有
+    // `if (stopRequested)` 守卫，然后往已经关闭的控制器里发事件。
+    stopRequested = true;
     _cancelPendingTimers();
     _eventController.close();
     super.dispose();

--- a/test/widget/pages/thoughter_page_test.dart
+++ b/test/widget/pages/thoughter_page_test.dart
@@ -230,6 +230,7 @@ class _FakeAgentService extends AgentService {
   String _mockStatusKey = '';
   bool stopRequested = false;
   final Set<Timer> _pendingTimers = <Timer>{};
+  final Set<Completer<void>> _pendingWaits = <Completer<void>>{};
   final StreamController<AgentEvent> _eventController =
       StreamController<AgentEvent>.broadcast(sync: true);
 
@@ -259,21 +260,34 @@ class _FakeAgentService extends AgentService {
   }
 
   Future<void> _delay(Duration duration) {
+    // 已经停了就不要再排新的定时器：取消放行等待方之后，runAgent 会从
+    // await 处继续往下跑到下一个 _delay，那个 Timer 建在 widget 树销毁之后，
+    // flutter_test 会以 "A Timer is still pending" 报错。
+    if (stopRequested) return Future<void>.value();
     final completer = Completer<void>();
     late final Timer timer;
     timer = Timer(duration, () {
       _pendingTimers.remove(timer);
+      _pendingWaits.remove(completer);
       completer.complete();
     });
     _pendingTimers.add(timer);
+    _pendingWaits.add(completer);
     return completer.future;
   }
 
+  /// 取消要把等待方也放出来：只 cancel 掉 Timer 的话，`await _delay(...)` 的
+  /// Completer 永远不完成，runAgent 停在 await 上不返回，stopRequested 之后
+  /// 的那些提前返回分支一个都跑不到。
   void _cancelPendingTimers() {
     for (final timer in _pendingTimers) {
       timer.cancel();
     }
     _pendingTimers.clear();
+    for (final completer in _pendingWaits) {
+      if (!completer.isCompleted) completer.complete();
+    }
+    _pendingWaits.clear();
   }
 
   @override
@@ -325,6 +339,10 @@ class _FakeAgentService extends AgentService {
     for (final chunk in reasoningChunks) {
       _emitEvent(AgentReasoningDeltaEvent(chunk));
       await _delay(const Duration(milliseconds: 12));
+      if (stopRequested) {
+        _setMockState(isRunning: false, statusKey: '');
+        return AgentResponse(content: '');
+      }
     }
 
     // 真实协议：agent 通过 propose_note_edit 工具产出 NoteProposalArtifact，


### PR DESCRIPTION
四处独立的问题。

## 1. 只思考、没调工具的那轮，回答下面不给「查看过程」

`_toolProcessBefore` 在 `items` 为空时直接 `return null`，把这一轮的推理过程一起丢了——正文上方只剩一行折叠标题，下面的操作行什么都不给，看着像思考被吞了。

现在只要有 `thinkingText` 就给入口。抽屉标题按实际发生的事说（没工具就是「思考」，不报「执行了 0 个操作」），按钮文案和图标跟着换成「查看思考过程」+ `psychology_outlined`。

## 2. 思考/工具早就结束，转圈却一直转到整段回答生成完

推理增量走 50ms 节流（`_scheduleToolProgressUpdate`），正文第一个 token 走直接写（`_updateToolProgressMessage(inProgress: false)`）。直接写没有作废队列里那条旧快照，它会晚一步落地把 `inProgress` 顶回 `true`，之后要等 `AgentResponseEvent` 才复位——现象正好是「转到回答完毕」。

修法：直接写一律先 `_cancelToolProgressUpdate()`，让它对节流队列具有权威性。正文流有同一类竞态（`isLoading` 被顶回 true → 末尾流式光标不灭、复制/重试行不出现），`_updateMessage` 同样处理。两个 `_flush*` 改成先摘待写状态再落地，避免自己清掉自己。

顺带补上工具面板建出来时漏掉的 `isLoading: true`：渲染判据是 `isLoading && meta.inProgress`，缺一个就导致面板出现后的头 50ms 明明在思考却显示成一条已完成的记录。

## 3. 交给模型的天气是存储 key，不是用户语言

`get_location_weather` 返回 `partly_cloudy`，每日提示写「天气：clear」，笔记元数据同理——界面显示「多云」，模型只能照抄一个英文标识符。

- 新增 `resolveAppLocalizations(localeCode)`（`lib/utils/localization_resolver.dart`），给 Service 和 Agent 工具这类没有 `BuildContext` 的地方取 l10n。用 `I18nLanguage.base` 去掉区域后缀，`zh_CN` 不会被判成不支持而掉到英文
- `GetLocationWeatherTool` 改收 `SettingsService`，`weather_description` / `weather_display` 按用户语言给出；`weather_key` 保留原样供机器判断
- `AIService` 在进提示词前翻好笔记的天气和时间段
- `daily_prompt_panel` 分开两条链路：本地模板仍按 key 选句子，AI 那条传人能读的天气名
- `ai_prompt_manager` 里那次早已失效的 key→描述 映射删掉（`getDescription('clear')` 只会还回 `'clear'`，判据 `== '未知'` 永远不成立，结果反而把天气输出成 `unknown`），改由调用方负责本地化
- `smart_push` 里逐行相同的 `_resolveDailyQuoteLocalizations` 改为转调，删掉副本

时间段（`morning` / `dawn`）是同一处、同样只是 key，一并翻了；`TimeUtils` 抽出不依赖 context 的 `localizedDayPeriodLabel`，原有的 context 版本转发给它。

## 4. Thoughter 输入框：阴影改高光

去掉落地投影，改成聚焦时表面抬一层 + 一圈贴边的强调色高光环（`spreadRadius`，不是模糊阴影）。对齐 ChatGPT / Claude / Gemini 的做法，也不再和纸墨这类零投影风格打架。

## 测试

新增 3 个回归测试：

- `thinking-only turn still exposes its process under the reply`
- `thinking spinner stops once the answer starts streaming`（`_FakeAgentService` 补了 `reasoningChunks`，用来复现推理→正文那条时序；把修复临时撤掉验证过它确实会失败）
- `GetLocationWeatherTool describes the weather in the user language, not the storage key`

外加 `resolveAppLocalizations` 的单测（含 `zh_CN` / `zh-Hans` / `EN_US` / 不支持语言回退）和 `ai_prompt_manager` 天气文案透传的断言。

`flutter analyze --no-fatal-infos` 干净（剩余 4 条 info 均为既有），`dart format` 无改动，CI 16 项检查全绿。

## 更正：先前关于 CI 既有失败的说法有误

本 PR 描述早先有一段说「`test/widget` 门禁本来就是红的」，依据是 flutter_quill 11.5.0 缺 `TextInputClient.onFocusReceived`。**那个结论是错的，现已删除。**

真实情况：那是我本地手动装的 Flutter 3.44.8 的问题，CI 上 `3.44.x` 解析到的补丁版本没有这个不兼容——本 PR 的 `Tests (widget 1/2, 2/2)` 和 `Tests (unit 1-4)` 全部通过。仓库和 `pubspec.lock` 没有需要处理的既有问题。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFApewE8eQEETN3sYTsBwh)_


---
## Summary by cubic
修复 Agent 过程展示与加载状态，确保只思考也能查看过程且转圈在回答开始时停止。并按用户语言把天气/时间段传给模型，统一无 context 的本地化解析；优化 Thoughter 输入框聚焦样式。

- **Bug Fixes**
  - 只思考也有过程入口：有思考文本就显示，标题为“思考”，按钮改为“查看思考过程”+ 图标。
  - 转圈不拖到回答结束：直接写入前一律取消节流快照；消息流同类竞态一并处理；工具面板初始化补 `isLoading: true`；flush 先清待写状态再落地。
  - 天气/时间段按语言传给模型：新增 `resolveAppLocalizations`（去区域后缀，超范围回退英文）；`GetLocationWeatherTool` 接入 `SettingsService` 输出本地化描述；`AIService` 在入提示词前翻译笔记的天气与时间段；`daily_prompt_panel` 本地模板用 key，AI 链路传本地化文本；`ai_prompt_manager` 移除失效的 key→描述映射；`TimeUtils` 提供无 context 的 `localizedDayPeriodLabel`；Thoughter 开场白改回传 key。
  - 语言解析复用：`smart_push` 改用 `resolveAppLocalizations`，移除重复实现。
  - UI：输入框去投影，聚焦时抬层并绘制贴边高光环。
  - 测试稳定性：假 Agent 取消时放行等待方，已停止后 `_delay` 不排新定时器并在推理循环中检查停止；`dispose` 与 `requestStop` 顺序对齐，事件发送兜住已关闭的控制器。

_Written for commit eb2fae601149c1bac595b14cc4ede9e4540841eb. Summary will update on new commits._

[Review in cubic](https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/446?utm_source=github)


## Summary by CodeRabbit

* **新功能**
  * 每日提示、分析与问答中的天气和时段信息会根据当前语言显示本地化文案。
  * 过程查看界面支持仅含思考内容的记录，并优化标题、图标与操作标签。
* **问题修复**
  * 修复流式更新被旧状态覆盖的问题，完成后不会意外恢复加载状态。
  * 思考与工具进度在首次更新前也会正确显示进行中状态。
* **本地化**
  * 未支持的语言会自动回退至英文。