### PR TITLE
🗃️ 黑匣: [完善 UI 及主题模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -42,3 +42,7 @@
 ## 2025-10-25 - 🗃️ 黑匣: [完善 FeatureGuideService 模块的结构化日志]
 **异常:** [MMKV读取/写入抛出异常且只使用了粗糙的debugPrint记录，丢失了错误栈与模块上下文]
 **拦截:** [使用 catch (e, stackTrace) 和 logError 封装 MMKV 异常，附带 error, stackTrace 和 source: 'FeatureGuideService' 参数，保存完整的堆栈上下文信息。]
+
+## 2025-10-25 - 🗃️ 黑匣: [完善 UI 及主题模块的结构化日志]
+**异常:** [HomePage 在恢复草稿和加载标签时、AppTheme 在加载各项持久化配置时、以及 ThoughterUI 在请求天气时遇到异常，仅使用了 catch (e) 进行了空捕获或粗糙的 logDebug，丢失了错误堆栈信息以及模块来源标识，使得排查相关功能失效的根因变得困难。]
+**拦截:** [已将上述流程中的 catch (e) 替换为 catch (e, stack)，并使用结构化的 AppLogger.e/logError 进行记录。注入了对应的描述信息、具体的错误对象 error: e、堆栈轨迹 stackTrace: stack，并指定了明确的日志来源模块 source (如 'HomePage', 'AppTheme', 'ThoughterUI')。确认不包含任何隐私数据。]

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -492,8 +492,13 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
             } else {
               logDebug('恢复草稿时发现原始笔记已删除，将作为新笔记处理');
             }
-          } catch (e) {
-            logDebug('恢复草稿时获取原始笔记失败: $e');
+          } catch (e, stack) {
+            logError(
+              '恢复草稿时获取原始笔记失败',
+              error: e,
+              stackTrace: stack,
+              source: 'HomePage',
+            );
           }
         }
 
@@ -583,8 +588,13 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
         context.read<DatabaseService>().getTags,
       );
       if (mounted) logDebug('标签加载完成，共 ${_pageController.tags.length} 个标签');
-    } catch (e) {
-      logDebug('加载标签时出错: $e');
+    } catch (e, stack) {
+      logError(
+        '加载标签时出错',
+        error: e,
+        stackTrace: stack,
+        source: 'HomePage',
+      );
     }
   }
 
@@ -595,8 +605,13 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       await Future.microtask(() async {
         await _loadTags();
       });
-    } catch (e) {
-      logDebug('预加载标签失败: $e');
+    } catch (e, stack) {
+      logError(
+        '预加载标签失败',
+        error: e,
+        stackTrace: stack,
+        source: 'HomePage',
+      );
     }
   }
 

--- a/lib/pages/thoughter/thoughter_ui.dart
+++ b/lib/pages/thoughter/thoughter_ui.dart
@@ -1162,8 +1162,13 @@ extension _ThoughterUI on _ThoughterPageState {
       if (pos != null) {
         try {
           await weatherService.getWeatherData(pos.latitude, pos.longitude);
-        } catch (e) {
-          logDebug('AI 打开编辑器获取天气失败: $e');
+        } catch (e, stack) {
+          logError(
+            'AI 打开编辑器获取天气失败',
+            error: e,
+            stackTrace: stack,
+            source: 'ThoughterUI',
+          );
         }
       }
     }
@@ -1323,8 +1328,13 @@ extension _ThoughterUI on _ThoughterPageState {
               pos.latitude,
               pos.longitude,
             );
-          } catch (e) {
-            logDebug('AI 直接保存获取天气失败: $e');
+          } catch (e, stack) {
+            logError(
+              'AI 直接保存获取天气失败',
+              error: e,
+              stackTrace: stack,
+              source: 'ThoughterUI',
+            );
             includeWeather = false;
           }
         } else {

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -409,8 +409,13 @@ class AppTheme with ChangeNotifier {
       logDebug(
         '主题服务初始化完成: 使用自定义颜色=$_useCustomColor, 使用动态取色=$_useDynamicColor, 主题模式=$_themeMode',
       );
-    } catch (e) {
-      logDebug('初始化主题服务失败: $e');
+    } catch (e, stack) {
+      logError(
+        '初始化主题服务失败',
+        error: e,
+        stackTrace: stack,
+        source: 'AppTheme',
+      );
       // 初始化失败时使用默认值。风格也要一并重置：_loadThemeStyle() 可能已经成功、
       // 后面某一步才抛，那样会留下「风格是纸墨、其余全是默认值」的半新半旧状态。
       _customColor = Colors.blue;
@@ -575,8 +580,13 @@ class AppTheme with ChangeNotifier {
         ); // This is correct for reconstructing Color from ARGB int
       }
       _useCustomColor = _storage?.getBool(_useCustomColorKey) ?? false;
-    } catch (e) {
-      logDebug('加载自定义颜色失败: $e');
+    } catch (e, stack) {
+      logError(
+        '加载自定义颜色失败',
+        error: e,
+        stackTrace: stack,
+        source: 'AppTheme',
+      );
       _customColor = Colors.blue;
       _useCustomColor = false;
     }
