### PR TITLE
fix(editor): 非全屏编辑器自动附加天气不再在保存时漏掉，抓取挪出动画期

### DIFF
--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -234,8 +234,12 @@ class AddNoteController extends ChangeNotifier {
   Future<void> fetchLocationForNewNote() async {
     final locService = locationService;
     if (locService == null) {
-      // 服务拿不到就抓不了，标志必须放掉：保存正等着它。
-      clearPendingLocationFetch();
+      // 服务拿不到就抓不了，按失败处理：既放掉标志（保存正等着它），
+      // 也取消这次附加，别让笔记带着「已附加位置」的勾却什么都没有。
+      includeLocation = false;
+      _clearNewLocation();
+      isFetchingLocation = false;
+      notifyListeners();
       return;
     }
 
@@ -288,7 +292,10 @@ class AddNoteController extends ChangeNotifier {
     final weaService = weatherService;
     final locService = locationService;
     if (weaService == null) {
-      clearPendingWeatherFetch();
+      // 同上：抓不了就别让 WeatherService 的旧数据在保存时冒充这条笔记的天气。
+      includeWeather = false;
+      isFetchingWeather = false;
+      notifyListeners();
       return;
     }
 

--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -42,6 +42,33 @@ class AddNoteController extends ChangeNotifier {
   /// 是否有任何元数据正在后台获取中
   bool get isFetchingMetadata => isFetchingLocation || isFetchingWeather;
 
+  /// 「预约」自动附加：抓取真正开始之前就把标志立起来。
+  ///
+  /// 保存流程靠这两个标志决定要不要转圈等待。只要中间出现一段标志为 false 的空窗
+  /// （等待延迟启动、位置抓完但天气还没开始），这期间点保存就会以为元数据已经齐了，
+  /// 直接落库，把用户在偏好里要的位置/天气丢掉。
+  void armAutoMetadataFetch({required bool location, required bool weather}) {
+    if (isFetchingLocation == location && isFetchingWeather == weather) return;
+    isFetchingLocation = location;
+    isFetchingWeather = weather;
+    notifyListeners();
+  }
+
+  /// 预约的位置抓取不会发生了（服务缺失、用户移除），放掉标志。
+  void clearPendingLocationFetch() {
+    if (!isFetchingLocation) return;
+    isFetchingLocation = false;
+    notifyListeners();
+  }
+
+  /// 预约的天气抓取不会发生了（服务缺失、没有坐标、用户移除），放掉标志，
+  /// 否则保存会一直转到超时。
+  void clearPendingWeatherFetch() {
+    if (!isFetchingWeather) return;
+    isFetchingWeather = false;
+    notifyListeners();
+  }
+
   // 一言标签加载状态
   bool isLoadingHitokotoTags = false;
 
@@ -143,6 +170,15 @@ class AddNoteController extends ChangeNotifier {
   void removeNewLocation() {
     includeLocation = false;
     _clearNewLocation();
+    // 用户主动移除，在途/预约的抓取就没有意义了，别让保存继续等它。
+    isFetchingLocation = false;
+    notifyListeners();
+  }
+
+  /// 新建笔记时用户主动移除天气。
+  void removeNewWeather() {
+    includeWeather = false;
+    isFetchingWeather = false;
     notifyListeners();
   }
 
@@ -197,7 +233,11 @@ class AddNoteController extends ChangeNotifier {
   /// 获取新建笔记的实时位置
   Future<void> fetchLocationForNewNote() async {
     final locService = locationService;
-    if (locService == null) return;
+    if (locService == null) {
+      // 服务拿不到就抓不了，标志必须放掉：保存正等着它。
+      clearPendingLocationFetch();
+      return;
+    }
 
     isFetchingLocation = true;
     notifyListeners();
@@ -247,7 +287,10 @@ class AddNoteController extends ChangeNotifier {
   Future<void> fetchWeatherForNewNote() async {
     final weaService = weatherService;
     final locService = locationService;
-    if (weaService == null) return;
+    if (weaService == null) {
+      clearPendingWeatherFetch();
+      return;
+    }
 
     isFetchingWeather = true;
     notifyListeners();

--- a/lib/pages/home/home_note_editor_actions.dart
+++ b/lib/pages/home/home_note_editor_actions.dart
@@ -55,8 +55,12 @@ class HomeNoteEditorActions {
     final messenger = ScaffoldMessenger.of(context);
     final l10n = AppLocalizations.of(context);
 
-    await loadTags();
-    if (!isMounted() || !context.mounted) return;
+    // 标签已经在内存里就直接开窗：这里 await 一次数据库查询会把整个开窗动作往后推，
+    // 而 edit() 一直是直接用缓存的，保存后也会重新加载。
+    if (isLoadingTags() || readTags().isEmpty) {
+      await loadTags();
+      if (!isMounted() || !context.mounted) return;
+    }
 
     if (isLoadingTags() || readTags().isEmpty) {
       logDebug('标签数据未准备好，重新加载标签数据...');

--- a/lib/pages/home/home_note_editor_actions.dart
+++ b/lib/pages/home/home_note_editor_actions.dart
@@ -55,12 +55,10 @@ class HomeNoteEditorActions {
     final messenger = ScaffoldMessenger.of(context);
     final l10n = AppLocalizations.of(context);
 
-    // 标签已经在内存里就直接开窗：这里 await 一次数据库查询会把整个开窗动作往后推，
-    // 而 edit() 一直是直接用缓存的，保存后也会重新加载。
-    if (isLoadingTags() || readTags().isEmpty) {
-      await loadTags();
-      if (!isMounted() || !context.mounted) return;
-    }
+    // 这次查询必须等：标签只在启动和切到笔记页时刷新，设置页里新增/改名/删除标签后
+    // 直接回来点新增笔记，缓存就是旧的。省这一次查询换来的开窗提前量没有实测支撑。
+    await loadTags();
+    if (!isMounted() || !context.mounted) return;
 
     if (isLoadingTags() || readTags().isEmpty) {
       logDebug('标签数据未准备好，重新加载标签数据...');

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -145,6 +145,13 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   Timer? _deferredControlsTimer;
   Timer? _autoFocusTimer;
 
+  // 自动附加位置/天气：initState 就按偏好确定要抓什么，抓取本身推迟到 UI 稳定后。
+  bool _autoAttachLocationPlanned = false;
+  bool _autoAttachWeatherPlanned = false;
+  bool _autoMetadataStarted = false;
+  Timer? _autoMetadataFallbackTimer;
+  Timer? _databaseListenerTimer;
+
   // AI推荐标签相关状态
   // 预留：后续接入本地 embedding/标签推荐时使用
 
@@ -264,6 +271,28 @@ class _AddNoteDialogState extends State<AddNoteDialog>
         );
       },
     );
+
+    final settingsService = _readServiceOrNull<SettingsService>(context);
+
+    // 先按偏好/预填充确定自动附加计划，并立刻把「获取中」标志立起来，再挂监听：
+    // 抓取本身要等 UI 稳定后才启动，这段时间里点保存必须能等到元数据。
+    // （挂监听之前 arm，避免 notifyListeners 在 initState 里触发 setState。）
+    if (widget.initialQuote == null) {
+      final bool useAIPrefill = widget.useAIPrefilledLocationWeather ?? false;
+      _autoAttachLocationPlanned = useAIPrefill
+          ? (widget.prefilledIncludeLocation ?? false)
+          : (widget.prefilledIncludeLocation ??
+              (settingsService?.autoAttachLocation ?? false));
+      _autoAttachWeatherPlanned = useAIPrefill
+          ? (widget.prefilledIncludeWeather ?? false)
+          : (widget.prefilledIncludeWeather ??
+              (settingsService?.autoAttachWeather ?? false));
+      _controller.armAutoMetadataFetch(
+        location: _autoAttachLocationPlanned,
+        weather: _autoAttachWeatherPlanned,
+      );
+    }
+
     _controller.addListener(_onControllerChanged);
     _controller.updateServices(
       locService: _readServiceOrNull<LocationService>(context),
@@ -325,7 +354,6 @@ class _AddNoteDialogState extends State<AddNoteDialog>
         _selectedTagIds.addAll(widget.prefilledTagIds!);
       }
 
-      final settingsService = _readServiceOrNull<SettingsService>(context);
       if (settingsService != null) {
         // 仅在没有预填充值时使用默认值
         if (_authorController.text.isEmpty &&
@@ -343,15 +371,6 @@ class _AddNoteDialogState extends State<AddNoteDialog>
             settingsService.defaultTagIds.isNotEmpty) {
           _selectedTagIds.addAll(settingsService.defaultTagIds);
         }
-
-        // 提前预置 fetching 标志：避免 metadataDelay 期间按钮可点导致保存时丢失数据。
-        // 真正的 fetch 在 delay 后启动，但标志从这里就开始保护保存按钮。
-        if (settingsService.autoAttachLocation) {
-          _controller.isFetchingLocation = true;
-        }
-        if (settingsService.autoAttachWeather) {
-          _controller.isFetchingWeather = true;
-        }
       }
     }
 
@@ -362,16 +381,17 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     }
 
     // 优化：完全延迟所有服务初始化和数据库监听器，避免阻塞首次绘制
-    // 使用 postFrameCallback + delay 确保首帧渲染完成后再执行重量级操作
+    // 定位、反查地址、天气请求都要走平台通道和网络，压在入场/键盘动画上最容易掉帧。
+    // 实际启动时机取「键盘 inset 稳定」和下面这个兜底延迟里先到的那个；用户提前点保存
+    // 时也会立刻启动（见 _startAutoMetadataFetch）。
     // 实验开关 addNoteDialogDeferAutoMetadata（默认 false）：
-    //   false → 延迟 300ms（首帧后）获取元数据（现有行为）
-    //   true  → 延迟 1500ms（键盘动画结束后）再获取元数据（实验）
-    final deferMetadata = (_readServiceOrNull<SettingsService>(context)
-            ?.addNoteDialogDeferAutoMetadata ??
-        false);
+    //   false → 兜底 900ms（略晚于典型键盘动画）
+    //   true  → 兜底 1500ms（更保守的实验值）
+    final deferMetadata =
+        settingsService?.addNoteDialogDeferAutoMetadata ?? false;
     final metadataDelay = deferMetadata
         ? const Duration(milliseconds: 1500)
-        : const Duration(milliseconds: 300);
+        : const Duration(milliseconds: 900);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final route = ModalRoute.of(context);
@@ -402,93 +422,17 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
 
-      // 延迟执行服务初始化和位置/天气获取，避免与动画竞争
-      Future.delayed(metadataDelay, () async {
-        // 清理 initState 提前预置的标志；unmount 时 widget 已销毁不需要清，但
-        // 正常流程中这里重置后由各 fetch 方法重新置 true，保证状态准确。
-        _controller.isFetchingLocation = false;
-        _controller.isFetchingWeather = false;
-
-        if (!mounted) return;
-
-        _dialogOpenTimelineTask
-            .instant('ThoughtEcho.AddNoteDialog.deferredMetadata.start');
-        _cachedLocationService = _readServiceOrNull<LocationService>(context);
-        _cachedWeatherService = _readServiceOrNull<WeatherService>(context);
-        _databaseService = _readServiceOrNull<DatabaseService>(context);
-
-        // 新建笔记时，读取用户偏好并自动勾选位置/天气
-        if (widget.initialQuote == null) {
-          final settingsService = _readServiceOrNull<SettingsService>(context);
-          final bool useAIPrefill =
-              widget.useAIPrefilledLocationWeather ?? false;
-          final autoLocation = useAIPrefill
-              ? (widget.prefilledIncludeLocation ?? false)
-              : (widget.prefilledIncludeLocation ??
-                  (settingsService?.autoAttachLocation ?? false));
-          final autoWeather = useAIPrefill
-              ? (widget.prefilledIncludeWeather ?? false)
-              : (widget.prefilledIncludeWeather ??
-                  (settingsService?.autoAttachWeather ?? false));
-
-          if (autoLocation || autoWeather) {
-            if (mounted) {
-              _recordDialogPerfStateChange('autoAttachPrefs');
-              setState(() {
-                if (autoLocation) {
-                  _controller.includeLocation = true;
-                }
-                if (autoWeather) {
-                  _controller.includeWeather = true;
-                }
-              });
-            }
-
-            _controller.updateServices(
-              locService: _cachedLocationService,
-              weaService: _cachedWeatherService,
-              dbService: _databaseService,
-            );
-            // 如果自动勾选了位置，获取位置；天气需要位置坐标，所以在位置获取后处理
-            if (autoLocation) {
-              await _controller.fetchLocationForNewNote();
-              // 位置获取后再获取天气
-              if (autoWeather &&
-                  _controller.includeLocation &&
-                  (_controller.newLatitude != null ||
-                      _cachedLocationService?.currentPosition != null)) {
-                _controller.fetchWeatherForNewNote();
-              } else if (autoWeather && !_controller.includeLocation) {
-                // 位置获取失败，天气也无法获取，取消天气选中并提示
-                if (mounted) {
-                  _recordDialogPerfStateChange('autoWeatherDisabled');
-                  _controller.setIncludeWeather(false);
-                }
-              }
-            } else if (autoWeather) {
-              // 没有勾选位置但勾选了天气，尝试用缓存的位置获取天气
-              _controller.fetchWeatherForNewNote();
-            }
-          }
-        }
-
-        // 延迟注册监听器，避免初始化时触发不必要的查询
-        Future.delayed(const Duration(milliseconds: 200), () {
-          if (mounted && _databaseService != null) {
-            _databaseService!.addListener(_onDatabaseChanged);
-          }
-        });
-        _dialogOpenTimelineTask
-            .instant('ThoughtEcho.AddNoteDialog.deferredMetadata.complete');
-      });
+      // 兜底：键盘没弹出（关闭了自动聚焦、外接键盘、桌面端）时也要把元数据抓起来。
+      _autoMetadataFallbackTimer = Timer(
+        metadataDelay,
+        () => unawaited(_startAutoMetadataFetch('fallbackTimer')),
+      );
     });
 
     // 性能优化：等 BottomSheet 入场和次要控件挂载稳定后再请求焦点弹出键盘。
     // 避免键盘 inset 动画与打开首帧/次要控件挂载叠加导致掉帧。
     // 实验开关 addNoteDialogAutoFocus（默认 true）：关闭后跳过自动聚焦。
-    final autoFocusEnabled =
-        _readServiceOrNull<SettingsService>(context)?.addNoteDialogAutoFocus ??
-            true;
+    final autoFocusEnabled = settingsService?.addNoteDialogAutoFocus ?? true;
     if (autoFocusEnabled) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
@@ -594,6 +538,87 @@ class _AddNoteDialogState extends State<AddNoteDialog>
         }),
       );
     }
+  }
+
+  /// 缓存位置/天气/数据库服务引用。
+  ///
+  /// 自动附加的抓取推迟到 UI 稳定后才跑，但用户可能更早点位置/天气按钮，
+  /// 所以每个用到服务的入口都先确保引用就位，否则 fetch 会因为服务为 null 直接空转。
+  void _ensureMetadataServices() {
+    _cachedLocationService ??= _readServiceOrNull<LocationService>(context);
+    _cachedWeatherService ??= _readServiceOrNull<WeatherService>(context);
+    _databaseService ??= _readServiceOrNull<DatabaseService>(context);
+    _controller.updateServices(
+      locService: _cachedLocationService,
+      weaService: _cachedWeatherService,
+      dbService: _databaseService,
+    );
+  }
+
+  /// 按 initState 定下的计划真正抓取位置/天气。
+  ///
+  /// 触发点有三个，谁先到谁执行，只跑一次：键盘 inset 稳定、兜底定时器、
+  /// 用户提前点保存。推迟到这些时机是为了不和入场/键盘动画抢主线程；
+  /// 保存路径上的「获取中」标志从 initState 就立着，所以推迟不会让元数据丢失。
+  Future<void> _startAutoMetadataFetch(String reason) async {
+    if (_autoMetadataStarted) return;
+    _autoMetadataStarted = true;
+    _autoMetadataFallbackTimer?.cancel();
+    _autoMetadataFallbackTimer = null;
+    if (!mounted) return;
+
+    _dialogOpenTimelineTask.instant(
+      'ThoughtEcho.AddNoteDialog.deferredMetadata.start',
+      arguments: <String, Object>{'reason': reason},
+    );
+    _ensureMetadataServices();
+
+    // 延迟注册监听器，避免初始化时触发不必要的查询
+    _databaseListenerTimer = Timer(const Duration(milliseconds: 200), () {
+      if (mounted && _databaseService != null) {
+        _databaseService!.addListener(_onDatabaseChanged);
+      }
+    });
+
+    final autoLocation = _autoAttachLocationPlanned;
+    final autoWeather = _autoAttachWeatherPlanned;
+    if (autoLocation || autoWeather) {
+      _recordDialogPerfStateChange('autoAttachPrefs');
+      setState(() {
+        if (autoLocation) {
+          _controller.includeLocation = true;
+        }
+        if (autoWeather) {
+          _controller.includeWeather = true;
+        }
+      });
+
+      // 天气要用位置的坐标，所以先等位置抓完再抓天气。
+      // 这两步之间 isFetchingWeather 必须一直立着（initState 已 arm），
+      // 否则位置刚抓完的那一瞬间点保存，会被当成元数据已就绪，天气就丢了。
+      if (autoLocation) {
+        await _controller.fetchLocationForNewNote();
+        if (!mounted) return;
+      }
+
+      if (autoWeather) {
+        final hasCoordinates = _controller.newLatitude != null ||
+            _cachedLocationService?.currentPosition != null;
+        if (!autoLocation || (_controller.includeLocation && hasCoordinates)) {
+          await _controller.fetchWeatherForNewNote();
+        } else {
+          // 位置没拿到，天气也无从获取：放掉预约标志，别让保存白等到超时。
+          _controller.clearPendingWeatherFetch();
+          if (!_controller.includeLocation) {
+            _recordDialogPerfStateChange('autoWeatherDisabled');
+            _controller.setIncludeWeather(false);
+          }
+        }
+      }
+    }
+
+    _dialogOpenTimelineTask
+        .instant('ThoughtEcho.AddNoteDialog.deferredMetadata.complete');
   }
 
   void _captureInitialState() {
@@ -950,6 +975,8 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       _dialogPerfKeyboardSettleTimer = Timer(
         const Duration(milliseconds: 220),
         () {
+          // 键盘动画结束，主线程空出来了，这时候再去抓位置/天气。
+          unawaited(_startAutoMetadataFetch('keyboardSettled'));
           if (_dialogPerfRecording) {
             _dialogPerfKeyboardSettledMs =
                 _dialogPerfStopwatch.elapsedMilliseconds;
@@ -1387,6 +1414,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     if (result == 'update' && hasCoordinates) {
       // 尝试用坐标更新地址（优先在线 Nominatim → 回退系统 SDK）
       try {
+        _ensureMetadataServices();
         final locationService = _cachedLocationService;
         if (locationService != null) {
           locationService.currentLocaleCode = l10n.localeName;
@@ -1472,6 +1500,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     ThemeData theme,
   ) async {
     final l10n = AppLocalizations.of(context);
+    _ensureMetadataServices();
     final weatherService = _cachedWeatherService;
     final hasWeatherData = weatherService?.hasData ?? false;
 
@@ -1528,10 +1557,9 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     );
 
     if (result == 'remove') {
-      setState(() {
-        _controller.includeWeather = false;
-      });
+      _controller.removeNewWeather();
     } else if (result == 'retry') {
+      _ensureMetadataServices();
       _controller.fetchWeatherForNewNote();
     }
   }
@@ -1573,6 +1601,8 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     _keyboardRebuildResumeTimer?.cancel();
     _deferredControlsTimer?.cancel();
     _autoFocusTimer?.cancel();
+    _autoMetadataFallbackTimer?.cancel();
+    _databaseListenerTimer?.cancel();
     _detachDialogPerfHooks();
     _dbChangeDebounceTimer?.cancel();
     _routeAnimation?.removeListener(_onRouteAnimationProgress);
@@ -1699,6 +1729,10 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       return null;
     }
 
+    // 用户比自动附加更快：先把还没开跑的抓取踢起来，再转圈等它，
+    // 否则会白等一个还躺在定时器里的任务。
+    unawaited(_startAutoMetadataFetch('save'));
+
     // 如果位置/天气正在异步获取中，显示 loading 并等待完成（最多 5s）
     var metadataTimedOut = false;
     if (_controller.isFetchingMetadata) {
@@ -1721,6 +1755,12 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       // 创建或更新笔记
       final isEditing = widget.initialQuote != null;
       final baseQuote = _fullInitialQuote ?? widget.initialQuote;
+      // 抓取可能一次都没跑（内容写得快、偏好没开），服务引用未必缓存过，
+      // 这里补一次读取，避免把已有的位置/天气当成没有。
+      final locationService = _cachedLocationService ??
+          _readServiceOrNull<LocationService>(context);
+      final weatherService =
+          _cachedWeatherService ?? _readServiceOrNull<WeatherService>(context);
 
       final Quote quote = Quote(
         id: widget.initialQuote?.id ?? const Uuid().v4(),
@@ -1745,7 +1785,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
                 ? _controller.originalLocation
                 : () {
                     final loc = _controller.newLocation ??
-                        _cachedLocationService?.getFormattedLocation();
+                        locationService?.getFormattedLocation();
                     if ((loc == null || loc.isEmpty) &&
                         _controller.newLatitude != null) {
                       return LocationService.kAddressPending;
@@ -1767,12 +1807,12 @@ class _AddNoteDialogState extends State<AddNoteDialog>
         weather: _controller.includeWeather
             ? (isEditing
                 ? _controller.originalWeather
-                : _cachedWeatherService?.currentWeather)
+                : weatherService?.currentWeather)
             : null,
         temperature: _controller.includeWeather
             ? (isEditing
                 ? _controller.originalTemperature
-                : _cachedWeatherService?.temperature)
+                : weatherService?.temperature)
             : null,
         dayPeriod: widget.initialQuote?.dayPeriod ?? currentDayPeriodKey,
         editSource: widget.initialQuote?.editSource,
@@ -2272,6 +2312,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
                                         if (value &&
                                             _controller.newLocation == null &&
                                             _controller.newLatitude == null) {
+                                          _ensureMetadataServices();
                                           _controller.fetchLocationForNewNote();
                                         }
                                         setState(() {
@@ -2367,6 +2408,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
                                         _controller.includeWeather = true;
                                       });
                                       // 勾选时获取天气
+                                      _ensureMetadataServices();
                                       _controller.fetchWeatherForNewNote();
                                     } else {
                                       setState(() {

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -1250,8 +1250,9 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   }
 
   void _detachDialogPerfHooks() {
-    // 自动附加那一段还在采样时先别摘，否则它一帧都收不到。
-    if (_autoMetadataRecording) {
+    // 两段采样共用同一个帧回调，任意一段还在跑就先别摘：
+    // 自动附加可能被保存提前触发并先结束，这时打开阶段还在录，摘早了后面的帧全丢。
+    if (_autoMetadataRecording || _dialogPerfRecording) {
       return;
     }
     if (_dialogPerfTimingsCallbackAttached) {
@@ -1738,8 +1739,11 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     _autoFocusTimer?.cancel();
     _autoMetadataFallbackTimer?.cancel();
     _databaseListenerTimer?.cancel();
+    // 两个采样标志都要在摘钩子前清掉，否则 _detachDialogPerfHooks 会以为还在录，
+    // 帧回调就留在 binding 上了。
     _autoMetadataRecording = false;
     _autoMetadataStopwatch.stop();
+    _dialogPerfRecording = false;
     _detachDialogPerfHooks();
     _dbChangeDebounceTimer?.cancel();
     _routeAnimation?.removeListener(_onRouteAnimationProgress);
@@ -2449,15 +2453,22 @@ class _AddNoteDialogState extends State<AddNoteDialog>
                                           return;
                                         }
                                         // 新建模式：首次勾选，获取位置
-                                        if (value &&
-                                            _controller.newLocation == null &&
-                                            _controller.newLatitude == null) {
-                                          _ensureMetadataServices();
-                                          _controller.fetchLocationForNewNote();
+                                        if (value) {
+                                          if (_controller.newLocation == null &&
+                                              _controller.newLatitude == null) {
+                                            _ensureMetadataServices();
+                                            _controller
+                                                .fetchLocationForNewNote();
+                                          }
+                                          setState(() {
+                                            _controller.includeLocation = true;
+                                          });
+                                          return;
                                         }
-                                        setState(() {
-                                          _controller.includeLocation = value;
-                                        });
+                                        // 取消勾选：走 removeNewLocation 一并放掉在途标志。
+                                        // 定位还没回来时（上面的弹窗分支进不去）只改勾选，
+                                        // 保存会继续等一个结果已经不要了的请求，最多转 5 秒。
+                                        _controller.removeNewLocation();
                                       },
                                       selectedColor:
                                           theme.colorScheme.primaryContainer,
@@ -2551,10 +2562,9 @@ class _AddNoteDialogState extends State<AddNoteDialog>
                                       _ensureMetadataServices();
                                       _controller.fetchWeatherForNewNote();
                                     } else {
+                                      // 同位置：取消勾选要连在途标志一起放掉
                                       _cancelAutoAttachPlan(weather: true);
-                                      setState(() {
-                                        _controller.includeWeather = false;
-                                      });
+                                      _controller.removeNewWeather();
                                     }
                                   },
                                   selectedColor:

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -118,6 +118,18 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   int? _dialogPerfKeyboardSettledMs;
   final Stopwatch _dialogPerfStopwatch = Stopwatch();
   final List<FrameTiming> _dialogPerfFrameTimings = <FrameTiming>[];
+  // 主体 Widget 树的构造耗时。首帧的 buildDuration 里既有它，也有路由/弹窗自身的
+  // element 挂载和布局；分开记一笔才知道该砍谁。
+  int _dialogPerfBodyBuildCount = 0;
+  double _dialogPerfBodyBuildWorstMs = 0;
+  double? _dialogPerfFirstBodyBuildMs;
+  // 自动附加阶段：抓取被挪到键盘稳定之后，已经落在上面那个采样窗口之外了，
+  // 单独记一段，否则这段的耗时和掉帧完全看不见。
+  final List<FrameTiming> _autoMetadataFrameTimings = <FrameTiming>[];
+  final Stopwatch _autoMetadataStopwatch = Stopwatch();
+  bool _autoMetadataRecording = false;
+  int? _autoMetadataLocationDoneMs;
+  int? _autoMetadataWeatherDoneMs;
   final Map<String, int> _dialogPerfStateChanges = <String, int>{};
   late final AppTracer _dialogOpenTimelineTask;
   bool _dialogOpenTimelineFinished = false;
@@ -540,6 +552,17 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     }
   }
 
+  /// 用户主动关掉位置/天气后，作废对应的自动附加计划。
+  ///
+  /// 计划是在 initState 定下的，而抓取要等 UI 稳定（或用户点保存）才执行。
+  /// 中间这段时间里用户把开关关掉，计划却还留着的话，
+  /// `_startAutoMetadataFetch` 会把它重新打开并再抓一次——用户明确移除的东西
+  /// 在保存时又被静默加回来。
+  void _cancelAutoAttachPlan({bool location = false, bool weather = false}) {
+    if (location) _autoAttachLocationPlanned = false;
+    if (weather) _autoAttachWeatherPlanned = false;
+  }
+
   /// 缓存位置/天气/数据库服务引用。
   ///
   /// 自动附加的抓取推迟到 UI 稳定后才跑，但用户可能更早点位置/天气按钮，
@@ -571,6 +594,13 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       'ThoughtEcho.AddNoteDialog.deferredMetadata.start',
       arguments: <String, Object>{'reason': reason},
     );
+    if (_dialogPerfEnabled) {
+      _autoMetadataRecording = true;
+      _autoMetadataFrameTimings.clear();
+      _autoMetadataStopwatch
+        ..reset()
+        ..start();
+    }
     _ensureMetadataServices();
 
     // 延迟注册监听器，避免初始化时触发不必要的查询
@@ -598,27 +628,79 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       // 否则位置刚抓完的那一瞬间点保存，会被当成元数据已就绪，天气就丢了。
       if (autoLocation) {
         await _controller.fetchLocationForNewNote();
-        if (!mounted) return;
+        _autoMetadataLocationDoneMs =
+            _autoMetadataStopwatch.elapsedMilliseconds;
+        if (!mounted) {
+          _finalizeAutoMetadataCapture('unmounted');
+          return;
+        }
       }
 
       if (autoWeather) {
         final hasCoordinates = _controller.newLatitude != null ||
             _cachedLocationService?.currentPosition != null;
-        if (!autoLocation || (_controller.includeLocation && hasCoordinates)) {
+        if (!_controller.includeWeather) {
+          // 定位还没回来的时候用户就把天气去掉了，尊重它，别再发一次已取消的请求。
+          _recordDialogPerfStateChange('autoWeatherCancelled');
+          _controller.clearPendingWeatherFetch();
+        } else if (!autoLocation ||
+            (_controller.includeLocation && hasCoordinates)) {
           await _controller.fetchWeatherForNewNote();
         } else {
-          // 位置没拿到，天气也无从获取：放掉预约标志，别让保存白等到超时。
-          _controller.clearPendingWeatherFetch();
-          if (!_controller.includeLocation) {
-            _recordDialogPerfStateChange('autoWeatherDisabled');
-            _controller.setIncludeWeather(false);
-          }
+          // 位置没拿到，天气也无从获取：取消这次附加并放掉标志。
+          // 只清标志不清勾选的话，保存会把 WeatherService 里上一次的天气
+          // 写进一条根本没有坐标的笔记。
+          _recordDialogPerfStateChange('autoWeatherDisabled');
+          _controller.removeNewWeather();
         }
+        _autoMetadataWeatherDoneMs = _autoMetadataStopwatch.elapsedMilliseconds;
       }
     }
 
     _dialogOpenTimelineTask
         .instant('ThoughtEcho.AddNoteDialog.deferredMetadata.complete');
+    _finalizeAutoMetadataCapture(reason);
+  }
+
+  /// 自动附加阶段的采样收尾。
+  ///
+  /// 这段现在跑在键盘稳定之后，已经在「打开性能结果」的采样窗口之外——
+  /// 之前那份 log 里 `stateChanges={}` 就是因为它整段发生在窗口关闭以后。
+  void _finalizeAutoMetadataCapture(String trigger) {
+    if (!_autoMetadataRecording) {
+      return;
+    }
+    _autoMetadataRecording = false;
+    _autoMetadataStopwatch.stop();
+    _detachDialogPerfHooks();
+
+    final summary = _summarizeFrames(_autoMetadataFrameTimings);
+    final locationOutcome = !_autoAttachLocationPlanned
+        ? 'skip'
+        : (_controller.includeLocation && _controller.newLatitude != null
+            ? 'ok'
+            : 'failed');
+    final weatherOutcome = !_autoAttachWeatherPlanned
+        ? 'skip'
+        : (_controller.includeWeather &&
+                (_cachedWeatherService?.hasData ?? false)
+            ? 'ok'
+            : 'failed');
+
+    logDebug(
+      '自动附加耗时: trigger=$trigger, '
+      'total=${_autoMetadataStopwatch.elapsedMilliseconds}ms, '
+      'locationDone=${_autoMetadataLocationDoneMs ?? -1}ms, '
+      'weatherDone=${_autoMetadataWeatherDoneMs ?? -1}ms, '
+      'location=$locationOutcome, weather=$weatherOutcome, '
+      'frames=${summary.frames}, jank16=${summary.jank16}, '
+      'jank32=${summary.jank32}, jank50=${summary.jank50}, '
+      'avg=${summary.avgMs.toStringAsFixed(1)}ms, '
+      'worst=${summary.worstMs.toStringAsFixed(1)}ms, '
+      'buildWorst=${summary.buildWorstMs.toStringAsFixed(1)}ms, '
+      'rasterWorst=${summary.rasterWorstMs.toStringAsFixed(1)}ms',
+      source: 'AddNoteDialog.Perf',
+    );
   }
 
   void _captureInitialState() {
@@ -754,6 +836,9 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     _dialogPerfStateChanges.clear();
     _dialogPerfBuildCount = 0;
     _dialogPerfBodyReuseCount = 0;
+    _dialogPerfBodyBuildCount = 0;
+    _dialogPerfBodyBuildWorstMs = 0;
+    _dialogPerfFirstBodyBuildMs = null;
     _dialogPerfInsetBuildCount = 0;
     _dialogPerfInsetChangeCount = 0;
     _dialogPerfMetricsChangeCount = 0;
@@ -797,6 +882,9 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   void _collectDialogPerfTimings(List<FrameTiming> timings) {
     if (_dialogPerfRecording) {
       _dialogPerfFrameTimings.addAll(timings);
+    }
+    if (_autoMetadataRecording) {
+      _autoMetadataFrameTimings.addAll(timings);
     }
   }
 
@@ -884,7 +972,22 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       return _cachedDialogBody!;
     }
 
+    if (!_dialogPerfRecording) {
+      final body = buildBody();
+      _cachedDialogBody = body;
+      return body;
+    }
+
+    // 只测 Widget 树的构造，不含 element 挂载、布局和光栅化——
+    // 拿它和帧的 buildDuration 对比，才知道首帧那一下重在我们这棵树还是框架侧。
+    final stopwatch = Stopwatch()..start();
     final body = buildBody();
+    final elapsedMs = stopwatch.elapsedMicroseconds / 1000.0;
+    _dialogPerfBodyBuildCount++;
+    _dialogPerfFirstBodyBuildMs ??= elapsedMs;
+    if (elapsedMs > _dialogPerfBodyBuildWorstMs) {
+      _dialogPerfBodyBuildWorstMs = elapsedMs;
+    }
     _cachedDialogBody = body;
     return body;
   }
@@ -1007,17 +1110,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     _dialogPerfMetricsChangeCount++;
   }
 
-  void _finalizeDialogPerfCapture(String reason) {
-    if (!_dialogPerfRecording) {
-      return;
-    }
-
-    _dialogPerfRecording = false;
-    _dialogPerfStopwatch.stop();
-    _dialogPerfFinalizeTimer?.cancel();
-    _dialogPerfKeyboardSettleTimer?.cancel();
-    _detachDialogPerfHooks();
-
+  _FramePhaseSummary _summarizeFrames(List<FrameTiming> timings) {
     int jankyFrames = 0;
     int jankyFrames32 = 0;
     int jankyFrames50 = 0;
@@ -1028,7 +1121,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     double worstBuildMs = 0;
     double worstRasterMs = 0;
 
-    for (final timing in _dialogPerfFrameTimings) {
+    for (final timing in timings) {
       final buildMicros = timing.buildDuration.inMicroseconds;
       final rasterMicros = timing.rasterDuration.inMicroseconds;
       final totalMicros = buildMicros + rasterMicros;
@@ -1059,13 +1152,45 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       }
     }
 
-    final totalFrames = _dialogPerfFrameTimings.length;
-    final avgFrameMs =
-        totalFrames == 0 ? 0.0 : (totalFrameMicros / totalFrames) / 1000.0;
-    final avgBuildMs =
-        totalFrames == 0 ? 0.0 : (totalBuildMicros / totalFrames) / 1000.0;
-    final avgRasterMs =
-        totalFrames == 0 ? 0.0 : (totalRasterMicros / totalFrames) / 1000.0;
+    final totalFrames = timings.length;
+    return _FramePhaseSummary(
+      frames: totalFrames,
+      jank16: jankyFrames,
+      jank32: jankyFrames32,
+      jank50: jankyFrames50,
+      avgMs: totalFrames == 0 ? 0.0 : (totalFrameMicros / totalFrames) / 1000.0,
+      worstMs: worstFrameMs,
+      buildAvgMs:
+          totalFrames == 0 ? 0.0 : (totalBuildMicros / totalFrames) / 1000.0,
+      buildWorstMs: worstBuildMs,
+      rasterAvgMs:
+          totalFrames == 0 ? 0.0 : (totalRasterMicros / totalFrames) / 1000.0,
+      rasterWorstMs: worstRasterMs,
+    );
+  }
+
+  void _finalizeDialogPerfCapture(String reason) {
+    if (!_dialogPerfRecording) {
+      return;
+    }
+
+    _dialogPerfRecording = false;
+    _dialogPerfStopwatch.stop();
+    _dialogPerfFinalizeTimer?.cancel();
+    _dialogPerfKeyboardSettleTimer?.cancel();
+    _detachDialogPerfHooks();
+
+    final summary = _summarizeFrames(_dialogPerfFrameTimings);
+    final jankyFrames = summary.jank16;
+    final jankyFrames32 = summary.jank32;
+    final jankyFrames50 = summary.jank50;
+    final worstFrameMs = summary.worstMs;
+    final worstBuildMs = summary.buildWorstMs;
+    final worstRasterMs = summary.rasterWorstMs;
+    final totalFrames = summary.frames;
+    final avgFrameMs = summary.avgMs;
+    final avgBuildMs = summary.buildAvgMs;
+    final avgRasterMs = summary.rasterAvgMs;
     final keyboardDurationMs = _dialogPerfKeyboardStartMs == null ||
             _dialogPerfKeyboardSettledMs == null
         ? null
@@ -1090,6 +1215,10 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       'keyboardSettled=${_dialogPerfKeyboardSettledMs ?? -1}ms, '
       'keyboardDuration=${keyboardDurationMs ?? -1}ms, '
       'widgetBuilds=$_dialogPerfBuildCount, '
+      'bodyBuilds=$_dialogPerfBodyBuildCount, '
+      'bodyBuildFirst='
+      '${_dialogPerfFirstBodyBuildMs?.toStringAsFixed(1) ?? "-1"}ms, '
+      'bodyBuildWorst=${_dialogPerfBodyBuildWorstMs.toStringAsFixed(1)}ms, '
       'bodyReuses=$_dialogPerfBodyReuseCount, '
       'insetBuilds=$_dialogPerfInsetBuildCount, '
       'insetChanges=$_dialogPerfInsetChangeCount, '
@@ -1121,6 +1250,10 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   }
 
   void _detachDialogPerfHooks() {
+    // 自动附加那一段还在采样时先别摘，否则它一帧都收不到。
+    if (_autoMetadataRecording) {
+      return;
+    }
     if (_dialogPerfTimingsCallbackAttached) {
       WidgetsBinding.instance.removeTimingsCallback(_collectDialogPerfTimings);
       _dialogPerfTimingsCallbackAttached = false;
@@ -1488,6 +1621,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
         }
       }
     } else if (result == 'remove') {
+      _cancelAutoAttachPlan(location: true);
       _controller.removeNewLocation();
       setState(() {});
     }
@@ -1557,6 +1691,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     );
 
     if (result == 'remove') {
+      _cancelAutoAttachPlan(weather: true);
       _controller.removeNewWeather();
     } else if (result == 'retry') {
       _ensureMetadataServices();
@@ -1603,6 +1738,8 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     _autoFocusTimer?.cancel();
     _autoMetadataFallbackTimer?.cancel();
     _databaseListenerTimer?.cancel();
+    _autoMetadataRecording = false;
+    _autoMetadataStopwatch.stop();
     _detachDialogPerfHooks();
     _dbChangeDebounceTimer?.cancel();
     _routeAnimation?.removeListener(_onRouteAnimationProgress);
@@ -2293,6 +2430,9 @@ class _AddNoteDialogState extends State<AddNoteDialog>
                                       label: Text(l10n.location),
                                       selected: _controller.includeLocation,
                                       onSelected: (value) async {
+                                        if (!value) {
+                                          _cancelAutoAttachPlan(location: true);
+                                        }
                                         // 编辑模式下统一弹对话框
                                         if (widget.initialQuote != null) {
                                           await _showLocationDialog(
@@ -2411,6 +2551,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
                                       _ensureMetadataServices();
                                       _controller.fetchWeatherForNewNote();
                                     } else {
+                                      _cancelAutoAttachPlan(weather: true);
                                       setState(() {
                                         _controller.includeWeather = false;
                                       });
@@ -2719,4 +2860,31 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       });
     }
   }
+}
+
+/// 一段时间窗口内的帧耗时统计。打开阶段和自动附加阶段各算一份。
+class _FramePhaseSummary {
+  const _FramePhaseSummary({
+    required this.frames,
+    required this.jank16,
+    required this.jank32,
+    required this.jank50,
+    required this.avgMs,
+    required this.worstMs,
+    required this.buildAvgMs,
+    required this.buildWorstMs,
+    required this.rasterAvgMs,
+    required this.rasterWorstMs,
+  });
+
+  final int frames;
+  final int jank16;
+  final int jank32;
+  final int jank50;
+  final double avgMs;
+  final double worstMs;
+  final double buildAvgMs;
+  final double buildWorstMs;
+  final double rasterAvgMs;
+  final double rasterWorstMs;
 }

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -596,6 +596,10 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     );
     if (_dialogPerfEnabled) {
       _autoMetadataRecording = true;
+      if (!_dialogPerfTimingsCallbackAttached) {
+        WidgetsBinding.instance.addTimingsCallback(_collectDialogPerfTimings);
+        _dialogPerfTimingsCallbackAttached = true;
+      }
       _autoMetadataFrameTimings.clear();
       _autoMetadataStopwatch
         ..reset()

--- a/test/unit/controllers/add_note_controller_test.dart
+++ b/test/unit/controllers/add_note_controller_test.dart
@@ -42,4 +42,54 @@ void main() {
       expect(controller.originalLongitude, isNull);
     });
   });
+
+  group('AddNoteController 自动附加抓取标志', () {
+    test('armAutoMetadataFetch 预约后 isFetchingMetadata 立即为真', () {
+      final controller = AddNoteController(context: FakeBuildContext());
+      var notified = 0;
+      controller.addListener(() => notified++);
+
+      controller.armAutoMetadataFetch(location: true, weather: true);
+
+      expect(controller.isFetchingLocation, isTrue);
+      expect(controller.isFetchingWeather, isTrue);
+      expect(controller.isFetchingMetadata, isTrue);
+      expect(notified, 1);
+    });
+
+    test('armAutoMetadataFetch 状态没变时不通知', () {
+      final controller = AddNoteController(context: FakeBuildContext());
+      var notified = 0;
+      controller.addListener(() => notified++);
+
+      controller.armAutoMetadataFetch(location: false, weather: false);
+
+      expect(notified, 0);
+    });
+
+    test('服务缺失时抓取会放掉预约标志，避免保存白等', () async {
+      final controller = AddNoteController(context: FakeBuildContext())
+        ..armAutoMetadataFetch(location: true, weather: true);
+
+      await controller.fetchLocationForNewNote();
+      expect(controller.isFetchingLocation, isFalse);
+      expect(controller.isFetchingWeather, isTrue);
+
+      await controller.fetchWeatherForNewNote();
+      expect(controller.isFetchingWeather, isFalse);
+      expect(controller.isFetchingMetadata, isFalse);
+    });
+
+    test('用户主动移除位置/天气时清掉在途标志', () {
+      final controller = AddNoteController(context: FakeBuildContext())
+        ..armAutoMetadataFetch(location: true, weather: true);
+
+      controller.removeNewLocation();
+      expect(controller.isFetchingLocation, isFalse);
+
+      controller.removeNewWeather();
+      expect(controller.includeWeather, isFalse);
+      expect(controller.isFetchingWeather, isFalse);
+    });
+  });
 }