@@ -589,8 +599,13 @@ class AppTheme with ChangeNotifier {
       if (modeString != null) {
         _themeMode = ThemeMode.values.byName(modeString);
       }
-    } catch (e) {
-      logDebug('加载主题模式失败: $e');
+    } catch (e, stack) {
+      logError(
+        '加载主题模式失败',
+        error: e,
+        stackTrace: stack,
+        source: 'AppTheme',
+      );
       _themeMode = ThemeMode.system;
     }
   }
@@ -599,8 +614,13 @@ class AppTheme with ChangeNotifier {
   void _loadThemeStyle() {
     try {
       _themeStyle = ThemeStyle.fromName(_storage?.getString(_themeStyleKey));
-    } catch (e) {
-      logDebug('加载主题风格失败: $e');
+    } catch (e, stack) {
+      logError(
+        '加载主题风格失败',
+        error: e,
+        stackTrace: stack,
+        source: 'AppTheme',
+      );
       _themeStyle = ThemeStyle.defaultStyle;
     }
   }
@@ -612,8 +632,13 @@ class AppTheme with ChangeNotifier {
       if (useDynamic != null) {
         _useDynamicColor = useDynamic;
       }
-    } catch (e) {
-      logDebug('加载动态取色设置失败: $e');
+    } catch (e, stack) {
+      logError(
+        '加载动态取色设置失败',
+        error: e,
+        stackTrace: stack,
+        source: 'AppTheme',
+      );
       _useDynamicColor = true; // 默认启用
     }
   }


### PR DESCRIPTION
🗃️ 黑匣: [完善 UI 及主题模块的结构化日志]

本次 PR 主要针对以下模块进行异常日志结构的标准化完善，确保潜在的故障能被有效追踪且不泄露任何用户隐私：

- **HomePage**: 针对恢复草稿发现原始笔记缺失及加载和预加载标签失败等隐蔽错误，将粗糙的 `logDebug` 及 `catch (e)` 升级为带有错误对象与堆栈轨迹 (`stack`) 的 `logError`，并附带明确的模块标识 `source: 'HomePage'`。
- **AppTheme**: 在持久化存储加载各类自定义设定（如颜色、模式、风格）失败时，将原有的日志替换为结构化异常捕获，附加堆栈和模块名。修改过程中保持了出现错误时的“恢复默认配置”逻辑完整性。
- **ThoughterUI**: 当 AI 需要在编辑器或者后台静默保存触发天气及定位服务抛出异常时，通过 `catch (e, stack)` 结构捕获错误，替换 `logDebug` 以避免在复杂场景下丢失错误堆栈信息，并使用 `source: 'ThoughterUI'` 标识来源。

⚠️ 声明：本次修改纯为补全错误捕获与日志记录结构，经过排查已确认代码仅会捕获与基础数据流有关的本地异常（如定位抛错、键值读取等），不包含也不记录任何敏感隐私信息或外部传入的敏感内容实体。

`.jules/blackbox.md` 已同步更新记录。

---
*PR created automatically by Jules for task [2152191256834360023](https://jules.google.com/task/2152191256834360023) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
统一 UI 与主题模块的错误日志为结构化记录：使用 logError 捕获 error 与 stackTrace 并标注 source，便于排查且不记录隐私。覆盖 HomePage、AppTheme、ThoughterUI，保持既有回退逻辑不变。

- **Refactors**
  - HomePage：草稿恢复与标签加载/预加载改用 catch(e, stack) + logError，source: 'HomePage'。
  - AppTheme：初始化与加载自定义颜色/主题模式/风格/动态取色改为结构化日志；失败时继续按默认值恢复。
  - ThoughterUI：编辑器打开与后台保存获取天气异常改为结构化日志，source: 'ThoughterUI'，降级处理不变。
  - 文档：更新 `\.jules/blackbox.md` 记录本次日志完善。

<sup>Written for commit ce0f24b97cab5f439b82dc2ab85fb189720c03f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进草稿恢复、标签加载及预加载失败时的错误记录。
  * 改进主题配置和天气获取失败时的异常记录。
  * 错误日志现包含更完整的错误详情与堆栈信息，便于排查问题，同时避免记录隐私数据。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->