--- a/test/unit/controllers/add_note_controller_test.dart
+++ b/test/unit/controllers/add_note_controller_test.dart
@@ -67,16 +67,22 @@ void main() {
       expect(notified, 0);
     });
 
-    test('服务缺失时抓取会放掉预约标志，避免保存白等', () async {
+    test('服务缺失时按失败处理：放掉标志并取消勾选，不留虚假的已附加状态', () async {
       final controller = AddNoteController(context: FakeBuildContext())
+        ..includeLocation = true
+        ..includeWeather = true
         ..armAutoMetadataFetch(location: true, weather: true);
 
       await controller.fetchLocationForNewNote();
       expect(controller.isFetchingLocation, isFalse);
+      expect(controller.includeLocation, isFalse,
+          reason: '拿不到位置服务就不该保留「已附加位置」的勾');
       expect(controller.isFetchingWeather, isTrue);
 
       await controller.fetchWeatherForNewNote();
       expect(controller.isFetchingWeather, isFalse);
+      expect(controller.includeWeather, isFalse,
+          reason: '拿不到天气服务时保留勾选，保存会把上一次的天气写进这条笔记');
       expect(controller.isFetchingMetadata, isFalse);
     });
 

--- a/test/widget/add_note_dialog_auto_metadata_test.dart
+++ b/test/widget/add_note_dialog_auto_metadata_test.dart
@@ -30,8 +30,10 @@ Position _beijingPosition() => Position(
     );
 
 class _TestSettingsService extends ChangeNotifier implements SettingsService {
+  _TestSettingsService({this.autoAttachLocation = true});
+
   @override
-  bool get autoAttachLocation => true;
+  final bool autoAttachLocation;
 
   @override
   bool get autoAttachWeather => true;
@@ -66,6 +68,9 @@ class _TestSettingsService extends ChangeNotifier implements SettingsService {
 
 /// 定位要 200ms 才回来——用户完全可能在这之前就点保存。
 class _SlowLocationService extends ChangeNotifier implements LocationService {
+  _SlowLocationService({Position? initialPosition})
+      : _position = initialPosition;
+
   Position? _position;
 
   @override
@@ -118,6 +123,39 @@ class _SlowWeatherService extends ChangeNotifier implements WeatherService {
 
   @override
   String get temperature => _hasData ? '25°C' : '';
+
+  @override
+  String getFormattedWeather(AppLocalizations l10n) => 'clear 25°C';
+
+  @override
+  IconData getWeatherIconData() => Icons.wb_sunny;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// 天气立刻就有数据，用来构造「用户手动勾上又移除」的场景。
+class _InstantWeatherService extends ChangeNotifier implements WeatherService {
+  var fetchCount = 0;
+
+  @override
+  Future<void> getWeatherData(
+    double latitude,
+    double longitude, {
+    bool forceRefresh = false,
+    Duration? timeout,
+  }) async {
+    fetchCount++;
+  }
+
+  @override
+  bool get hasData => true;
+
+  @override
+  String get currentWeather => 'clear';
+
+  @override
+  String get temperature => '25°C';
 
   @override
   String getFormattedWeather(AppLocalizations l10n) => 'clear 25°C';
@@ -203,7 +241,9 @@ void main() {
     await TestHarness.initialize();
   });
 
-  tearDown(() {
+  // 用 tearDownAll：UnifiedLogService 是单例，逐个用例 dispose 会让后面的用例
+  // 用到一个已经销毁的实例。
+  tearDownAll(() {
     UnifiedLogService.instance.dispose();
   });
 
@@ -254,6 +294,54 @@ void main() {
     expect(saved!.temperature, '25°C');
     expect(saved!.latitude, 39.9042);
     expect(saved!.location, '中国,北京市,北京市,朝阳区');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 600));
+  });
+
+  testWidgets('抓取开始前用户移除天气：保存时不会被自动附加计划加回来', (WidgetTester tester) async {
+    Quote? saved;
+    final weather = _InstantWeatherService();
+
+    await tester.pumpWidget(
+      _buildApp(
+        // 只预约天气，把变量收敛到一条线上
+        settings: _TestSettingsService(autoAttachLocation: false),
+        // 天气要有坐标才抓得动，这里给一个已缓存的位置
+        location: _SlowLocationService(initialPosition: _beijingPosition()),
+        weather: weather,
+        onSave: (quote) => saved = quote,
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // 兜底定时器还没到，自动附加一次都没跑；用户自己先勾上天气
+    final weatherChip = find.byKey(const ValueKey('add_note_weather_chip'));
+    await tester.tap(weatherChip);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(weather.fetchCount, 1);
+
+    // 再点一次打开详情对话框，明确移除。
+    // 这里用固定小步 pump 而不是 pumpAndSettle：整段必须压在兜底定时器（900ms）之前，
+    // 否则自动附加会先跑起来，测的就不是「抓取开始前移除」这个场景了。
+    await tester.tap(weatherChip);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.tap(find.text('移除'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    await tester.tap(find.byType(FilledButton).last);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(saved, isNotNull);
+    expect(saved!.weather, isNull, reason: '用户明确移除的天气不该在保存时被静默加回');
+    expect(weather.fetchCount, 1, reason: '不该为已取消的附加再发一次请求');
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump(const Duration(milliseconds: 600));

--- a/test/widget/add_note_dialog_auto_metadata_test.dart
+++ b/test/widget/add_note_dialog_auto_metadata_test.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:provider/provider.dart';
+import 'package:thoughtecho/gen_l10n/app_localizations.dart';
+import 'package:thoughtecho/models/app_settings.dart';
+import 'package:thoughtecho/models/local_ai_settings.dart';
+import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/services/database_service.dart';
+import 'package:thoughtecho/services/feature_guide_service.dart';
+import 'package:thoughtecho/services/location_service.dart';
+import 'package:thoughtecho/services/settings_service.dart';
+import 'package:thoughtecho/services/unified_log_service.dart';
+import 'package:thoughtecho/services/weather_service.dart';
+import 'package:thoughtecho/widgets/add_note_dialog.dart';
+
+import '../test_harness.dart';
+
+Position _beijingPosition() => Position(
+      longitude: 116.4074,
+      latitude: 39.9042,
+      timestamp: DateTime(2026, 1, 1),
+      accuracy: 0.0,
+      altitude: 0.0,
+      altitudeAccuracy: 0.0,
+      heading: 0.0,
+      headingAccuracy: 0.0,
+      speed: 0.0,
+      speedAccuracy: 0.0,
+    );
+
+class _TestSettingsService extends ChangeNotifier implements SettingsService {
+  @override
+  bool get autoAttachLocation => true;
+
+  @override
+  bool get autoAttachWeather => true;
+
+  @override
+  String? get defaultAuthor => null;
+
+  @override
+  String? get defaultSource => null;
+
+  @override
+  List<String> get defaultTagIds => const [];
+
+  @override
+  AppSettings get appSettings => AppSettings(developerMode: false);
+
+  @override
+  bool get enableFirstOpenScrollPerfMonitor => false;
+
+  @override
+  LocalAISettings get localAISettings => const LocalAISettings();
+
+  @override
+  bool get addNoteDialogDeferAutoMetadata => false;
+
+  @override
+  bool get addNoteDialogAutoFocus => false;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// 定位要 200ms 才回来——用户完全可能在这之前就点保存。
+class _SlowLocationService extends ChangeNotifier implements LocationService {
+  Position? _position;
+
+  @override
+  bool get hasLocationPermission => true;
+
+  @override
+  bool get isLocationServiceEnabled => true;
+
+  @override
+  Position? get currentPosition => _position;
+
+  @override
+  Future<Position?> getCurrentLocation({
+    bool highAccuracy = false,
+    bool skipPermissionRequest = false,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    _position = _beijingPosition();
+    return _position;
+  }
+
+  @override
+  String getFormattedLocation() => '中国,北京市,北京市,朝阳区';
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// 天气在定位之后才开始抓，再花 300ms——两次抓取之间正是元数据被丢掉的窗口。
+class _SlowWeatherService extends ChangeNotifier implements WeatherService {
+  bool _hasData = false;
+
+  @override
+  Future<void> getWeatherData(
+    double latitude,
+    double longitude, {
+    bool forceRefresh = false,
+    Duration? timeout,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    _hasData = true;
+    notifyListeners();
+  }
+
+  @override
+  bool get hasData => _hasData;
+
+  @override
+  String get currentWeather => _hasData ? 'clear' : '';
+
+  @override
+  String get temperature => _hasData ? '25°C' : '';
+
+  @override
+  String getFormattedWeather(AppLocalizations l10n) => 'clear 25°C';
+
+  @override
+  IconData getWeatherIconData() => Icons.wb_sunny;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestDatabaseService extends ChangeNotifier implements DatabaseService {
+  @override
+  Future<Quote?> getQuoteById(String id, {bool includeDeleted = false}) async =>
+      null;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestFeatureGuideService extends ChangeNotifier
+    implements FeatureGuideService {
+  @override
+  bool hasShown(String guideId) => true;
+
+  @override
+  bool hasShownAll(List<String> guideIds) => true;
+
+  @override
+  bool hasShownAny(List<String> guideIds) => true;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _buildApp({
+  required SettingsService settings,
+  required LocationService location,
+  required WeatherService weather,
+  required void Function(Quote) onSave,
+}) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<SettingsService>.value(value: settings),
+      ChangeNotifierProvider<LocationService>.value(value: location),
+      ChangeNotifierProvider<WeatherService>.value(value: weather),
+      ChangeNotifierProvider<DatabaseService>.value(
+        value: _TestDatabaseService(),
+      ),
+      ChangeNotifierProvider<FeatureGuideService>.value(
+        value: _TestFeatureGuideService(),
+      ),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('zh'),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showDialog<void>(
+              context: context,
+              builder: (_) => Dialog(
+                child: AddNoteDialog(
+                  tags: const [],
+                  prefilledContent: '测试内容',
+                  onSave: onSave,
+                ),
+              ),
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await TestHarness.initialize();
+  });
+
+  tearDown(() {
+    UnifiedLogService.instance.dispose();
+  });
+
+  testWidgets('抓取还没开始就点保存：转圈等到位置和天气都到手', (WidgetTester tester) async {
+    Quote? saved;
+
+    await tester.pumpWidget(
+      _buildApp(
+        settings: _TestSettingsService(),
+        location: _SlowLocationService(),
+        weather: _SlowWeatherService(),
+        onSave: (quote) => saved = quote,
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pump();
+    // 兜底定时器（900ms）都还没到，抓取一次都没跑起来。
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // 用位置定位保存按钮：等待中它的文案会换成转圈，按文案找会找不到。
+    final saveButton = find.byType(FilledButton).last;
+    expect(find.descendant(of: saveButton, matching: find.text('保存')),
+        findsOneWidget);
+    await tester.tap(saveButton);
+    await tester.pump();
+
+    // 等待中：保存按钮换成转圈并禁用
+    expect(
+      find.descendant(
+        of: saveButton,
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsOneWidget,
+    );
+    expect(tester.widget<FilledButton>(saveButton).onPressed, isNull);
+    expect(saved, isNull);
+
+    // 定位 200ms + 天气 300ms，中间那段窗口不能被当成「已经抓完」
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(saved, isNull, reason: '位置刚到手、天气还没抓，不该提前落库');
+
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pump();
+
+    expect(saved, isNotNull);
+    expect(saved!.weather, 'clear');
+    expect(saved!.temperature, '25°C');
+    expect(saved!.latitude, 39.9042);
+    expect(saved!.location, '中国,北京市,北京市,朝阳区');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 600));
+  });
+}

--- a/test/widget/widgets/add_note_dialog_test.dart
+++ b/test/widget/widgets/add_note_dialog_test.dart
@@ -14,7 +14,7 @@ import 'package:thoughtecho/services/unified_log_service.dart';
 import 'package:thoughtecho/services/weather_service.dart';
 import 'package:thoughtecho/widgets/add_note_dialog.dart';
 
-import '../test_harness.dart';
+import '../../test_harness.dart';
 
 Position _beijingPosition() => Position(
       longitude: 116.4074,
@@ -342,6 +342,45 @@ void main() {
     expect(saved, isNotNull);
     expect(saved!.weather, isNull, reason: '用户明确移除的天气不该在保存时被静默加回');
     expect(weather.fetchCount, 1, reason: '不该为已取消的附加再发一次请求');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 600));
+  });
+
+  testWidgets('定位途中取消勾选位置：保存不再空等这次已经不要的请求', (WidgetTester tester) async {
+    Quote? saved;
+
+    await tester.pumpWidget(
+      _buildApp(
+        settings: _TestSettingsService(),
+        location: _SlowLocationService(),
+        weather: _SlowWeatherService(),
+        onSave: (quote) => saved = quote,
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // 手动勾上位置，定位要 200ms 才回来
+    final locationChip = find.byKey(const ValueKey('add_note_location_chip'));
+    await tester.tap(locationChip);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    // 还没拿到坐标就取消勾选：此时弹窗分支进不去，只会改勾选状态
+    await tester.tap(locationChip);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 20));
+
+    await tester.tap(find.byType(FilledButton).last);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 20));
+
+    expect(saved, isNotNull, reason: '取消掉的定位不该再把保存拖住');
+    expect(saved!.latitude, isNull);
+    expect(saved!.location, isNull);
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump(const Duration(milliseconds: 600));


### PR DESCRIPTION
## 问题

偏好里开了「自动附加位置/天气」，在非全屏编辑器里写完就点保存，天气可能不会被附上——而保存按钮那圈 loading 看起来是等过了的。

保存靠 `isFetchingMetadata = isFetchingLocation || isFetchingWeather` 决定要不要转圈等，这个标志有三处空窗，正好落在用户点保存的时机上：

1. **位置抓完到天气开抓之间**，`isFetchingWeather` 是 `false`。位置和天气是串行的（天气要用位置的坐标），位置一回来 `_waitForMetadata` 就认为元数据齐了，直接落库退出，天气还没开始抓就被丢掉。
2. 延迟启动前先把两个标志清零，中间这段点保存同样不等。
3. 预置标志只覆盖了偏好设置这一条路径，**AI 预填充和每日一言快速添加从头就没预置过**。

## 改动

- `initState` 一次性算出自动附加计划（偏好 / `prefilledIncludeLocation·Weather` / AI 预填充），当场把「获取中」标志立起来，直到整条位置→天气链路真正结束才放掉。
- 反过来，服务缺失、位置失败拿不到坐标、用户主动移除位置/天气这些「不会再抓了」的分支各自清标志，避免保存白转到 5s 超时才放行。
- 抓取本身从「首帧后 300ms」挪到**键盘 inset 稳定之后**（兜底 900ms，实验开关 `addNoteDialogDeferAutoMetadata` 仍为 1500ms）。定位、地址反查、天气请求都走平台通道和网络，原来正好压在入场 + 键盘动画中间。因为标志从 `initState` 就立着，推迟不会让元数据丢失；用户提前点保存会立刻把抓取踢起来再转圈等，不会白等定时器。
- 抓取推迟后服务引用可能还没缓存，位置/天气按钮、重试、地址更新等入口统一走 `_ensureMetadataServices()`，否则 fetch 会因为 service 为 null 直接空转（这个问题在原来的 300ms 窗口里也存在）。
- `HomeNoteEditorActions.add()`：标签已在内存时不再为开窗多等一次数据库查询，`edit()` 一直就是这么做的。

## 验证

新增回归测试 `test/widget/add_note_dialog_auto_metadata_test.dart`：定位 200ms、天气 300ms，开窗 50ms 就点保存。改动前保存下来的 `quote.weather` 是 `''`，改动后是 `'clear'`，中途还断言了「位置刚到手、天气没抓」时不能提前落库。

`test/unit/controllers/add_note_controller_test.dart` 补了预约标志的通知语义、服务缺失时的放行、用户移除时的清标志。

- `flutter analyze lib/` 干净（只剩一处未改动文件里的 `cacheExtent` 废弃提示）
- 相关 57 个测试全过：`add_note_dialog_*`、`keyboard_inset_padding`、`home_note_editor_actions`、`note_editor_draft_behavior`、`unit/controllers`

## 不在本次范围

打开时的首帧构建（实测 124ms，是这次抓到的最重的一帧）没动。`_deferredControlsVisible` 目前初始为 `true`，两阶段挂载实际是空转的；重新启用能砍首帧，但弹窗高度会在入场动画后跳一下，且有测试锁着当前行为，留作单独讨论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128VUSSxRYe4VxcBPNARSiv

---
_Generated by [Claude Code](https://claude.ai/code/session_0128VUSSxRYe4VxcBPNARSiv)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复非全屏编辑器保存时漏附加天气的问题，并把位置/天气自动附加移出入场/键盘动画期；保存会按计划等到结果或在不可用时明确放弃，避免卡顿与误写元数据。

- **Bug Fixes**
  - 在 `initState` 计算自动附加计划并 `arm` 获取中标志，整条位置→天气链路结束后再清，保存不再漏天气。
  - 服务缺失/无坐标/用户移除时，同步取消勾选并清在途标志，避免把旧天气写进无坐标的笔记；chip 取消勾选改走 `removeNewLocation`/`removeNewWeather`，保存不再空等已取消的请求。
  - 抓取前用户移除会作废自动附加计划，保存不再被静默加回；入口统一走 `_ensureMetadataServices()`，保存前未启动会立刻触发并等待。新增用例覆盖抓取未启前保存、抓取前移除、定位途中取消再保存。

- **Performance**
  - 自动抓取改为在键盘 inset 稳定后启动，兜底 900ms（实验 1500ms）；数据库监听延后注册，避开入场/键盘动画。
  - 新增自动附加阶段帧耗时与结果日志，拆出主体 Widget 构造耗时；两段采样共用帧回调并在两段都结束后再摘，`dispose` 中同步清标志。
  - `HomeNoteEditorActions.add()` 始终等待 `loadTags()`，确保标签最新。

<sup>Written for commit 5c573ffb12ca8f0e7c63c2dfde03fd515db488d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新建笔记时自动获取位置和天气信息，并在保存前等待抓取完成。
  - 抓取期间显示进度状态，支持取消自动附加。
  - 无可用服务或抓取失败时，自动清理相关选项和过期数据。

- **问题修复**
  - 修复用户移除位置或天气后仍被重新添加的问题。
  - 避免保存流程因无法执行的元数据抓取而持续等待。

- **测试**
  - 新增自动位置、天气抓取及保存流程的控制器和界面测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->