### PR TITLE
fix(note-list): 刷新不再把已加载的列表塌回第一页，底部指示器不再卡住

### DIFF
--- a/integration_test/note_list_performance_test.dart
+++ b/integration_test/note_list_performance_test.dart
@@ -132,6 +132,8 @@ class _PerformanceDatabaseService extends DatabaseService {
     List<String>? selectedWeathers,
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
+    int? refillCount,
+    List<Quote>? skipNotifyIfSameAs,
   }) async {}
 
   @override

--- a/integration_test/note_list_performance_test.dart
+++ b/integration_test/note_list_performance_test.dart
@@ -133,7 +133,7 @@ class _PerformanceDatabaseService extends DatabaseService {
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
     int? refillCount,
-    List<Quote>? skipNotifyIfSameAs,
+    bool suppressNotify = false,
   }) async {}
 
   @override

--- a/lib/services/database/database_pagination_mixin.dart
+++ b/lib/services/database/database_pagination_mixin.dart
@@ -89,6 +89,8 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     // 位置夹紧，正是这个 PR 要修的塌陷。保留 UI 上那份更长（略旧）的列表，
     // 并保住回填目标，等下一次刷新继续补齐。
     // 注意只在失败时这么做：正常取完发现变短是真实的删除，必须如实推送。
+    // 这条保护依赖 loadMoreQuotes 在 suppressNotify 时把所有错误都抛出来，
+    // 否则被吞掉的错误会伪装成"取完了"，仍然推出截断列表。
     if (failed && _currentQuotes.length < previousQuotes.length) {
       logDebug(
         '刷新回填未取满（${_currentQuotes.length}/${previousQuotes.length}），'
@@ -550,8 +552,11 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
         _safeNotifyQuotesStream();
       }
 
-      // 如果是超时错误，重新抛出让UI处理
-      if (e is TimeoutException) {
+      // 回填期间必须把**所有**错误交出去：_refillAfterRefresh 要靠异常判断
+      // 「保留旧列表」还是「如实推送」。只 rethrow 超时的话，SQLite 异常、
+      // 反序列化失败等会被这里吞掉、正常返回，回填便误以为成功，
+      // 截断后的列表照样推给 UI —— 列表塌缩的保护就形同虚设。
+      if (suppressNotify || e is TimeoutException) {
         rethrow;
       }
     } finally {

--- a/lib/services/database/database_pagination_mixin.dart
+++ b/lib/services/database/database_pagination_mixin.dart
@@ -54,22 +54,48 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     required List<Quote> previousQuotes,
   }) async {
     final generation = _quotesLoadGeneration;
+    var failed = false;
 
     while (_currentQuotes.length < targetCount &&
         _watchHasMore &&
         !_isDisposed &&
         generation == _quotesLoadGeneration) {
       final before = _currentQuotes.length;
-      await loadMoreQuotes(
-        refillCount: targetCount - before,
-        suppressNotify: true,
-      );
-      // 没有新增说明查询失败或结果被去重光了，再循环就是死循环。
+      try {
+        await loadMoreQuotes(
+          refillCount: targetCount - before,
+          suppressNotify: true,
+        );
+      } catch (e, stackTrace) {
+        // 查询失败/超时。loadMoreQuotes 对超时会 rethrow，这里必须接住，
+        // 否则 unawaited 的回填会变成未处理的异步异常。
+        failed = true;
+        logError(
+          '刷新回填失败: $e',
+          error: e,
+          stackTrace: stackTrace,
+          source: 'DatabaseService',
+        );
+        break;
+      }
+      // 没有新增说明结果被去重光了，再循环就是死循环。
       if (_currentQuotes.length <= before) break;
     }
 
     // 期间又来了一次刷新：由那一次负责推送，这里直接退场。
     if (_isDisposed || generation != _quotesLoadGeneration) return;
+
+    // 回填因失败中断且没取够：**不要推**。推出去的短列表会把用户正滑到的
+    // 位置夹紧，正是这个 PR 要修的塌陷。保留 UI 上那份更长（略旧）的列表，
+    // 并保住回填目标，等下一次刷新继续补齐。
+    // 注意只在失败时这么做：正常取完发现变短是真实的删除，必须如实推送。
+    if (failed && _currentQuotes.length < previousQuotes.length) {
+      logDebug(
+        '刷新回填未取满（${_currentQuotes.length}/${previousQuotes.length}），'
+        '跳过推送以免列表塌缩',
+      );
+      return;
+    }
 
     _pendingRefillTarget = 0;
 
@@ -348,6 +374,9 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
       _watchOffset = 0;
       _currentQuotes = [];
       _currentQuoteIds.clear(); // 性能优化：同步清空 ID Set
+      // 换了筛选条件，旧结果集的回填目标不再适用，留着会让下一次刷新
+      // 按旧条数超量加载。
+      _pendingRefillTarget = 0;
       _isLoading = false;
       _quotesLoadGeneration++;
       _watchHasMore = true; // 重置分页状态
@@ -514,8 +543,12 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
         return;
       }
       logError('加载更多笔记失败: $e', error: e, source: 'DatabaseService');
-      // 确保即使出错也通知UI，避免无限加载状态
-      _safeNotifyQuotesStream();
+      // 确保即使出错也通知UI，避免无限加载状态。
+      // 但分块回填期间不推：半成品比原列表更短，推出去就是一次列表塌缩，
+      // 失败后的最终状态由 _refillAfterRefresh 统一决定。
+      if (!suppressNotify) {
+        _safeNotifyQuotesStream();
+      }
 
       // 如果是超时错误，重新抛出让UI处理
       if (e is TimeoutException) {

--- a/lib/services/database/database_pagination_mixin.dart
+++ b/lib/services/database/database_pagination_mixin.dart
@@ -52,6 +52,7 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
   Future<void> _refillAfterRefresh({
     required int targetCount,
     required List<Quote> previousQuotes,
+    required bool previousHasMore,
   }) async {
     final generation = _quotesLoadGeneration;
     var failed = false;
@@ -106,7 +107,10 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
         ..clear()
         ..addAll(previousQuotes.map((quote) => quote.id).whereType<String>());
       _watchOffset = _currentQuotes.length;
-      _watchHasMore = true;
+      // 连分页游标一起复原：刷新前如果已经翻到底（_watchHasMore == false），
+      // 无条件写 true 会让列表重新显示"还有下一页"，用户滑到底还会看到
+      // 一次注定取不到东西的转圈。
+      _watchHasMore = previousHasMore;
       // 状态已经复原，下一次刷新可以直接按 _currentQuotes.length 算目标。
       _pendingRefillTarget = 0;
       return;
@@ -166,6 +170,8 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
       // 就是一次明显的卡顿。回收站过期清理、同步后的例行刷新等场景，
       // 可见列表其实一条都没变。
       final List<Quote> previousQuotes = List<Quote>.from(_currentQuotes);
+      // 回填失败要整体回滚时，分页游标也得跟着回到刷新前的样子。
+      final bool previousHasMore = _watchHasMore;
       logDebug('刷新笔记流数据，需回填 $reloadCount 条');
       // 优化：清除所有缓存，确保获取最新数据
       clearAllCacheForParts();
@@ -184,6 +190,7 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
         _refillAfterRefresh(
           targetCount: reloadCount,
           previousQuotes: previousQuotes,
+          previousHasMore: previousHasMore,
         ),
       );
     } else {

--- a/lib/services/database/database_pagination_mixin.dart
+++ b/lib/services/database/database_pagination_mixin.dart
@@ -2,30 +2,83 @@ part of '../database_service.dart';
 
 /// Mixin providing pagination and stream operations for DatabaseService.
 mixin _DatabasePaginationMixin on _DatabaseServiceBase {
-  /// 刷新回填单次查询的条数上限：超过这个量级的列表极少见，
-  /// 与其把一次刷新变成慢查询，不如让它退回按页加载。
-  static const int _maxRefillCount = 500;
+  /// 刷新回填单次查询的条数上限。超过这个量级会分多次查询，
+  /// 既不把一次刷新拖成慢查询，也不会让列表停在更短的中间态
+  /// （全部取回后才推送，见 [_refillAfterRefresh]）。
+  static const int _maxRefillChunk = 500;
 
-  /// 判断刷新前后的可见列表是否完全一致（顺序、条目、内容都没变）。
+  /// 判断刷新前后的可见列表是否逐条完全一致。
   ///
-  /// 只要有一条 `lastModified` 为空就直接判为「不确定」，宁可多推一次也不漏掉
-  /// 真实更新——早期数据可能没有这个字段，缺了它就没法判断内容有没有动过。
+  /// 用 [Quote.toJson] 逐字段比较而不是挑几个字段：挑字段的写法一旦漏掉展示用
+  /// 的列（weather、day_period、location……）就会把真实更新误判成"没变"从而
+  /// 吞掉推送，而且新增字段时没人会记得同步这里。`toJson` 覆盖所有持久化字段，
+  /// 天然不会漏；`tagIds` 不在 `toJson` 里，单独比。
+  ///
+  /// 只在刷新路径上跑一次，不在滚动帧里，这点比较开销远小于一次整表重建。
   bool _quoteListsEquivalent(List<Quote> previous, List<Quote> current) {
     // 空列表不参与去重：首屏/清空后的刷新必须让 UI 收到事件。
     if (previous.isEmpty) return false;
     if (previous.length != current.length) return false;
     for (var i = 0; i < previous.length; i++) {
-      final a = previous[i];
-      final b = current[i];
-      if (a.lastModified == null || b.lastModified == null) return false;
-      if (a.id != b.id ||
-          a.lastModified != b.lastModified ||
-          a.favoriteCount != b.favoriteCount ||
-          a.isDeleted != b.isDeleted) {
-        return false;
-      }
+      if (!_quoteEquivalent(previous[i], current[i])) return false;
     }
     return true;
+  }
+
+  bool _quoteEquivalent(Quote a, Quote b) {
+    if (identical(a, b)) return true;
+
+    final aTags = a.tagIds;
+    final bTags = b.tagIds;
+    if (aTags.length != bTags.length) return false;
+    for (var i = 0; i < aTags.length; i++) {
+      if (aTags[i] != bTags[i]) return false;
+    }
+
+    final aJson = a.toJson();
+    final bJson = b.toJson();
+    if (aJson.length != bJson.length) return false;
+    for (final entry in aJson.entries) {
+      if (!bJson.containsKey(entry.key)) return false;
+      if (bJson[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  /// 刷新后的回填：分块把原有条数全部取回，**全部到位后才推送一次**。
+  ///
+  /// 中途不推送是关键——只要推出去一个比原来短的列表，用户正滑到的位置就会被
+  /// maxScrollExtent 夹紧，也就是这个 PR 要修的"列表突然飞走"。
+  Future<void> _refillAfterRefresh({
+    required int targetCount,
+    required List<Quote> previousQuotes,
+  }) async {
+    final generation = _quotesLoadGeneration;
+
+    while (_currentQuotes.length < targetCount &&
+        _watchHasMore &&
+        !_isDisposed &&
+        generation == _quotesLoadGeneration) {
+      final before = _currentQuotes.length;
+      await loadMoreQuotes(
+        refillCount: targetCount - before,
+        suppressNotify: true,
+      );
+      // 没有新增说明查询失败或结果被去重光了，再循环就是死循环。
+      if (_currentQuotes.length <= before) break;
+    }
+
+    // 期间又来了一次刷新：由那一次负责推送，这里直接退场。
+    if (_isDisposed || generation != _quotesLoadGeneration) return;
+
+    _pendingRefillTarget = 0;
+
+    if (_quoteListsEquivalent(previousQuotes, _currentQuotes)) {
+      logDebug('刷新后可见列表无变化，跳过整表推送');
+      return;
+    }
+
+    _safeNotifyQuotesStream();
   }
 
   /// 修复：安全地通知笔记流订阅者
@@ -57,7 +110,16 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
       // 已经滑到深处的列表会瞬间从 N 条塌回一页，maxScrollExtent 随之骤减，
       // 滚动位置被夹紧 —— 表现就是「列表突然飞走/弹回顶部 + 底部转圈 + 大片空白」。
       // 所以刷新必须一次把原有页数全部取回，列表长度保持不变。
-      final int reloadCount = _currentQuotes.length;
+      //
+      // 上一次刷新可能还在回填途中（那时 _currentQuotes 已被清空），
+      // 此时按当时的长度 0 算目标会退化成只取一页，等于把这个 bug 放回来。
+      // 沿用在途目标即可。
+      final int loadedCount = _currentQuotes.isNotEmpty
+          ? _currentQuotes.length
+          : _pendingRefillTarget;
+      // 列表本来就是空的（首屏前的刷新）：照旧取一页。
+      final int reloadCount = loadedCount > 0 ? loadedCount : _watchLimit;
+      _pendingRefillTarget = reloadCount;
       // 回填结果和刷新前一模一样时不再向 UI 推送：整表推送会让列表页
       // 重建全部已加载 item（上百次 build + 首次布局），发生在滚动帧里
       // 就是一次明显的卡顿。回收站过期清理、同步后的例行刷新等场景，
@@ -77,9 +139,11 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
       _isLoading = false;
 
       // 触发重新加载
-      loadMoreQuotes(
-        refillCount: reloadCount,
-        skipNotifyIfSameAs: previousQuotes,
+      unawaited(
+        _refillAfterRefresh(
+          targetCount: reloadCount,
+          previousQuotes: previousQuotes,
+        ),
       );
     } else {
       logDebug('笔记流无监听器或已关闭，跳过刷新');
@@ -351,7 +415,7 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
     int? refillCount,
-    List<Quote>? skipNotifyIfSameAs,
+    bool suppressNotify = false,
   }) async {
     // 使用当前观察的参数作为默认值
     tagIds ??= _watchTagIds;
@@ -370,10 +434,10 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     _isLoading = true;
     final loadGeneration = _quotesLoadGeneration;
     final requestOffset = _watchOffset;
-    // 刷新回填：一次取回原有的全部页数，避免列表在用户滚动途中变短。
-    // 上限保护，防止极深列表把单次查询拖成慢查询。
+    // 刷新回填：一次尽量多取，避免列表在用户滚动途中变短。
+    // 单次查询封顶，超出的部分由 _refillAfterRefresh 继续分块取。
     final int requestLimit = refillCount != null && refillCount > _watchLimit
-        ? (refillCount > _maxRefillCount ? _maxRefillCount : refillCount)
+        ? (refillCount > _maxRefillChunk ? _maxRefillChunk : refillCount)
         : _watchLimit;
     logDebug(
       '开始加载更多笔记，当前已有 ${_currentQuotes.length} 条，offset=$requestOffset，limit=$requestLimit',
@@ -436,11 +500,9 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
       // 通知状态变化
       notifyListeners();
 
-      if (skipNotifyIfSameAs != null &&
-          _quoteListsEquivalent(skipNotifyIfSameAs, _currentQuotes)) {
-        logDebug('刷新后可见列表无变化，跳过整表推送');
-        return;
-      }
+      // 回填分块进行时由 _refillAfterRefresh 在全部到位后统一推送：
+      // 中途推出去的短列表会把用户的滚动位置夹紧。
+      if (suppressNotify) return;
 
       // 修复：使用安全的方式通知订阅者
       _safeNotifyQuotesStream();

--- a/lib/services/database/database_pagination_mixin.dart
+++ b/lib/services/database/database_pagination_mixin.dart
@@ -85,17 +85,30 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     // 期间又来了一次刷新：由那一次负责推送，这里直接退场。
     if (_isDisposed || generation != _quotesLoadGeneration) return;
 
-    // 回填因失败中断且没取够：**不要推**。推出去的短列表会把用户正滑到的
-    // 位置夹紧，正是这个 PR 要修的塌陷。保留 UI 上那份更长（略旧）的列表，
-    // 并保住回填目标，等下一次刷新继续补齐。
+    // 回填因失败中断且没取够：**整体回滚到刷新前的状态**。
+    //
+    // 只"跳过推送"是不够的：那样 UI 还显示着 N 条，内存里的 _currentQuotes
+    // 却已被清空、_watchOffset 也归零了。接下来任何一次普通分页（空闲预取、
+    // 滚到底部的兜底加载）都会从 offset=0 取回第一页并正常推给 UI，
+    // 列表照样塌回第一页 —— 这个 PR 要修的塌陷又从后门绕了回来。
+    // 所以必须把列表、ID 集合和分页游标一起复原，让内存状态和 UI 重新一致。
+    //
     // 注意只在失败时这么做：正常取完发现变短是真实的删除，必须如实推送。
     // 这条保护依赖 loadMoreQuotes 在 suppressNotify 时把所有错误都抛出来，
     // 否则被吞掉的错误会伪装成"取完了"，仍然推出截断列表。
     if (failed && _currentQuotes.length < previousQuotes.length) {
       logDebug(
         '刷新回填未取满（${_currentQuotes.length}/${previousQuotes.length}），'
-        '跳过推送以免列表塌缩',
+        '回滚到刷新前的状态以免列表塌缩',
       );
+      _currentQuotes = List<Quote>.from(previousQuotes);
+      _currentQuoteIds
+        ..clear()
+        ..addAll(previousQuotes.map((quote) => quote.id).whereType<String>());
+      _watchOffset = _currentQuotes.length;
+      _watchHasMore = true;
+      // 状态已经复原，下一次刷新可以直接按 _currentQuotes.length 算目标。
+      _pendingRefillTarget = 0;
       return;
     }
 

--- a/lib/services/database/database_pagination_mixin.dart
+++ b/lib/services/database/database_pagination_mixin.dart
@@ -436,9 +436,11 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     final requestOffset = _watchOffset;
     // 刷新回填：一次尽量多取，避免列表在用户滚动途中变短。
     // 单次查询封顶，超出的部分由 _refillAfterRefresh 继续分块取。
-    final int requestLimit = refillCount != null && refillCount > _watchLimit
-        ? (refillCount > _maxRefillChunk ? _maxRefillChunk : refillCount)
-        : _watchLimit;
+    // refillCount 一给就照它来（只受分块上限约束）：最后一块往往小于一页，
+    // 若这时退回 _watchLimit 就会多取一整页，回填出比刷新前更长的列表。
+    final int requestLimit = refillCount == null
+        ? _watchLimit
+        : (refillCount > _maxRefillChunk ? _maxRefillChunk : refillCount);
     logDebug(
       '开始加载更多笔记，当前已有 ${_currentQuotes.length} 条，offset=$requestOffset，limit=$requestLimit',
     );

--- a/lib/services/database/database_pagination_mixin.dart
+++ b/lib/services/database/database_pagination_mixin.dart
@@ -2,6 +2,32 @@ part of '../database_service.dart';
 
 /// Mixin providing pagination and stream operations for DatabaseService.
 mixin _DatabasePaginationMixin on _DatabaseServiceBase {
+  /// 刷新回填单次查询的条数上限：超过这个量级的列表极少见，
+  /// 与其把一次刷新变成慢查询，不如让它退回按页加载。
+  static const int _maxRefillCount = 500;
+
+  /// 判断刷新前后的可见列表是否完全一致（顺序、条目、内容都没变）。
+  ///
+  /// 只要有一条 `lastModified` 为空就直接判为「不确定」，宁可多推一次也不漏掉
+  /// 真实更新——早期数据可能没有这个字段，缺了它就没法判断内容有没有动过。
+  bool _quoteListsEquivalent(List<Quote> previous, List<Quote> current) {
+    // 空列表不参与去重：首屏/清空后的刷新必须让 UI 收到事件。
+    if (previous.isEmpty) return false;
+    if (previous.length != current.length) return false;
+    for (var i = 0; i < previous.length; i++) {
+      final a = previous[i];
+      final b = current[i];
+      if (a.lastModified == null || b.lastModified == null) return false;
+      if (a.id != b.id ||
+          a.lastModified != b.lastModified ||
+          a.favoriteCount != b.favoriteCount ||
+          a.isDeleted != b.isDeleted) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /// 修复：安全地通知笔记流订阅者
   /// 性能优化：由于 _currentQuotes 已通过 _currentQuoteIds 保证唯一性，
   /// 此处直接发送，无需再次遍历去重
@@ -26,7 +52,18 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
   @override
   void _refreshQuotesStream() {
     if (_quotesController != null && !_quotesController!.isClosed) {
-      logDebug('刷新笔记流数据');
+      // 刷新前记住已经加载出来的条数：任何一次数据变更（保存笔记、收藏、
+      // 位置回填、回收站清理、同步导入……）都会走到这里，若只重新取回第一页，
+      // 已经滑到深处的列表会瞬间从 N 条塌回一页，maxScrollExtent 随之骤减，
+      // 滚动位置被夹紧 —— 表现就是「列表突然飞走/弹回顶部 + 底部转圈 + 大片空白」。
+      // 所以刷新必须一次把原有页数全部取回，列表长度保持不变。
+      final int reloadCount = _currentQuotes.length;
+      // 回填结果和刷新前一模一样时不再向 UI 推送：整表推送会让列表页
+      // 重建全部已加载 item（上百次 build + 首次布局），发生在滚动帧里
+      // 就是一次明显的卡顿。回收站过期清理、同步后的例行刷新等场景，
+      // 可见列表其实一条都没变。
+      final List<Quote> previousQuotes = List<Quote>.from(_currentQuotes);
+      logDebug('刷新笔记流数据，需回填 $reloadCount 条');
       // 优化：清除所有缓存，确保获取最新数据
       clearAllCacheForParts();
 
@@ -40,7 +77,10 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
       _isLoading = false;
 
       // 触发重新加载
-      loadMoreQuotes();
+      loadMoreQuotes(
+        refillCount: reloadCount,
+        skipNotifyIfSameAs: previousQuotes,
+      );
     } else {
       logDebug('笔记流无监听器或已关闭，跳过刷新');
     }
@@ -206,7 +246,6 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     }
 
     // 更新当前的筛选参数
-    _watchOffset = 0;
     _watchLimit = limit;
     _watchTagIds = tagIds;
     _watchCategoryId = categoryId;
@@ -238,6 +277,11 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
       _quotesController = StreamController<List<Quote>>.broadcast();
 
       // 修复：在重置状态时确保原子性操作，避免竞态条件
+      // 注意：_watchOffset 只能在这里（真正重建流、清空 _currentQuotes 时）归零。
+      // 复用已有流的分支若也归零，下一次 loadMoreQuotes 会重新查第一页，
+      // 结果全是重复数据被去重掉——列表一条都不增长，_watchHasMore 却被
+      // 重新置回 true，底部加载指示器就此常驻并反复触发无效分页。
+      _watchOffset = 0;
       _currentQuotes = [];
       _currentQuoteIds.clear(); // 性能优化：同步清空 ID Set
       _isLoading = false;
@@ -306,6 +350,8 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     List<String>? selectedWeathers,
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
+    int? refillCount,
+    List<Quote>? skipNotifyIfSameAs,
   }) async {
     // 使用当前观察的参数作为默认值
     tagIds ??= _watchTagIds;
@@ -324,8 +370,13 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
     _isLoading = true;
     final loadGeneration = _quotesLoadGeneration;
     final requestOffset = _watchOffset;
+    // 刷新回填：一次取回原有的全部页数，避免列表在用户滚动途中变短。
+    // 上限保护，防止极深列表把单次查询拖成慢查询。
+    final int requestLimit = refillCount != null && refillCount > _watchLimit
+        ? (refillCount > _maxRefillCount ? _maxRefillCount : refillCount)
+        : _watchLimit;
     logDebug(
-      '开始加载更多笔记，当前已有 ${_currentQuotes.length} 条，offset=$requestOffset，limit=$_watchLimit',
+      '开始加载更多笔记，当前已有 ${_currentQuotes.length} 条，offset=$requestOffset，limit=$requestLimit',
     );
 
     try {
@@ -333,7 +384,7 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
         tagIds: tagIds,
         categoryId: categoryId,
         offset: requestOffset,
-        limit: _watchLimit,
+        limit: requestLimit,
         orderBy: _watchOrderBy,
         searchQuery: searchQuery,
         selectedWeathers: selectedWeathers,
@@ -379,11 +430,17 @@ mixin _DatabasePaginationMixin on _DatabaseServiceBase {
         }
 
         // 简化：统一的_watchHasMore判断逻辑
-        _watchHasMore = quotes.length >= _watchLimit;
+        _watchHasMore = quotes.length >= requestLimit;
       }
 
       // 通知状态变化
       notifyListeners();
+
+      if (skipNotifyIfSameAs != null &&
+          _quoteListsEquivalent(skipNotifyIfSameAs, _currentQuotes)) {
+        logDebug('刷新后可见列表无变化，跳过整表推送');
+        return;
+      }
 
       // 修复：使用安全的方式通知订阅者
       _safeNotifyQuotesStream();

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -192,7 +192,7 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
     int? refillCount,
-    List<Quote>? skipNotifyIfSameAs,
+    bool suppressNotify = false,
   });
 
   Future<void> importDataFromMap(
@@ -408,6 +408,11 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
   int _watchOffset = 0;
   bool _watchHasMore = true;
   String? _watchSearchQuery;
+
+  /// 刷新回填的目标条数。刷新会先清空 `_currentQuotes`，若此时又来一次刷新，
+  /// 按当时的列表长度（0）算目标就会退化成只取一页，正是要修的列表塌陷。
+  /// 记住在途目标，让后来的刷新沿用它。
+  int _pendingRefillTarget = 0;
 
   /// 查询缓存，统一管理过期清理逻辑。
   final ExpiringCache<String, List<Quote>> _filterCache = ExpiringCache(

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -184,6 +184,13 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
     List<String>? selectedDayPeriods,
     bool includeDeleted = false,
   });
+  /// 取下一页笔记并追加到当前列表。
+  ///
+  /// [refillCount] 覆盖本次查询的条数（仅受单次分块上限约束），供刷新回填按
+  /// 「刷新前已加载多少」一次取回，避免列表在用户滚动途中变短。不传则按页大小取。
+  ///
+  /// [suppressNotify] 抑制本次的列表流推送，供分块回填在全部到位后再统一推送
+  /// ——中途推出去的短列表会把滚动位置夹紧。抑制期间调用方必须自行负责最终推送。
   Future<void> loadMoreQuotes({
     List<String>? tagIds,
     String? categoryId,

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -184,6 +184,7 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
     List<String>? selectedDayPeriods,
     bool includeDeleted = false,
   });
+
   /// 取下一页笔记并追加到当前列表。
   ///
   /// [refillCount] 覆盖本次查询的条数（仅受单次分块上限约束），供刷新回填按

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -191,6 +191,8 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
     List<String>? selectedWeathers,
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
+    int? refillCount,
+    List<Quote>? skipNotifyIfSameAs,
   });
 
   Future<void> importDataFromMap(

--- a/lib/utils/optimized_image_loader.dart
+++ b/lib/utils/optimized_image_loader.dart
@@ -18,6 +18,10 @@ ImageProvider? createOptimizedImageProvider(
   );
 }
 
+/// 把逻辑显示尺寸换算成解码用的设备像素尺寸，见 [decodeDimensionFor]。
+int? decodeSizeFor(double logicalSize, double pixelRatio) =>
+    decodeDimensionFor(logicalSize, pixelRatio);
+
 bool isInlineDataImage(String source) => isDataUrl(source);
 
 Uint8List? decodeInlineImageBytes(String source) => tryDecodeDataUrl(source);

--- a/lib/utils/optimized_image_loader.dart
+++ b/lib/utils/optimized_image_loader.dart
@@ -22,6 +22,9 @@ ImageProvider? createOptimizedImageProvider(
 int? decodeSizeFor(double logicalSize, double pixelRatio) =>
     decodeDimensionFor(logicalSize, pixelRatio);
 
+/// 由解码宽度推出总像素预算下的高度上限，见 [decodeHeightBudgetFor]。
+int? decodeHeightBudget(int? decodeWidth) => decodeHeightBudgetFor(decodeWidth);
+
 bool isInlineDataImage(String source) => isDataUrl(source);
 
 Uint8List? decodeInlineImageBytes(String source) => tryDecodeDataUrl(source);

--- a/lib/utils/optimized_image_loader_base.dart
+++ b/lib/utils/optimized_image_loader_base.dart
@@ -26,6 +26,30 @@ ImageProvider wrapWithDecodeLimit(
   );
 }
 
+/// 解码尺寸的下限与上限（设备像素）。
+///
+/// 下限避免极窄容器把图解成马赛克；上限避免超大图把单张解码撑爆。
+const int minDecodeDimension = 160;
+const int maxDecodeDimension = 2048;
+
+/// 把「逻辑显示尺寸 × 像素比」换算成解码用的设备像素尺寸。
+///
+/// 尺寸非法（0、负数、NaN、无穷）时返回 null，表示不设解码上限、按原图解。
+int? decodeDimensionFor(double logicalSize, double pixelRatio) {
+  if (!logicalSize.isFinite || logicalSize <= 0) {
+    return null;
+  }
+
+  final double devicePixels = logicalSize * pixelRatio;
+  if (!devicePixels.isFinite || devicePixels <= 0) {
+    return null;
+  }
+
+  if (devicePixels < minDecodeDimension) return minDecodeDimension;
+  if (devicePixels > maxDecodeDimension) return maxDecodeDimension;
+  return devicePixels.round();
+}
+
 bool isDataUrl(String source) => source.startsWith('data:');
 
 Uint8List? tryDecodeDataUrl(String source) {

--- a/lib/utils/optimized_image_loader_base.dart
+++ b/lib/utils/optimized_image_loader_base.dart
@@ -50,6 +50,30 @@ int? decodeDimensionFor(double logicalSize, double pixelRatio) {
   return devicePixels.round();
 }
 
+/// 单张图片的解码总像素预算（宽 × 高）。
+///
+/// 这是**防炸保险，不是画质旋钮**。只给解码宽度封顶时，高度会按原图比例推算：
+/// 一张 1080×100000 的超长拼接图在 688 的解码宽度下会展开成 688×63703
+/// ≈ 4400 万像素、单张约 175MB，足以直接压垮图片缓存乃至进程。
+///
+/// 取值刻意留得很宽（12M 像素，约 48MB）：常规照片、甚至十来屏拼接的长截图
+/// 都远在预算之内，不会被这条保险碰到。**不要**拿它当"长图省内存"的手段——
+/// 等比缩放不是裁剪，压低总像素会连带压低解码宽度，而卡片仍按完整宽度显示，
+/// 结果是整张图（含当前可见的那一截）被放大变糊。
+const int maxDecodePixels = 12 * 1000 * 1000;
+
+/// 由解码宽度推出满足 [maxDecodePixels] 的高度上限，配合
+/// [ResizeImagePolicy.fit] 使用：没超预算的图片不会被这个框改变尺寸。
+///
+/// [decodeWidth] 为 null（不限制宽度）时返回 null，此时也不设高度上限。
+int? decodeHeightBudgetFor(int? decodeWidth) {
+  if (decodeWidth == null || decodeWidth <= 0) {
+    return null;
+  }
+  final budget = maxDecodePixels ~/ decodeWidth;
+  return budget > 0 ? budget : null;
+}
+
 bool isDataUrl(String source) => source.startsWith('data:');
 
 Uint8List? tryDecodeDataUrl(String source) {

--- a/lib/utils/optimized_image_loader_base.dart
+++ b/lib/utils/optimized_image_loader_base.dart
@@ -1,5 +1,31 @@
 import 'dart:typed_data';
 
+import 'package:flutter/widgets.dart';
+
+/// 按解码上限包装 provider。
+///
+/// 同时给了宽高时必须用 [ResizeImagePolicy.fit]（等比缩放到框内），
+/// `ResizeImage` 默认的 `exact` 会把图拉成给定的宽高、直接变形。
+/// 只给一个维度时另一维本就按比例推算，沿用默认策略即可。
+ImageProvider wrapWithDecodeLimit(
+  ImageProvider provider,
+  int? cacheWidth,
+  int? cacheHeight,
+) {
+  if (cacheWidth == null && cacheHeight == null) {
+    return provider;
+  }
+
+  return ResizeImage(
+    provider,
+    width: cacheWidth,
+    height: cacheHeight,
+    policy: (cacheWidth != null && cacheHeight != null)
+        ? ResizeImagePolicy.fit
+        : ResizeImagePolicy.exact,
+  );
+}
+
 bool isDataUrl(String source) => source.startsWith('data:');
 
 Uint8List? tryDecodeDataUrl(String source) {

--- a/lib/utils/optimized_image_loader_io.dart
+++ b/lib/utils/optimized_image_loader_io.dart
@@ -43,10 +43,5 @@ ImageProvider _wrapResize(
   ImageProvider provider,
   int? cacheWidth,
   int? cacheHeight,
-) {
-  if (cacheWidth == null && cacheHeight == null) {
-    return provider;
-  }
-
-  return ResizeImage(provider, width: cacheWidth, height: cacheHeight);
-}
+) =>
+    wrapWithDecodeLimit(provider, cacheWidth, cacheHeight);

--- a/lib/utils/optimized_image_loader_stub.dart
+++ b/lib/utils/optimized_image_loader_stub.dart
@@ -23,9 +23,5 @@ ImageProvider? createOptimizedImageProvider(
     provider = NetworkImage(source);
   }
 
-  if (cacheWidth != null || cacheHeight != null) {
-    provider = ResizeImage(provider, width: cacheWidth, height: cacheHeight);
-  }
-
-  return provider;
+  return wrapWithDecodeLimit(provider, cacheWidth, cacheHeight);
 }

--- a/lib/utils/quill_editor_extensions.dart
+++ b/lib/utils/quill_editor_extensions.dart
@@ -273,6 +273,21 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
   static final LinkedHashSet<String> _loadedSources = LinkedHashSet<String>();
   static const int _maxCachedSources = 200;
 
+  /// 卡片内预览图的解码倍率上限。
+  ///
+  /// 这条路径只服务笔记卡片（全屏编辑器用 `optimizedImages: false` 的原生
+  /// builder，点开的大图预览页不传解码上限，都拿全分辨率），所以这里只需要
+  /// 满足"滑过去看一眼"的清晰度。
+  ///
+  /// 按屏幕最高精度（dpr 3）解码，单张常规照片就要 2.8MB，二十几张即可占满
+  /// Flutter 默认 100MB 的图片缓存；之后每次上下滑都在淘汰和重新解码，
+  /// 正是滑过图片时卡顿的来源。降到 2 倍后单张约 1.2MB，占用降到三分之一，
+  /// 常规滚动不再触发淘汰。
+  ///
+  /// 注意这个上限只是封顶：真实倍率仍取设备的 devicePixelRatio，
+  /// 低分屏机型本来就低于 2，画质按屏幕自适应这件事没有变。
+  static const double _previewMaxPixelRatio = 2.0;
+
   bool _shouldLoad = false;
   bool _hasError = false;
   bool _isLoaded = false;
@@ -385,10 +400,18 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
 
         final double devicePixelRatio = mediaQuery.devicePixelRatio.clamp(
           1.0,
-          3.0,
+          _previewMaxPixelRatio,
         );
         final int? targetCacheWidth = _computeCacheSize(
           displayWidth,
+          devicePixelRatio,
+        );
+        // 高度上限：一屏高就够了。卡片里的长图（长截图、拼接图）是滚过去看的，
+        // 超出一屏的部分不需要按屏幕精度解码。只给宽度封顶时，一张 1:4 的长图
+        // 会解成 1030×4120 ≈ 400 万像素、单张 16MB，几张就把整个图片缓存挤爆。
+        // 常规横竖图的自然高度远在这个框内，不受影响。
+        final int? targetCacheHeight = _computeCacheSize(
+          mediaQuery.size.height,
           devicePixelRatio,
         );
 
@@ -403,6 +426,7 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
                 context,
                 displayWidth,
                 targetCacheWidth,
+                targetCacheHeight,
               ),
             ),
           ),
@@ -423,6 +447,7 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
     BuildContext context,
     double width,
     int? cacheWidth,
+    int? cacheHeight,
   ) {
     if (!_shouldLoad) {
       return _buildImagePlaceholder(context, width);
@@ -434,7 +459,8 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
 
     final provider = createOptimizedImageProvider(
       widget.source,
-      cacheWidth: _shouldLoad ? cacheWidth : null,
+      cacheWidth: cacheWidth,
+      cacheHeight: cacheHeight,
     );
 
     if (provider == null) {

--- a/lib/utils/quill_editor_extensions.dart
+++ b/lib/utils/quill_editor_extensions.dart
@@ -402,16 +402,12 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
           1.0,
           _previewMaxPixelRatio,
         );
-        final int? targetCacheWidth = _computeCacheSize(
+        // 只按显示宽度封顶，**不要**再给高度单独封顶。
+        // 等比缩放不是裁剪：给长图加高度上限会把解码宽度一起压下去，而卡片
+        // 仍按完整宽度显示，结果是整张图（包括当前可见的那一截）被放大变糊。
+        // 长图的内存占用只能靠宽度这一个维度控制。
+        final int? targetCacheWidth = decodeSizeFor(
           displayWidth,
-          devicePixelRatio,
-        );
-        // 高度上限：一屏高就够了。卡片里的长图（长截图、拼接图）是滚过去看的，
-        // 超出一屏的部分不需要按屏幕精度解码。只给宽度封顶时，一张 1:4 的长图
-        // 会解成 1030×4120 ≈ 400 万像素、单张 16MB，几张就把整个图片缓存挤爆。
-        // 常规横竖图的自然高度远在这个框内，不受影响。
-        final int? targetCacheHeight = _computeCacheSize(
-          mediaQuery.size.height,
           devicePixelRatio,
         );
 
@@ -426,7 +422,6 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
                 context,
                 displayWidth,
                 targetCacheWidth,
-                targetCacheHeight,
               ),
             ),
           ),
@@ -447,7 +442,6 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
     BuildContext context,
     double width,
     int? cacheWidth,
-    int? cacheHeight,
   ) {
     if (!_shouldLoad) {
       return _buildImagePlaceholder(context, width);
@@ -460,7 +454,6 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
     final provider = createOptimizedImageProvider(
       widget.source,
       cacheWidth: cacheWidth,
-      cacheHeight: cacheHeight,
     );
 
     if (provider == null) {
@@ -481,8 +474,8 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
           image: provider,
           width: width,
           fit: BoxFit.contain,
-          // 解码尺寸已按 displayWidth × devicePixelRatio 精确匹配显示尺寸
-          // （见 _computeCacheSize），绘制时基本是 1:1 采样，medium 的
+          // 解码尺寸已按 displayWidth × devicePixelRatio 匹配显示尺寸
+          // （见 decodeDimensionFor），绘制时基本是 1:1 采样，medium 的
           // mipmap 生成属于纯浪费：多一份 GPU 内存和一趟缩略链构建，
           // 画面却和 low 没有区别。
           filterQuality: FilterQuality.low,
@@ -601,20 +594,6 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
         builder: (_) => MotionPhotoPreviewPage(imageUrl: widget.source),
       ),
     );
-  }
-
-  int? _computeCacheSize(double dimension, double devicePixelRatio) {
-    if (!dimension.isFinite || dimension <= 0) {
-      return null;
-    }
-
-    final double logicalPixels = dimension * devicePixelRatio;
-    if (!logicalPixels.isFinite || logicalPixels <= 0) {
-      return null;
-    }
-
-    final double bounded = logicalPixels.clamp(160.0, 2048.0);
-    return bounded.round();
   }
 
   Widget _buildImagePlaceholder(BuildContext context, double width) {

--- a/lib/utils/quill_editor_extensions.dart
+++ b/lib/utils/quill_editor_extensions.dart
@@ -410,6 +410,13 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
           displayWidth,
           devicePixelRatio,
         );
+        // 唯一的高度约束是总像素预算这条防炸保险：只给宽度封顶时高度按原图
+        // 比例展开，1080×100000 这种超长拼接图会解成上千万像素直接压垮进程。
+        // 常规照片和长截图都在预算之内，不会被它改变尺寸（fit 策略只在超框时
+        // 才缩放），因此不会重新引入长图变糊的问题。
+        final int? decodePixelBudgetHeight = decodeHeightBudget(
+          targetCacheWidth,
+        );
 
         return RepaintBoundary(
           child: ConstrainedBox(
@@ -422,6 +429,7 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
                 context,
                 displayWidth,
                 targetCacheWidth,
+                decodePixelBudgetHeight,
               ),
             ),
           ),
@@ -442,6 +450,7 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
     BuildContext context,
     double width,
     int? cacheWidth,
+    int? cacheHeight,
   ) {
     if (!_shouldLoad) {
       return _buildImagePlaceholder(context, width);
@@ -454,6 +463,7 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
     final provider = createOptimizedImageProvider(
       widget.source,
       cacheWidth: cacheWidth,
+      cacheHeight: cacheHeight,
     );
 
     if (provider == null) {

--- a/lib/utils/quill_editor_extensions.dart
+++ b/lib/utils/quill_editor_extensions.dart
@@ -455,7 +455,11 @@ class _LazyQuillImageState extends State<_LazyQuillImage>
           image: provider,
           width: width,
           fit: BoxFit.contain,
-          filterQuality: FilterQuality.medium,
+          // 解码尺寸已按 displayWidth × devicePixelRatio 精确匹配显示尺寸
+          // （见 _computeCacheSize），绘制时基本是 1:1 采样，medium 的
+          // mipmap 生成属于纯浪费：多一份 GPU 内存和一趟缩略链构建，
+          // 画面却和 low 没有区别。
+          filterQuality: FilterQuality.low,
           isAntiAlias: true,
           gaplessPlayback: true,
           frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {

--- a/lib/widgets/note_list/note_list_data_stream.dart
+++ b/lib/widgets/note_list/note_list_data_stream.dart
@@ -97,6 +97,14 @@ extension _NoteListDataStreamExtension on NoteListViewState {
             );
           }
 
+          // _hasMore 必须在 setState 内就取数据库的真实分页状态。
+          // 早先用 `list.length >= _pageSize` 推断、事后再普通赋值纠正，
+          // 会让每个数据事件都先渲染一帧多出来的尾部占位/转圈，
+          // 表现就是"加载图标闪一下"，同时 itemCount 变化还会抖动列表高度。
+          final bool dbHasMore = db.hasMoreQuotes;
+          // 列表被整表替换前的偏移，用于事件后校正被夹紧的滚动位置。
+          final double? offsetBeforeUpdate = _safeScrollOffset;
+
           _updateState(() {
             if (isFirstLoad) {
               _quotes.clear();
@@ -106,7 +114,7 @@ extension _NoteListDataStreamExtension on NoteListViewState {
               ..addAll(
                 list,
               ); // Simplified: always replace for consistency, but flag prevents extra sets
-            _hasMore = list.length >= NoteListViewState._pageSize;
+            _hasMore = dbHasMore;
             _isLoading = isLoadMorePage;
             _pruneExpansionControllers();
             // 注意：此处不递增 _resultsVersion。
@@ -115,6 +123,8 @@ extension _NoteListDataStreamExtension on NoteListViewState {
             // 创建从偏移量 0 开始的新 ListView，导致列表跳回顶部。
             // 搜索/筛选切换动画由 _updateStreamSubscription 的首个数据事件负责递增。
           });
+          _guardScrollAnchorAfterDataEvent(offsetBeforeUpdate);
+
           if (_loadMorePerfRecording &&
               (_quotes.length > _loadMorePerfStartCount || !_hasMore)) {
             _markLoadMorePerfDataArrived();
@@ -171,15 +181,6 @@ extension _NoteListDataStreamExtension on NoteListViewState {
             );
           }
 
-          // 修复：同步 _hasMore 状态与数据库服务状态
-          final dbService = _databaseService ?? _readDatabaseService();
-          if (_hasMore != dbService.hasMoreQuotes) {
-            logDebug(
-              '同步 _hasMore 状态: $_hasMore -> ${dbService.hasMoreQuotes}',
-              source: 'NoteListView',
-            );
-            _hasMore = dbService.hasMoreQuotes;
-          }
           // 重置滚动范围检查计数器
           _scrollExtentCheckCounter = 0;
 
@@ -387,10 +388,13 @@ extension _NoteListDataStreamExtension on NoteListViewState {
           final isLoadMorePage = _loadMoreAwaitingPage &&
               (list.length > _loadMoreRequestStartCount ||
                   list.length < NoteListViewState._pageSize);
+          final bool dbHasMore = db.hasMoreQuotes;
+          final double? offsetBeforeUpdate =
+              pendingScrollToTop ? null : _safeScrollOffset;
           _updateState(() {
             _quotes.clear();
             _quotes.addAll(list);
-            _hasMore = list.length >= NoteListViewState._pageSize;
+            _hasMore = dbHasMore;
             _isLoading = isLoadMorePage;
             _pruneExpansionControllers();
           });
@@ -423,6 +427,11 @@ extension _NoteListDataStreamExtension on NoteListViewState {
             });
           }
 
+          // 没有走"保留滚动位置"分支时，由通用锚点保护兜住列表变短造成的位移。
+          if (savedScrollOffset == null) {
+            _guardScrollAnchorAfterDataEvent(offsetBeforeUpdate);
+          }
+
           // Restore scroll position smoothly (only if preserveScrollPosition is true)
           // 只在第一次数据到达时恢复一次；之后置 null 防止后续 stream 事件
           // （如 load more）重复 animateTo，导致用户滑动时列表跳回旧位置。
@@ -447,15 +456,6 @@ extension _NoteListDataStreamExtension on NoteListViewState {
             });
           }
 
-          // 修复：同步 _hasMore 状态与数据库服务状态
-          final dbServiceForSync = _databaseService ?? _readDatabaseService();
-          if (_hasMore != dbServiceForSync.hasMoreQuotes) {
-            logDebug(
-              '更新订阅后同步 _hasMore 状态: $_hasMore -> ${dbServiceForSync.hasMoreQuotes}',
-              source: 'NoteListView',
-            );
-            _hasMore = dbServiceForSync.hasMoreQuotes;
-          }
           // 重置滚动范围检查计数器
           _scrollExtentCheckCounter = 0;
 

--- a/lib/widgets/note_list/note_list_data_stream.dart
+++ b/lib/widgets/note_list/note_list_data_stream.dart
@@ -403,6 +403,8 @@ extension _NoteListDataStreamExtension on NoteListViewState {
           // 之前依赖 ListView 换 key 重建来隐式归零，现在列表常驻，需显式归零。
           if (pendingScrollToTop) {
             pendingScrollToTop = false;
+            // 结果集换了，旧的还原目标作废，否则回到顶部后又被拽回旧位置。
+            _cancelPendingScrollRestore();
             final pos = _safeScrollPosition;
             if (pos != null && pos.pixels != 0) {
               pos.jumpTo(0);

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -751,6 +751,8 @@ extension _NoteListItemsExtension on NoteListViewState {
 
       // 延迟放行图片解码和异常检测，避免与 ScrollEnd 帧的 loadMore 挤在同一帧。
       isListScrolling.value = false;
+      // 拖拽期间不跟手势抢位置，挂起的还原留到这里补做。
+      _reconcileScrollAnchor(null);
       _checkAndFixScrollExtentAnomaly();
     });
   }

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -1,5 +1,10 @@
 part of '../note_list_view.dart';
 
+/// 列表底部"还有下一页"占位格的高度。空闲占位与加载动画共用，
+/// 保证 `_isLoading` 翻转不会改变列表总高度。
+/// 取值对齐 [AppLoadingView] 内部 Lottie 的最小尺寸（80），动画正好填满不溢出。
+const double _loadMoreFooterHeight = 80.0;
+
 /// List building, search, and item rendering for NoteListViewState.
 extension _NoteListItemsExtension on NoteListViewState {
   Widget _buildNoteListView(BuildContext context) {
@@ -451,6 +456,8 @@ extension _NoteListItemsExtension on NoteListViewState {
           // 单独的拖拽信号让冷 Quill 恢复队列在整个手势期间保持静默。
           isListDragActive.value = true;
           _cancelScrollEndSettledWork();
+          // 用户重新接管列表：放弃尚未执行的数据事件位置还原，避免回拉手感。
+          _cancelPendingScrollRestore();
           if (_searchFocusNode.hasFocus) {
             _searchFocusNode.unfocus();
           }
@@ -704,13 +711,23 @@ extension _NoteListItemsExtension on NoteListViewState {
             }
             // 底部加载指示器：仅在主动加载时显示动画，
             // 空闲态用透明占位确保 itemCount 正确以触发自动加载。
-            if (_isLoading) {
-              return const Padding(
-                padding: EdgeInsets.symmetric(vertical: 16),
-                child: AppLoadingView(size: 32),
-              );
-            }
-            return const SizedBox(height: 48);
+            //
+            // 由 _loadMoreIndicator 驱动，切换只重建这一格，不牵动整列表；
+            // 也保证加载结束后指示器一定会收起（不再依赖别处恰好有 setState）。
+            //
+            // 两种状态必须同高。此前空闲占位 48、加载态是 80 的 Lottie 外加
+            // 上下各 16 的内边距（合计 112）——每翻转一次列表总高就跳 64 像素，
+            // 正在底部附近滑动时就是肉眼可见的"列表抖一下/飞一下"。
+            // 这一格永远处在"还有下一页"的过渡区，等高之后用户察觉不到差异。
+            return ValueListenableBuilder<bool>(
+              valueListenable: _loadMoreIndicator,
+              builder: (context, loading, _) => SizedBox(
+                height: _loadMoreFooterHeight,
+                child: loading
+                    ? const AppLoadingView(size: _loadMoreFooterHeight)
+                    : null,
+              ),
+            );
           },
         ),
       ),

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -754,13 +754,13 @@ extension _NoteListScrollExtension on NoteListViewState {
   void _guardScrollAnchorAfterDataEvent(double? previousOffset) {
     // 既没有新偏移可记，也没有挂起的目标，就没必要多排一次帧回调。
     if ((previousOffset == null || previousOffset <= 0) &&
-        _pendingScrollRestoreOffset == null) {
+        !_scrollAnchor.hasPending) {
       return;
     }
 
-    final generation = _scrollAnchorGeneration;
+    final generation = _scrollAnchor.generation;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || generation != _scrollAnchorGeneration) return;
+      if (!mounted || !_scrollAnchor.isCurrent(generation)) return;
       _reconcileScrollAnchor(previousOffset);
     });
   }
@@ -771,7 +771,7 @@ extension _NoteListScrollExtension on NoteListViewState {
 
     final decision = resolveScrollAnchorAction(
       previousOffset: previousOffset,
-      pendingOffset: _consumePendingScrollRestoreOffset(),
+      pendingOffset: _scrollAnchor.consume(DateTime.now()),
       currentPixels: position.pixels,
       maxScrollExtent: position.maxScrollExtent,
       isDragging: isListDragActive.value,
@@ -782,8 +782,7 @@ extension _NoteListScrollExtension on NoteListViewState {
       case ScrollAnchorAction.none:
         return;
       case ScrollAnchorAction.remember:
-        _pendingScrollRestoreOffset = decision.targetOffset;
-        _pendingScrollRestoreAt = DateTime.now();
+        _scrollAnchor.remember(decision.targetOffset!, DateTime.now());
         logDebug(
           '滚动锚点暂存待还原: ${decision.targetOffset?.round()} '
           '(max=${position.maxScrollExtent.round()}, '
@@ -801,29 +800,9 @@ extension _NoteListScrollExtension on NoteListViewState {
     }
   }
 
-  /// 取出仍在有效期内的待还原偏移；过期或不存在返回 null。
-  /// 无论是否过期都会清空字段，由调用方按 [resolveScrollAnchorAction] 的结论重写。
-  double? _consumePendingScrollRestoreOffset() {
-    final pending = _pendingScrollRestoreOffset;
-    final at = _pendingScrollRestoreAt;
-    _pendingScrollRestoreOffset = null;
-    _pendingScrollRestoreAt = null;
-    if (pending == null || at == null) return null;
-    if (DateTime.now().difference(at) >
-        NoteListViewState._pendingScrollRestoreWindow) {
-      return null;
-    }
-    return pending;
-  }
-
   /// 用户重新按住列表、或筛选变化要求回到顶部时调用：
   /// 这两种情况下旧的还原目标都已经作废，不能再把用户拽回去。
-  void _cancelPendingScrollRestore() {
-    _pendingScrollRestoreOffset = null;
-    _pendingScrollRestoreAt = null;
-    // 递增版本，让已排队但还没执行的锚点回调直接作废。
-    _scrollAnchorGeneration++;
-  }
+  void _cancelPendingScrollRestore() => _scrollAnchor.cancel();
 
   void _resetLoadMoreGate() {
     _loadMoreAwaitingPage = false;

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -744,6 +744,81 @@ extension _NoteListScrollExtension on NoteListViewState {
     });
   }
 
+  /// 数据事件把 `_quotes` 整表替换之后调用的滚动锚点兜底。
+  ///
+  /// 只处理一种情况：**新内容比原来短，短到够不着用户当前的偏移**。
+  /// 这时 maxScrollExtent 骤减，滚动位置被夹紧，用户看到的就是"列表突然飞走"。
+  /// 兜底分两步——先把够不着的偏移记下来，等后续事件把列表补长再无动画还原。
+  ///
+  /// 刻意不比较 `position.pixels`：数据事件常常发生在惯性滑动中，偏移每帧都在
+  /// 合法地变化，按偏移差纠正等于和惯性打架。只有 maxScrollExtent 装不下原偏移
+  /// 才是真正的"被夹掉"。
+  ///
+  /// [previousOffset] 为数据应用之前的偏移量。
+  void _guardScrollAnchorAfterDataEvent(double? previousOffset) {
+    if (previousOffset == null || previousOffset <= 0) {
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final position = _safeScrollPosition;
+      if (position == null) return;
+
+      const tolerance = NoteListViewState._dataEventScrollShiftTolerance;
+      final maxExtent = position.maxScrollExtent;
+      final pending = _consumePendingScrollRestoreOffset();
+
+      // 内容装不下原偏移：记住目标，等列表补长。取更深的那个，
+      // 避免连续多次变短时把目标越记越浅。
+      if (maxExtent + tolerance < previousOffset) {
+        final target = (pending != null && pending > previousOffset)
+            ? pending
+            : previousOffset;
+        _pendingScrollRestoreOffset = target;
+        _pendingScrollRestoreAt = DateTime.now();
+        logDebug(
+          '数据事件使列表变短，暂存待还原偏移: ${target.round()} '
+          '(max=${maxExtent.round()}, quotes=${_quotes.length})',
+          source: 'NoteListView',
+        );
+        return;
+      }
+
+      // 之前被夹掉的偏移现在够得着了，还原回去。只向下（更深处）还原，
+      // 不会把用户往回拽。
+      if (pending != null &&
+          pending <= maxExtent &&
+          position.pixels < pending - tolerance) {
+        position.jumpTo(pending);
+        logDebug(
+          '列表已补长，还原被夹掉的滚动位置: ${pending.round()}',
+          source: 'NoteListView',
+        );
+      }
+    });
+  }
+
+  /// 取出仍在有效期内的待还原偏移；过期或不存在返回 null。
+  double? _consumePendingScrollRestoreOffset() {
+    final pending = _pendingScrollRestoreOffset;
+    final at = _pendingScrollRestoreAt;
+    _pendingScrollRestoreOffset = null;
+    _pendingScrollRestoreAt = null;
+    if (pending == null || at == null) return null;
+    if (DateTime.now().difference(at) >
+        NoteListViewState._pendingScrollRestoreWindow) {
+      return null;
+    }
+    return pending;
+  }
+
+  /// 用户重新按住列表说明他已经接受了当前位置，不再回拉。
+  void _cancelPendingScrollRestore() {
+    _pendingScrollRestoreOffset = null;
+    _pendingScrollRestoreAt = null;
+  }
+
   void _resetLoadMoreGate() {
     _loadMoreAwaitingPage = false;
     _loadMoreSettleTimer?.cancel();

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -746,60 +746,62 @@ extension _NoteListScrollExtension on NoteListViewState {
 
   /// 数据事件把 `_quotes` 整表替换之后调用的滚动锚点兜底。
   ///
-  /// 只处理一种情况：**新内容比原来短，短到够不着用户当前的偏移**。
-  /// 这时 maxScrollExtent 骤减，滚动位置被夹紧，用户看到的就是"列表突然飞走"。
-  /// 兜底分两步——先把够不着的偏移记下来，等后续事件把列表补长再无动画还原。
+  /// 判断逻辑全在纯函数 [resolveScrollAnchorAction] 里（含各种边界与单测），
+  /// 这里只负责取状态、执行结果。
   ///
-  /// 刻意不比较 `position.pixels`：数据事件常常发生在惯性滑动中，偏移每帧都在
-  /// 合法地变化，按偏移差纠正等于和惯性打架。只有 maxScrollExtent 装不下原偏移
-  /// 才是真正的"被夹掉"。
-  ///
-  /// [previousOffset] 为数据应用之前的偏移量。
+  /// [previousOffset] 为数据应用之前的偏移量；为 null 表示这次只是「再试一次
+  /// 之前挂起的还原」（例如滚动停止后的回调）。
   void _guardScrollAnchorAfterDataEvent(double? previousOffset) {
-    if (previousOffset == null || previousOffset <= 0) {
+    // 既没有新偏移可记，也没有挂起的目标，就没必要多排一次帧回调。
+    if ((previousOffset == null || previousOffset <= 0) &&
+        _pendingScrollRestoreOffset == null) {
       return;
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      final position = _safeScrollPosition;
-      if (position == null) return;
-
-      const tolerance = NoteListViewState._dataEventScrollShiftTolerance;
-      final maxExtent = position.maxScrollExtent;
-      final pending = _consumePendingScrollRestoreOffset();
-
-      // 内容装不下原偏移：记住目标，等列表补长。取更深的那个，
-      // 避免连续多次变短时把目标越记越浅。
-      if (maxExtent + tolerance < previousOffset) {
-        final target = (pending != null && pending > previousOffset)
-            ? pending
-            : previousOffset;
-        _pendingScrollRestoreOffset = target;
-        _pendingScrollRestoreAt = DateTime.now();
-        logDebug(
-          '数据事件使列表变短，暂存待还原偏移: ${target.round()} '
-          '(max=${maxExtent.round()}, quotes=${_quotes.length})',
-          source: 'NoteListView',
-        );
-        return;
-      }
-
-      // 之前被夹掉的偏移现在够得着了，还原回去。只向下（更深处）还原，
-      // 不会把用户往回拽。
-      if (pending != null &&
-          pending <= maxExtent &&
-          position.pixels < pending - tolerance) {
-        position.jumpTo(pending);
-        logDebug(
-          '列表已补长，还原被夹掉的滚动位置: ${pending.round()}',
-          source: 'NoteListView',
-        );
-      }
+      _reconcileScrollAnchor(previousOffset);
     });
   }
 
+  void _reconcileScrollAnchor(double? previousOffset) {
+    final position = _safeScrollPosition;
+    if (position == null) return;
+
+    final decision = resolveScrollAnchorAction(
+      previousOffset: previousOffset,
+      pendingOffset: _consumePendingScrollRestoreOffset(),
+      currentPixels: position.pixels,
+      maxScrollExtent: position.maxScrollExtent,
+      isDragging: isListDragActive.value,
+      tolerance: NoteListViewState._dataEventScrollShiftTolerance,
+    );
+
+    switch (decision.action) {
+      case ScrollAnchorAction.none:
+        return;
+      case ScrollAnchorAction.remember:
+        _pendingScrollRestoreOffset = decision.targetOffset;
+        _pendingScrollRestoreAt = DateTime.now();
+        logDebug(
+          '滚动锚点暂存待还原: ${decision.targetOffset?.round()} '
+          '(max=${position.maxScrollExtent.round()}, '
+          'dragging=${isListDragActive.value}, quotes=${_quotes.length})',
+          source: 'NoteListView',
+        );
+        return;
+      case ScrollAnchorAction.restore:
+        position.jumpTo(decision.targetOffset!);
+        logDebug(
+          '还原被夹掉的滚动位置: ${decision.targetOffset!.round()}',
+          source: 'NoteListView',
+        );
+        return;
+    }
+  }
+
   /// 取出仍在有效期内的待还原偏移；过期或不存在返回 null。
+  /// 无论是否过期都会清空字段，由调用方按 [resolveScrollAnchorAction] 的结论重写。
   double? _consumePendingScrollRestoreOffset() {
     final pending = _pendingScrollRestoreOffset;
     final at = _pendingScrollRestoreAt;
@@ -813,7 +815,8 @@ extension _NoteListScrollExtension on NoteListViewState {
     return pending;
   }
 
-  /// 用户重新按住列表说明他已经接受了当前位置，不再回拉。
+  /// 用户重新按住列表、或筛选变化要求回到顶部时调用：
+  /// 这两种情况下旧的还原目标都已经作废，不能再把用户拽回去。
   void _cancelPendingScrollRestore() {
     _pendingScrollRestoreOffset = null;
     _pendingScrollRestoreAt = null;

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -784,7 +784,14 @@ extension _NoteListScrollExtension on NoteListViewState {
         _scrollAnchor.clear();
         return;
       case ScrollAnchorAction.remember:
-        _scrollAnchor.remember(decision.targetOffset!, now);
+        if (!_scrollAnchor.remember(decision.targetOffset!, now)) {
+          // 本轮夹紧已经超过有效期：用户早就滑到别处了，不能再拽他。
+          logDebug(
+            '滚动锚点已过期，放弃还原: ${decision.targetOffset!.round()}',
+            source: 'NoteListView',
+          );
+          return;
+        }
         logDebug(
           '滚动锚点暂存待还原: ${decision.targetOffset?.round()} '
           '(max=${position.maxScrollExtent.round()}, '

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -758,8 +758,9 @@ extension _NoteListScrollExtension on NoteListViewState {
       return;
     }
 
+    final generation = _scrollAnchorGeneration;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
+      if (!mounted || generation != _scrollAnchorGeneration) return;
       _reconcileScrollAnchor(previousOffset);
     });
   }
@@ -820,6 +821,8 @@ extension _NoteListScrollExtension on NoteListViewState {
   void _cancelPendingScrollRestore() {
     _pendingScrollRestoreOffset = null;
     _pendingScrollRestoreAt = null;
+    // 递增版本，让已排队但还没执行的锚点回调直接作废。
+    _scrollAnchorGeneration++;
   }
 
   void _resetLoadMoreGate() {

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -769,9 +769,10 @@ extension _NoteListScrollExtension on NoteListViewState {
     final position = _safeScrollPosition;
     if (position == null) return;
 
+    final now = DateTime.now();
     final decision = resolveScrollAnchorAction(
       previousOffset: previousOffset,
-      pendingOffset: _scrollAnchor.consume(DateTime.now()),
+      pendingOffset: _scrollAnchor.peek(now),
       currentPixels: position.pixels,
       maxScrollExtent: position.maxScrollExtent,
       isDragging: isListDragActive.value,
@@ -780,9 +781,10 @@ extension _NoteListScrollExtension on NoteListViewState {
 
     switch (decision.action) {
       case ScrollAnchorAction.none:
+        _scrollAnchor.clear();
         return;
       case ScrollAnchorAction.remember:
-        _scrollAnchor.remember(decision.targetOffset!, DateTime.now());
+        _scrollAnchor.remember(decision.targetOffset!, now);
         logDebug(
           '滚动锚点暂存待还原: ${decision.targetOffset?.round()} '
           '(max=${position.maxScrollExtent.round()}, '
@@ -791,6 +793,7 @@ extension _NoteListScrollExtension on NoteListViewState {
         );
         return;
       case ScrollAnchorAction.restore:
+        _scrollAnchor.clear();
         position.jumpTo(decision.targetOffset!);
         logDebug(
           '还原被夹掉的滚动位置: ${decision.targetOffset!.round()}',

--- a/lib/widgets/note_list/scroll_alignment.dart
+++ b/lib/widgets/note_list/scroll_alignment.dart
@@ -14,8 +14,13 @@ bool shouldSkipVisibleTargetAlignment({
 
 /// 在数据事件之间保存「被内容变短夹掉的滚动偏移」。
 ///
-/// 单独抽出来是因为它有两条容易悄悄回归的规则：
+/// 单独抽出来是因为它有几条容易悄悄回归的规则：
 /// - **有效期**：过老的目标不能再去拽用户，他早就滑到别处了；
+/// - **一轮夹紧只有一个有效期**：从这一轮**第一次**挂起开始计时，中途目标
+///   变深也不重新计时，否则连绵不断的数据事件能把有效期无限续下去；
+/// - **过期即封锁**：过期之后本轮夹紧彻底作废，在下一次 [clear] / [cancel]
+///   之前不再接受任何新目标。否则同一次决策里 `peek` 刚把目标判过期，
+///   紧接着又用仍被夹紧的 previousOffset 挂一个新的，等于换个名字重新计时；
 /// - **作废版本**：用户重新拖拽、或筛选切换要回到顶部时，目标必须整体作废。
 ///   光清字段挡不住**已经排进帧回调队列**的那次还原，所以还要递增版本号，
 ///   让在途回调自己退出。
@@ -27,6 +32,7 @@ class ScrollAnchorTracker {
 
   double? _offset;
   DateTime? _since;
+  bool _expired = false;
   int _generation = 0;
 
   /// 当前版本号。排帧回调前取一次，回调执行时用 [isCurrent] 比对。
@@ -36,6 +42,9 @@ class ScrollAnchorTracker {
   bool isCurrent(int capturedGeneration) => capturedGeneration == _generation;
 
   bool get hasPending => _offset != null;
+
+  /// 本轮夹紧是否已过期作废。为 true 时 [remember] 一律不受理。
+  bool get isExpired => _expired;
 
   /// 读取仍在有效期内的目标；过期会就地丢弃并返回 null。
   ///
@@ -48,28 +57,30 @@ class ScrollAnchorTracker {
     if (now.difference(since) > retention) {
       _offset = null;
       _since = null;
+      _expired = true;
       return null;
     }
     return offset;
   }
 
-  /// 挂起（或顺延）一个还原目标。
+  /// 挂起（或顺延）一个还原目标，返回是否受理。
   ///
-  /// 同一个目标反复顺延时**保留最初的时刻**：数据事件可能一个接一个地来，
-  /// 每次都重新计时的话有效期会被无限续期，用户可能在很久之后忽然被拽回去。
-  /// 目标本身变了才算新的夹紧事件，这时才重新计时。
-  void remember(double offset, DateTime now) {
-    if (_offset != offset) {
-      _since = now;
-    }
+  /// 计时只在本轮夹紧的**第一次**挂起时开始：数据事件可能一个接一个地来，
+  /// 每次（哪怕目标变深了）都重新计时的话有效期会被无限续期，用户可能在很久
+  /// 之后忽然被拽回去。本轮已过期时返回 false，不再受理，直到调用方通过
+  /// [clear]（这次事件确认无需还原）或 [cancel]（用户重新操作）翻篇。
+  bool remember(double offset, DateTime now) {
+    if (_expired) return false;
     _since ??= now;
     _offset = offset;
+    return true;
   }
 
-  /// 清空目标（已还原到位、或已无需还原）。不影响版本号。
+  /// 清空目标（已还原到位、或已无需还原），并结束本轮夹紧。不影响版本号。
   void clear() {
     _offset = null;
     _since = null;
+    _expired = false;
   }
 
   /// 作废：清空目标并递增版本，让已排队的回调直接退出。

--- a/lib/widgets/note_list/scroll_alignment.dart
+++ b/lib/widgets/note_list/scroll_alignment.dart
@@ -12,6 +12,56 @@ bool shouldSkipVisibleTargetAlignment({
       targetOffset < currentOffset + viewportExtent;
 }
 
+/// 在数据事件之间保存「被内容变短夹掉的滚动偏移」。
+///
+/// 单独抽出来是因为它有两条容易悄悄回归的规则：
+/// - **有效期**：过老的目标不能再去拽用户，他早就滑到别处了；
+/// - **作废版本**：用户重新拖拽、或筛选切换要回到顶部时，目标必须整体作废。
+///   光清字段挡不住**已经排进帧回调队列**的那次还原，所以还要递增版本号，
+///   让在途回调自己退出。
+class ScrollAnchorTracker {
+  ScrollAnchorTracker({required this.retention});
+
+  /// 待还原目标的有效期。超过就丢弃。
+  final Duration retention;
+
+  double? _offset;
+  DateTime? _rememberedAt;
+  int _generation = 0;
+
+  /// 当前版本号。排帧回调前取一次，回调执行时用 [isCurrent] 比对。
+  int get generation => _generation;
+
+  /// 排队时取的版本是否仍然有效。
+  bool isCurrent(int capturedGeneration) => capturedGeneration == _generation;
+
+  bool get hasPending => _offset != null;
+
+  void remember(double offset, DateTime now) {
+    _offset = offset;
+    _rememberedAt = now;
+  }
+
+  /// 取出仍在有效期内的目标**并清空**；过期或不存在返回 null。
+  /// 调用方按决策结果决定要不要重新 [remember]。
+  double? consume(DateTime now) {
+    final offset = _offset;
+    final rememberedAt = _rememberedAt;
+    _offset = null;
+    _rememberedAt = null;
+    if (offset == null || rememberedAt == null) return null;
+    if (now.difference(rememberedAt) > retention) return null;
+    return offset;
+  }
+
+  /// 作废：清空目标并递增版本，让已排队的回调直接退出。
+  void cancel() {
+    _offset = null;
+    _rememberedAt = null;
+    _generation++;
+  }
+}
+
 /// 数据事件（整表替换 `_quotes`）之后对滚动锚点的处置方式。
 enum ScrollAnchorAction {
   /// 什么都不用做。

--- a/lib/widgets/note_list/scroll_alignment.dart
+++ b/lib/widgets/note_list/scroll_alignment.dart
@@ -41,14 +41,18 @@ class ScrollAnchorDecision {
 /// 夹紧，视觉上就是「列表突然飞走 / 弹回顶部」。这里把「记住目标」和「择机还原」
 /// 的判断抽成纯函数，方便覆盖各种边界。
 ///
-/// - [previousOffset]：本次数据应用之前的偏移量。
+/// - [previousOffset]：本次数据应用之前的偏移量。**只在内容已经装不下它时**
+///   才会成为锚点候选，见下方说明。
 /// - [pendingOffset]：之前被夹掉、仍在有效期内的待还原偏移。
 /// - [currentPixels] / [maxScrollExtent]：数据应用后的实际滚动状态。
 /// - [isDragging]：用户此刻是否正按住列表。拖拽期间跳位置会打断手势，
 ///   所以只记不跳，等松手后的事件或滚动停止再还原。
 ///
-/// 刻意不比较「偏移变了多少」：数据事件常发生在惯性滑动中，偏移每帧都在合法地
-/// 变化，按偏移差纠正等于和惯性打架。只有 maxScrollExtent 装不下目标才算被夹掉。
+/// **[previousOffset] 绝不能直接当作还原目标。** 数据事件（分页追加等）绝大多数
+/// 发生在惯性滑动中，`currentPixels` 每帧都在合法变化；若把"事件发生前的偏移"
+/// 当目标去比 `currentPixels`，普通的一次分页就会把正在上滑的用户拽回事件发生前
+/// 的位置，惯性也被打断。真正需要兜底的只有一种情况：内容变短到
+/// `maxScrollExtent` 已经装不下原偏移——那才是被夹掉，而不是用户自己滑走的。
 ScrollAnchorDecision resolveScrollAnchorAction({
   required double? previousOffset,
   required double? pendingOffset,
@@ -57,11 +61,14 @@ ScrollAnchorDecision resolveScrollAnchorAction({
   required bool isDragging,
   required double tolerance,
 }) {
+  // 原偏移是否被内容变短夹掉了。没被夹掉就完全不参与决策。
+  final wasClampedAway = previousOffset != null &&
+      previousOffset > 0 &&
+      previousOffset > maxScrollExtent + tolerance;
+
   // 目标取两者中更深的那个：连续多次变短时不能把目标越记越浅。
   double? target = pendingOffset;
-  if (previousOffset != null &&
-      previousOffset > 0 &&
-      (target == null || previousOffset > target)) {
+  if (wasClampedAway && (target == null || previousOffset > target)) {
     target = previousOffset;
   }
 

--- a/lib/widgets/note_list/scroll_alignment.dart
+++ b/lib/widgets/note_list/scroll_alignment.dart
@@ -11,3 +11,79 @@ bool shouldSkipVisibleTargetAlignment({
   return targetOffset >= currentOffset &&
       targetOffset < currentOffset + viewportExtent;
 }
+
+/// 数据事件（整表替换 `_quotes`）之后对滚动锚点的处置方式。
+enum ScrollAnchorAction {
+  /// 什么都不用做。
+  none,
+
+  /// 目标暂时够不着（内容还没回填够）或此刻不宜移动位置，先记着。
+  remember,
+
+  /// 立即无动画跳回目标偏移。
+  restore,
+}
+
+/// [resolveScrollAnchorAction] 的结果。[targetOffset] 在 remember/restore 时有值。
+class ScrollAnchorDecision {
+  const ScrollAnchorDecision(this.action, [this.targetOffset]);
+
+  final ScrollAnchorAction action;
+  final double? targetOffset;
+
+  @override
+  String toString() => 'ScrollAnchorDecision($action, $targetOffset)';
+}
+
+/// 决定数据事件后要不要把滚动位置拉回原处。
+///
+/// 列表在用户滑动途中被换成更短的数据时，maxScrollExtent 会骤减并把当前偏移
+/// 夹紧，视觉上就是「列表突然飞走 / 弹回顶部」。这里把「记住目标」和「择机还原」
+/// 的判断抽成纯函数，方便覆盖各种边界。
+///
+/// - [previousOffset]：本次数据应用之前的偏移量。
+/// - [pendingOffset]：之前被夹掉、仍在有效期内的待还原偏移。
+/// - [currentPixels] / [maxScrollExtent]：数据应用后的实际滚动状态。
+/// - [isDragging]：用户此刻是否正按住列表。拖拽期间跳位置会打断手势，
+///   所以只记不跳，等松手后的事件或滚动停止再还原。
+///
+/// 刻意不比较「偏移变了多少」：数据事件常发生在惯性滑动中，偏移每帧都在合法地
+/// 变化，按偏移差纠正等于和惯性打架。只有 maxScrollExtent 装不下目标才算被夹掉。
+ScrollAnchorDecision resolveScrollAnchorAction({
+  required double? previousOffset,
+  required double? pendingOffset,
+  required double currentPixels,
+  required double maxScrollExtent,
+  required bool isDragging,
+  required double tolerance,
+}) {
+  // 目标取两者中更深的那个：连续多次变短时不能把目标越记越浅。
+  double? target = pendingOffset;
+  if (previousOffset != null &&
+      previousOffset > 0 &&
+      (target == null || previousOffset > target)) {
+    target = previousOffset;
+  }
+
+  if (target == null || target <= 0) {
+    return const ScrollAnchorDecision(ScrollAnchorAction.none);
+  }
+
+  // 内容还装不下目标：继续挂着，等后续事件把列表补长。
+  // 只补长了一半（maxScrollExtent 仍小于目标）也走这里，不能把目标丢掉。
+  if (target > maxScrollExtent + tolerance) {
+    return ScrollAnchorDecision(ScrollAnchorAction.remember, target);
+  }
+
+  // 已经在目标位置或更深处，没什么要还原的。
+  if (currentPixels >= target - tolerance) {
+    return const ScrollAnchorDecision(ScrollAnchorAction.none);
+  }
+
+  // 正在拖拽：不跟手势抢，保留目标，等滚动停下来再还原。
+  if (isDragging) {
+    return ScrollAnchorDecision(ScrollAnchorAction.remember, target);
+  }
+
+  return ScrollAnchorDecision(ScrollAnchorAction.restore, target);
+}

--- a/lib/widgets/note_list/scroll_alignment.dart
+++ b/lib/widgets/note_list/scroll_alignment.dart
@@ -26,7 +26,7 @@ class ScrollAnchorTracker {
   final Duration retention;
 
   double? _offset;
-  DateTime? _rememberedAt;
+  DateTime? _since;
   int _generation = 0;
 
   /// 当前版本号。排帧回调前取一次，回调执行时用 [isCurrent] 比对。
@@ -37,27 +37,44 @@ class ScrollAnchorTracker {
 
   bool get hasPending => _offset != null;
 
-  void remember(double offset, DateTime now) {
-    _offset = offset;
-    _rememberedAt = now;
+  /// 读取仍在有效期内的目标；过期会就地丢弃并返回 null。
+  ///
+  /// **不清空**：调用方拿到决策结果后再显式 [remember] 或 [clear]，
+  /// 这样同一个目标跨多次数据事件顺延时能保住它最初挂起的时刻。
+  double? peek(DateTime now) {
+    final offset = _offset;
+    final since = _since;
+    if (offset == null || since == null) return null;
+    if (now.difference(since) > retention) {
+      _offset = null;
+      _since = null;
+      return null;
+    }
+    return offset;
   }
 
-  /// 取出仍在有效期内的目标**并清空**；过期或不存在返回 null。
-  /// 调用方按决策结果决定要不要重新 [remember]。
-  double? consume(DateTime now) {
-    final offset = _offset;
-    final rememberedAt = _rememberedAt;
+  /// 挂起（或顺延）一个还原目标。
+  ///
+  /// 同一个目标反复顺延时**保留最初的时刻**：数据事件可能一个接一个地来，
+  /// 每次都重新计时的话有效期会被无限续期，用户可能在很久之后忽然被拽回去。
+  /// 目标本身变了才算新的夹紧事件，这时才重新计时。
+  void remember(double offset, DateTime now) {
+    if (_offset != offset) {
+      _since = now;
+    }
+    _since ??= now;
+    _offset = offset;
+  }
+
+  /// 清空目标（已还原到位、或已无需还原）。不影响版本号。
+  void clear() {
     _offset = null;
-    _rememberedAt = null;
-    if (offset == null || rememberedAt == null) return null;
-    if (now.difference(rememberedAt) > retention) return null;
-    return offset;
+    _since = null;
   }
 
   /// 作废：清空目标并递增版本，让已排队的回调直接退出。
   void cancel() {
-    _offset = null;
-    _rememberedAt = null;
+    clear();
     _generation++;
   }
 }

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -234,14 +234,8 @@ class NoteListViewState extends State<NoteListView> {
   // 列表在用户滑动途中被换成更短的数据时，maxScrollExtent 会骤减并把当前
   // 偏移夹紧，视觉上就是"列表突然飞走/弹回顶部"。这里记住被夹掉的偏移，
   // 等后续事件把列表补长后无动画还原。
-  double? _pendingScrollRestoreOffset;
-  DateTime? _pendingScrollRestoreAt;
-
-  /// 锚点回调的版本号。作废挂起目标（用户重新拖拽、筛选回顶）时递增，
-  /// 已排队的 post-frame 回调据此直接退出——只清字段挡不住在途回调。
-  int _scrollAnchorGeneration = 0;
-  static const Duration _pendingScrollRestoreWindow = Duration(
-    milliseconds: 1500,
+  final ScrollAnchorTracker _scrollAnchor = ScrollAnchorTracker(
+    retention: const Duration(milliseconds: 1500),
   );
   static const double _dataEventScrollShiftTolerance = 1.0;
 

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -236,6 +236,10 @@ class NoteListViewState extends State<NoteListView> {
   // 等后续事件把列表补长后无动画还原。
   double? _pendingScrollRestoreOffset;
   DateTime? _pendingScrollRestoreAt;
+
+  /// 锚点回调的版本号。作废挂起目标（用户重新拖拽、筛选回顶）时递增，
+  /// 已排队的 post-frame 回调据此直接退出——只清字段挡不住在途回调。
+  int _scrollAnchorGeneration = 0;
   static const Duration _pendingScrollRestoreWindow = Duration(
     milliseconds: 1500,
   );

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -186,7 +186,30 @@ class NoteListViewState extends State<NoteListView> {
 
   // 分页和懒加载状态
   final List<Quote> _quotes = [];
-  bool _isLoading = true; // 初始化为 true，避免闪现"无笔记"
+
+  bool _isLoadingBacking = true; // 初始化为 true，避免闪现"无笔记"
+
+  /// 分页加载中标志。既是 `_loadMore` 的并发闸门，也决定底部指示器是否可见。
+  ///
+  /// 通过 setter 把可见性同步给 [_loadMoreIndicator]：底部指示器因此不再依赖
+  /// 整列表 setState 才能收起。此前 [_settleLoadMoreLoadingFlag] 在滚动中会
+  /// 只改字段、不触发重建（为了不在滚动帧里重建整列表），若之后恰好没有别的
+  /// setState，加载动画就会一直挂在列表底部转下去。
+  bool get _isLoading => _isLoadingBacking;
+
+  set _isLoading(bool value) {
+    if (_isLoadingBacking == value) return;
+    _isLoadingBacking = value;
+    // dispose 之后仍可能有在途回调改写闸门，此时 notifier 已释放。
+    if (mounted) {
+      _loadMoreIndicator.value = value;
+    }
+  }
+
+  /// 底部加载指示器的可见性。单独用 ValueNotifier 驱动，
+  /// 切换时只重建那一格，不会牵动已加载的上百个 item。
+  final ValueNotifier<bool> _loadMoreIndicator = ValueNotifier<bool>(true);
+
   bool _hasMore = true;
   static const int _pageSize = AppConstants.defaultPageSize;
   StreamSubscription<List<Quote>>? _quotesSub;
@@ -206,6 +229,17 @@ class NoteListViewState extends State<NoteListView> {
   // 修复：用于检测和恢复滚动范围异常的计数器
   int _scrollExtentCheckCounter = 0;
   static const int _maxScrollExtentChecks = 3;
+
+  // 数据事件（整表替换）后的滚动锚点保护：
+  // 列表在用户滑动途中被换成更短的数据时，maxScrollExtent 会骤减并把当前
+  // 偏移夹紧，视觉上就是"列表突然飞走/弹回顶部"。这里记住被夹掉的偏移，
+  // 等后续事件把列表补长后无动画还原。
+  double? _pendingScrollRestoreOffset;
+  DateTime? _pendingScrollRestoreAt;
+  static const Duration _pendingScrollRestoreWindow = Duration(
+    milliseconds: 1500,
+  );
+  static const double _dataEventScrollShiftTolerance = 1.0;
 
   // 修复：添加防抖定时器和性能优化
   Timer? _searchDebounceTimer;
@@ -760,6 +794,7 @@ class NoteListViewState extends State<NoteListView> {
       notifier.dispose();
     }
     _expansionNotifiers.clear();
+    _loadMoreIndicator.dispose();
 
     // 修复问题3：移除页面切换时的缓存清空，保留缓存以提升返回体验
     // QuoteContent.resetCaches(); // 缓存将由 LRU 自动管理

--- a/test/sync_integration_test.mocks.dart
+++ b/test/sync_integration_test.mocks.dart
@@ -807,7 +807,7 @@ class MockDatabaseService extends _i1.Mock implements _i14.DatabaseService {
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
     int? refillCount,
-    List<_i16.Quote>? skipNotifyIfSameAs,
+    bool? suppressNotify,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -821,7 +821,7 @@ class MockDatabaseService extends _i1.Mock implements _i14.DatabaseService {
             #selectedDayPeriods: selectedDayPeriods,
             #includeDeleted: includeDeleted,
             #refillCount: refillCount,
-            #skipNotifyIfSameAs: skipNotifyIfSameAs,
+            #suppressNotify: suppressNotify,
           },
         ),
         returnValue: _i10.Future<void>.value(),

--- a/test/sync_integration_test.mocks.dart
+++ b/test/sync_integration_test.mocks.dart
@@ -806,6 +806,8 @@ class MockDatabaseService extends _i1.Mock implements _i14.DatabaseService {
     List<String>? selectedWeathers,
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
+    int? refillCount,
+    List<_i16.Quote>? skipNotifyIfSameAs,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -818,6 +820,8 @@ class MockDatabaseService extends _i1.Mock implements _i14.DatabaseService {
             #selectedWeathers: selectedWeathers,
             #selectedDayPeriods: selectedDayPeriods,
             #includeDeleted: includeDeleted,
+            #refillCount: refillCount,
+            #skipNotifyIfSameAs: skipNotifyIfSameAs,
           },
         ),
         returnValue: _i10.Future<void>.value(),

--- a/test/unit/services/database_pagination_test.dart
+++ b/test/unit/services/database_pagination_test.dart
@@ -290,10 +290,11 @@ void main() {
         final sub = await loadThreePages(events);
         addTearDown(sub.cancel);
 
-        // 一路翻到底：7 条全部取回，再取一次拿到空页，hasMore 变 false。
+        // 一路翻到底：第 4 页（offset 6, limit 2）只取到 1 条，不足一页，
+        // hasMore 就在这时翻成 false（判据是 quotes.length >= requestLimit，
+        // 不需要再多取一次空页）。
         await service.loadMoreQuotes();
         await _waitForEvent(events, (quotes) => quotes.length, equals(7));
-        await service.loadMoreQuotes();
         expect(service.hasMoreQuotes, isFalse);
 
         await failRefill(events);

--- a/test/unit/services/database_pagination_test.dart
+++ b/test/unit/services/database_pagination_test.dart
@@ -274,6 +274,38 @@ void main() {
     );
 
     test(
+      '回填失败回滚时，已经翻到底的分页状态不会被重新标记为还有下一页',
+      () async {
+        final events = <List<Quote>>[];
+        final sub = await loadThreePages(events);
+        addTearDown(sub.cancel);
+
+        // 一路翻到底：7 条全部取回，再取一次拿到空页，hasMore 变 false。
+        await service.loadMoreQuotes();
+        await _waitForEvent(events, (quotes) => quotes.length, equals(7));
+        await service.loadMoreQuotes();
+        expect(service.hasMoreQuotes, isFalse);
+
+        final queriesBeforeRefresh = service.completedQueries;
+        service.failNextQueriesWith = StateError('数据库炸了');
+
+        service.refreshQuotes();
+        await _waitUntil(
+          () => service.completedQueries > queriesBeforeRefresh,
+        );
+        await _drainEventLoop();
+
+        // 回滚要把分页游标一起复原。无条件写 true 的话，明明已经没有下一页的
+        // 列表会重新显示"还有下一页"，用户滑到底还会看到一次白转的加载指示器。
+        expect(
+          service.hasMoreQuotes,
+          isFalse,
+          reason: '回填失败回滚后，已翻到底的列表被错误标记为仍可分页',
+        );
+      },
+    );
+
+    test(
       '刷新结果与刷新前完全一致时不再整表推送',
       () async {
         final events = <List<Quote>>[];

--- a/test/unit/services/database_pagination_test.dart
+++ b/test/unit/services/database_pagination_test.dart
@@ -22,41 +22,7 @@ void main() {
       service = _DuplicatePageDatabaseService();
 
       db = await databaseFactory.openDatabase(inMemoryDatabasePath);
-      await db.execute('''
-          CREATE TABLE quotes(
-            id TEXT PRIMARY KEY,
-            content TEXT NOT NULL,
-            date TEXT NOT NULL,
-            source TEXT,
-            source_author TEXT,
-            source_work TEXT,
-            ai_analysis TEXT,
-            sentiment TEXT,
-            keywords TEXT,
-            summary TEXT,
-            category_id TEXT DEFAULT '',
-            color_hex TEXT,
-            location TEXT,
-            latitude REAL,
-            longitude REAL,
-            weather TEXT,
-            temperature TEXT,
-            edit_source TEXT,
-            delta_content TEXT,
-            day_period TEXT,
-            last_modified TEXT,
-            favorite_count INTEGER DEFAULT 0,
-            is_deleted INTEGER DEFAULT 0,
-            deleted_at TEXT
-          )
-        ''');
-      await db.execute('''
-          CREATE TABLE quote_tags (
-            quote_id TEXT NOT NULL,
-            tag_id TEXT NOT NULL,
-            PRIMARY KEY (quote_id, tag_id)
-          )
-        ''');
+      await _createQuoteTables(db);
 
       DatabaseService.setTestDatabase(db);
       await service.init();
@@ -156,6 +122,8 @@ void main() {
 
         final eventsBeforeRefresh = events.length;
         service.requestedPages.clear();
+        // 内容确实变了，这次刷新应当推送（去重只针对完全没变的刷新）。
+        service.contentRevision++;
 
         service.refreshQuotes();
 
@@ -194,7 +162,8 @@ void main() {
 
         // 相同筛选条件再次订阅：复用已有流，不应重建分页状态。
         final secondEvents = <List<Quote>>[];
-        final secondSub = service.watchQuotes(limit: 2).listen(secondEvents.add);
+        final secondSub =
+            service.watchQuotes(limit: 2).listen(secondEvents.add);
         addTearDown(secondSub.cancel);
         await _waitForEvent(secondEvents, (quotes) => quotes.length, equals(6));
 
@@ -216,20 +185,57 @@ void main() {
     );
 
     test(
-      '刷新结果与刷新前完全一致时不再整表推送',
+      '第一次刷新还在回填途中又来一次刷新，仍然回填全部条数',
       () async {
-        service.stampLastModified = true;
         final events = <List<Quote>>[];
         final sub = await loadThreePages(events);
         addTearDown(sub.cancel);
 
         final eventsBeforeRefresh = events.length;
         service.requestedPages.clear();
+        service.contentRevision++;
+
+        // 连续两次刷新：第二次进来时 _currentQuotes 已被第一次清空。
+        // 若按"当时的列表长度"算回填目标就会退化成只取一页，
+        // 列表塌回第一页——正是这个 PR 要修的 bug。
+        service.refreshQuotes();
+        service.refreshQuotes();
+
+        await _waitForEvent(
+          events,
+          (quotes) => quotes.length,
+          equals(6),
+          startIndex: eventsBeforeRefresh,
+        );
+
+        for (var i = eventsBeforeRefresh; i < events.length; i++) {
+          expect(
+            events[i].length,
+            6,
+            reason: '并发刷新期间第 ${i - eventsBeforeRefresh} 个事件把列表截短了',
+          );
+        }
+      },
+    );
+
+    test(
+      '刷新结果与刷新前完全一致时不再整表推送',
+      () async {
+        final events = <List<Quote>>[];
+        final sub = await loadThreePages(events);
+        addTearDown(sub.cancel);
+
+        final eventsBeforeRefresh = events.length;
+        final queriesBeforeRefresh = service.completedQueries;
+        service.requestedPages.clear();
 
         service.refreshQuotes();
-        await _waitUntil(() => service.requestedPages.isNotEmpty);
-        // 给推送留出足够的调度时间，确认它确实没有发生。
-        await Future<void>.delayed(const Duration(milliseconds: 120));
+        // 等回填查询真正**完成**（而不是刚被记录），再把事件循环排空：
+        // 推送若会发生，此时必定已经发生，不需要靠固定延时赌时序。
+        await _waitUntil(
+          () => service.completedQueries > queriesBeforeRefresh,
+        );
+        await _drainEventLoop();
 
         // 整表推送会让列表页重建上百个 item，在滚动帧里就是一次可见卡顿。
         expect(
@@ -240,6 +246,13 @@ void main() {
       },
     );
   });
+}
+
+/// 排空事件循环：用于"某件事不应该发生"的负向断言。
+Future<void> _drainEventLoop() async {
+  for (var i = 0; i < 8; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
 }
 
 Future<void> _waitUntil(bool Function() condition) async {
@@ -299,8 +312,12 @@ class _PagedDatabaseService extends DatabaseService {
   final int totalQuotes;
   final requestedPages = <({int offset, int limit})>[];
 
-  /// 是否给假数据带上 lastModified：刷新去重需要靠它判断内容有没有变。
-  bool stampLastModified = false;
+  /// 已经**返回结果**的查询数。负向断言要等查询真的跑完，
+  /// 只看 requestedPages 会在查询还在飞的时候就放行。
+  int completedQueries = 0;
+
+  /// 模拟"笔记内容真的变了"：改这个值，刷新回填就会拿到不同的数据。
+  int contentRevision = 0;
 
   @override
   Future<List<Quote>> getUserQuotes({
@@ -319,16 +336,17 @@ class _PagedDatabaseService extends DatabaseService {
   }) async {
     requestedPages.add((offset: offset, limit: limit));
     final end = (offset + limit) < totalQuotes ? offset + limit : totalQuotes;
-    return [
+    final quotes = [
       for (var i = offset; i < end; i++)
         Quote(
           id: 'quote-$i',
-          content: '分页测试 quote-$i',
+          content: '分页测试 quote-$i rev$contentRevision',
           date: DateTime(2026, 6, 29).toIso8601String(),
-          lastModified:
-              stampLastModified ? '2026-06-29T00:00:00.000Z' : null,
+          lastModified: '2026-06-29T00:00:00.000Z',
         ),
     ];
+    completedQueries++;
+    return quotes;
   }
 }
 

--- a/test/unit/services/database_pagination_test.dart
+++ b/test/unit/services/database_pagination_test.dart
@@ -219,6 +219,48 @@ void main() {
     );
 
     test(
+      '回填查询失败时不推半成品，列表不会塌缩',
+      () async {
+        final events = <List<Quote>>[];
+        final sub = await loadThreePages(events);
+        addTearDown(sub.cancel);
+
+        final eventsBeforeRefresh = events.length;
+        final queriesBeforeRefresh = service.completedQueries;
+        // 超时只是失败的一种；SQLite 异常等会被 loadMoreQuotes 内部吞掉，
+        // 用非超时异常才能真正验证"所有错误都要交出去"这条契约。
+        service.failNextQueriesWith = StateError('数据库炸了');
+
+        service.refreshQuotes();
+        await _waitUntil(
+          () => service.completedQueries > queriesBeforeRefresh,
+        );
+        await _drainEventLoop();
+
+        // 回填一条都没取到。此时推送就是把列表从 6 条清成 0 条——
+        // 用户正滑到的位置会被 maxScrollExtent 夹紧，正是要修的塌陷。
+        for (var i = eventsBeforeRefresh; i < events.length; i++) {
+          expect(
+            events[i].length,
+            greaterThanOrEqualTo(6),
+            reason: '回填失败后推出了比刷新前更短的列表',
+          );
+        }
+
+        // 恢复正常后的下一次刷新要能把 6 条补回来（回填目标没丢）。
+        service.failNextQueriesWith = null;
+        service.contentRevision++;
+        service.refreshQuotes();
+        await _waitForEvent(
+          events,
+          (quotes) => quotes.length,
+          equals(6),
+          startIndex: eventsBeforeRefresh,
+        );
+      },
+    );
+
+    test(
       '刷新结果与刷新前完全一致时不再整表推送',
       () async {
         final events = <List<Quote>>[];
@@ -375,6 +417,9 @@ class _PagedDatabaseService extends DatabaseService {
   /// 模拟"笔记内容真的变了"：改这个值，刷新回填就会拿到不同的数据。
   int contentRevision = 0;
 
+  /// 令后续查询在返回前抛出异常，用于验证回填失败时的保护。
+  Object? failNextQueriesWith;
+
   @override
   Future<List<Quote>> getUserQuotes({
     List<String>? tagIds,
@@ -391,6 +436,11 @@ class _PagedDatabaseService extends DatabaseService {
     bool includeDeleted = false,
   }) async {
     requestedPages.add((offset: offset, limit: limit));
+    final failure = failNextQueriesWith;
+    if (failure != null) {
+      completedQueries++;
+      throw failure;
+    }
     final end = (offset + limit) < totalQuotes ? offset + limit : totalQuotes;
     final quotes = [
       for (var i = offset; i < end; i++)

--- a/test/unit/services/database_pagination_test.dart
+++ b/test/unit/services/database_pagination_test.dart
@@ -218,6 +218,23 @@ void main() {
       },
     );
 
+    /// 让一次刷新的回填查询全部失败，返回失败前的事件数。
+    ///
+    /// 超时只是失败的一种；SQLite 异常等会被 loadMoreQuotes 内部吞掉，
+    /// 用非超时异常才能真正验证"所有错误都要交出去"这条契约。
+    Future<int> failRefill(List<List<Quote>> events) async {
+      final eventsBeforeRefresh = events.length;
+      final queriesBeforeRefresh = service.completedQueries;
+      service.failQueriesWith = StateError('数据库炸了');
+
+      service.refreshQuotes();
+      await _waitUntil(() => service.completedQueries > queriesBeforeRefresh);
+      await _drainEventLoop();
+
+      service.failQueriesWith = null;
+      return eventsBeforeRefresh;
+    }
+
     test(
       '回填查询失败时不推半成品，列表不会塌缩',
       () async {
@@ -225,17 +242,7 @@ void main() {
         final sub = await loadThreePages(events);
         addTearDown(sub.cancel);
 
-        final eventsBeforeRefresh = events.length;
-        final queriesBeforeRefresh = service.completedQueries;
-        // 超时只是失败的一种；SQLite 异常等会被 loadMoreQuotes 内部吞掉，
-        // 用非超时异常才能真正验证"所有错误都要交出去"这条契约。
-        service.failNextQueriesWith = StateError('数据库炸了');
-
-        service.refreshQuotes();
-        await _waitUntil(
-          () => service.completedQueries > queriesBeforeRefresh,
-        );
-        await _drainEventLoop();
+        final eventsBeforeRefresh = await failRefill(events);
 
         // 回填一条都没取到。此时推送就是把列表从 6 条清成 0 条——
         // 用户正滑到的位置会被 maxScrollExtent 夹紧，正是要修的塌陷。
@@ -246,12 +253,22 @@ void main() {
             reason: '回填失败后推出了比刷新前更短的列表',
           );
         }
+      },
+    );
 
-        // 关键：失败后内存状态必须整体回滚，而不只是"跳过推送"。
-        // 否则 _currentQuotes 已空、_watchOffset 已归零，接下来任何一次
-        // 普通分页（空闲预取、滚到底部的兜底加载）都会从 offset=0 取回
-        // 第一页并正常推给 UI —— 列表照样塌回第一页。
-        service.failNextQueriesWith = null;
+    test(
+      '回填失败回滚后，普通分页从原游标续取而不是塌回第一页',
+      () async {
+        final events = <List<Quote>>[];
+        final sub = await loadThreePages(events);
+        addTearDown(sub.cancel);
+
+        final eventsBeforeRefresh = await failRefill(events);
+
+        // 失败后内存状态必须整体回滚，而不只是"跳过推送"。否则 _currentQuotes
+        // 已空、_watchOffset 已归零，接下来任何一次普通分页（空闲预取、滚到
+        // 底部的兜底加载）都会从 offset=0 取回第一页并正常推给 UI ——
+        // 列表照样塌回第一页。
         service.requestedPages.clear();
         await service.loadMoreQuotes();
         await _waitForEvent(
@@ -263,13 +280,6 @@ void main() {
 
         // 续页要从第 6 条之后接着取，而不是回到 offset 0。
         expect(service.requestedPages.single.offset, 6);
-        for (var i = eventsBeforeRefresh; i < events.length; i++) {
-          expect(
-            events[i].length,
-            greaterThanOrEqualTo(6),
-            reason: '失败回滚后的普通分页把列表塌回了第一页',
-          );
-        }
       },
     );
 
@@ -286,14 +296,7 @@ void main() {
         await service.loadMoreQuotes();
         expect(service.hasMoreQuotes, isFalse);
 
-        final queriesBeforeRefresh = service.completedQueries;
-        service.failNextQueriesWith = StateError('数据库炸了');
-
-        service.refreshQuotes();
-        await _waitUntil(
-          () => service.completedQueries > queriesBeforeRefresh,
-        );
-        await _drainEventLoop();
+        await failRefill(events);
 
         // 回滚要把分页游标一起复原。无条件写 true 的话，明明已经没有下一页的
         // 列表会重新显示"还有下一页"，用户滑到底还会看到一次白转的加载指示器。
@@ -462,8 +465,9 @@ class _PagedDatabaseService extends DatabaseService {
   /// 模拟"笔记内容真的变了"：改这个值，刷新回填就会拿到不同的数据。
   int contentRevision = 0;
 
-  /// 令后续查询在返回前抛出异常，用于验证回填失败时的保护。
-  Object? failNextQueriesWith;
+  /// 令查询在返回前抛出异常，用于验证回填失败时的保护。
+  /// 一经设置，**此后所有**查询都会失败，直到调用方把它置回 null。
+  Object? failQueriesWith;
 
   @override
   Future<List<Quote>> getUserQuotes({
@@ -481,7 +485,7 @@ class _PagedDatabaseService extends DatabaseService {
     bool includeDeleted = false,
   }) async {
     requestedPages.add((offset: offset, limit: limit));
-    final failure = failNextQueriesWith;
+    final failure = failQueriesWith;
     if (failure != null) {
       completedQueries++;
       throw failure;

--- a/test/unit/services/database_pagination_test.dart
+++ b/test/unit/services/database_pagination_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:thoughtecho/models/quote_model.dart';
@@ -97,6 +99,237 @@ void main() {
       },
     );
   });
+
+  group('Database pagination refresh', () {
+    late _PagedDatabaseService service;
+    late Database db;
+
+    setUp(() async {
+      await TestHarness.initialize();
+      DatabaseService.clearTestDatabase();
+      service = _PagedDatabaseService(totalQuotes: 7);
+
+      db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+      await _createQuoteTables(db);
+      DatabaseService.setTestDatabase(db);
+      await service.init();
+    });
+
+    tearDown(() async {
+      DatabaseService.clearTestDatabase();
+      await db.close();
+    });
+
+    Future<StreamSubscription<List<Quote>>> loadThreePages(
+      List<List<Quote>> events,
+    ) async {
+      final sub = service.watchQuotes(limit: 2).listen(events.add);
+      await _waitForEvent(events, _ids, equals(['quote-0', 'quote-1']));
+      await service.loadMoreQuotes();
+      await _waitForEvent(
+        events,
+        _ids,
+        equals(['quote-0', 'quote-1', 'quote-2', 'quote-3']),
+      );
+      await service.loadMoreQuotes();
+      await _waitForEvent(
+        events,
+        _ids,
+        equals([
+          'quote-0',
+          'quote-1',
+          'quote-2',
+          'quote-3',
+          'quote-4',
+          'quote-5',
+        ]),
+      );
+      return sub;
+    }
+
+    test(
+      '刷新按已加载条数一次性回填，列表不会塌回第一页',
+      () async {
+        final events = <List<Quote>>[];
+        final sub = await loadThreePages(events);
+        addTearDown(sub.cancel);
+
+        final eventsBeforeRefresh = events.length;
+        service.requestedPages.clear();
+
+        service.refreshQuotes();
+
+        await _waitForEvent(
+          events,
+          (quotes) => quotes.length,
+          equals(6),
+          startIndex: eventsBeforeRefresh,
+        );
+
+        // 关键：刷新期间一条都不能变短。列表在用户滚动途中缩短会让
+        // maxScrollExtent 骤减、滚动位置被夹紧，视觉上就是"列表突然飞走"。
+        for (var i = eventsBeforeRefresh; i < events.length; i++) {
+          expect(
+            events[i].length,
+            6,
+            reason: '刷新过程中第 ${i - eventsBeforeRefresh} 个事件把列表截短了',
+          );
+        }
+
+        // 回填只查一次，limit 等于原有条数。
+        expect(service.requestedPages, hasLength(1));
+        expect(service.requestedPages.single.offset, 0);
+        expect(service.requestedPages.single.limit, 6);
+      },
+    );
+
+    test(
+      '筛选条件未变时重新订阅不会把分页偏移重置回 0',
+      () async {
+        final events = <List<Quote>>[];
+        final sub = await loadThreePages(events);
+        addTearDown(sub.cancel);
+
+        service.requestedPages.clear();
+
+        // 相同筛选条件再次订阅：复用已有流，不应重建分页状态。
+        final secondEvents = <List<Quote>>[];
+        final secondSub = service.watchQuotes(limit: 2).listen(secondEvents.add);
+        addTearDown(secondSub.cancel);
+        await _waitForEvent(secondEvents, (quotes) => quotes.length, equals(6));
+
+        await service.loadMoreQuotes();
+        await _waitForEvent(
+          secondEvents,
+          (quotes) => quotes.length,
+          equals(7),
+        );
+
+        // 偏移若被重置为 0，这一页取回的全是重复数据：列表一条都不增长，
+        // 底部加载指示器却会一直转。
+        expect(
+          service.requestedPages.map((page) => page.offset),
+          isNot(contains(0)),
+        );
+        expect(service.requestedPages.single.offset, 6);
+      },
+    );
+
+    test(
+      '刷新结果与刷新前完全一致时不再整表推送',
+      () async {
+        service.stampLastModified = true;
+        final events = <List<Quote>>[];
+        final sub = await loadThreePages(events);
+        addTearDown(sub.cancel);
+
+        final eventsBeforeRefresh = events.length;
+        service.requestedPages.clear();
+
+        service.refreshQuotes();
+        await _waitUntil(() => service.requestedPages.isNotEmpty);
+        // 给推送留出足够的调度时间，确认它确实没有发生。
+        await Future<void>.delayed(const Duration(milliseconds: 120));
+
+        // 整表推送会让列表页重建上百个 item，在滚动帧里就是一次可见卡顿。
+        expect(
+          events.length,
+          eventsBeforeRefresh,
+          reason: '可见列表毫无变化的刷新不应触发整表推送',
+        );
+      },
+    );
+  });
+}
+
+Future<void> _waitUntil(bool Function() condition) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 3));
+  while (DateTime.now().isBefore(deadline)) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail('Timed out waiting for condition');
+}
+
+List<String?> _ids(List<Quote> quotes) =>
+    quotes.map((quote) => quote.id).toList();
+
+Future<void> _createQuoteTables(Database db) async {
+  await db.execute('''
+      CREATE TABLE quotes(
+        id TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        date TEXT NOT NULL,
+        source TEXT,
+        source_author TEXT,
+        source_work TEXT,
+        ai_analysis TEXT,
+        sentiment TEXT,
+        keywords TEXT,
+        summary TEXT,
+        category_id TEXT DEFAULT '',
+        color_hex TEXT,
+        location TEXT,
+        latitude REAL,
+        longitude REAL,
+        weather TEXT,
+        temperature TEXT,
+        edit_source TEXT,
+        delta_content TEXT,
+        day_period TEXT,
+        last_modified TEXT,
+        favorite_count INTEGER DEFAULT 0,
+        is_deleted INTEGER DEFAULT 0,
+        deleted_at TEXT
+      )
+    ''');
+  await db.execute('''
+      CREATE TABLE quote_tags (
+        quote_id TEXT NOT NULL,
+        tag_id TEXT NOT NULL,
+        PRIMARY KEY (quote_id, tag_id)
+      )
+    ''');
+}
+
+/// 按 offset/limit 老实分页的假数据源，用于观察真实的取页请求。
+class _PagedDatabaseService extends DatabaseService {
+  _PagedDatabaseService({required this.totalQuotes}) : super.forTesting();
+
+  final int totalQuotes;
+  final requestedPages = <({int offset, int limit})>[];
+
+  /// 是否给假数据带上 lastModified：刷新去重需要靠它判断内容有没有变。
+  bool stampLastModified = false;
+
+  @override
+  Future<List<Quote>> getUserQuotes({
+    List<String>? tagIds,
+    String? categoryId,
+    int offset = 0,
+    int limit = 20,
+    String orderBy = 'date DESC',
+    String? searchQuery,
+    String? dateStart,
+    String? dateEnd,
+    List<String>? selectedWeathers,
+    List<String>? selectedDayPeriods,
+    bool excludeHiddenNotes = true,
+    bool includeDeleted = false,
+  }) async {
+    requestedPages.add((offset: offset, limit: limit));
+    final end = (offset + limit) < totalQuotes ? offset + limit : totalQuotes;
+    return [
+      for (var i = offset; i < end; i++)
+        Quote(
+          id: 'quote-$i',
+          content: '分页测试 quote-$i',
+          date: DateTime(2026, 6, 29).toIso8601String(),
+          lastModified:
+              stampLastModified ? '2026-06-29T00:00:00.000Z' : null,
+        ),
+    ];
+  }
 }
 
 Future<void> _waitForEvent<T>(

--- a/test/unit/services/database_pagination_test.dart
+++ b/test/unit/services/database_pagination_test.dart
@@ -247,16 +247,29 @@ void main() {
           );
         }
 
-        // 恢复正常后的下一次刷新要能把 6 条补回来（回填目标没丢）。
+        // 关键：失败后内存状态必须整体回滚，而不只是"跳过推送"。
+        // 否则 _currentQuotes 已空、_watchOffset 已归零，接下来任何一次
+        // 普通分页（空闲预取、滚到底部的兜底加载）都会从 offset=0 取回
+        // 第一页并正常推给 UI —— 列表照样塌回第一页。
         service.failNextQueriesWith = null;
-        service.contentRevision++;
-        service.refreshQuotes();
+        service.requestedPages.clear();
+        await service.loadMoreQuotes();
         await _waitForEvent(
           events,
           (quotes) => quotes.length,
-          equals(6),
+          equals(7),
           startIndex: eventsBeforeRefresh,
         );
+
+        // 续页要从第 6 条之后接着取，而不是回到 offset 0。
+        expect(service.requestedPages.single.offset, 6);
+        for (var i = eventsBeforeRefresh; i < events.length; i++) {
+          expect(
+            events[i].length,
+            greaterThanOrEqualTo(6),
+            reason: '失败回滚后的普通分页把列表塌回了第一页',
+          );
+        }
       },
     );
 

--- a/test/unit/services/database_pagination_test.dart
+++ b/test/unit/services/database_pagination_test.dart
@@ -246,6 +246,62 @@ void main() {
       },
     );
   });
+
+  group('Database pagination chunked refill', () {
+    late _PagedDatabaseService service;
+    late Database db;
+
+    setUp(() async {
+      await TestHarness.initialize();
+      DatabaseService.clearTestDatabase();
+      service = _PagedDatabaseService(totalQuotes: 600);
+
+      db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+      await _createQuoteTables(db);
+      DatabaseService.setTestDatabase(db);
+      await service.init();
+    });
+
+    tearDown(() async {
+      DatabaseService.clearTestDatabase();
+      await db.close();
+    });
+
+    test(
+      '超过单次分块上限时分多次回填，最后一块只取剩余条数',
+      () async {
+        // 单次查询上限 500：501 条要分成 500 + 1 两次取回。
+        final events = <List<Quote>>[];
+        final sub = service.watchQuotes(limit: 501).listen(events.add);
+        addTearDown(sub.cancel);
+        await _waitForEvent(events, (quotes) => quotes.length, equals(501));
+
+        final eventsBeforeRefresh = events.length;
+        service.requestedPages.clear();
+        service.contentRevision++;
+
+        service.refreshQuotes();
+
+        await _waitForEvent(
+          events,
+          (quotes) => quotes.length,
+          equals(501),
+          startIndex: eventsBeforeRefresh,
+        );
+
+        // 中途一条都不许推短列表。
+        for (var i = eventsBeforeRefresh; i < events.length; i++) {
+          expect(events[i].length, 501);
+        }
+
+        // 最后一块若退回整页大小，会多取回一整页、列表比刷新前更长。
+        expect(
+          service.requestedPages.map((page) => (page.offset, page.limit)),
+          containsAllInOrder([(0, 500), (500, 1)]),
+        );
+      },
+    );
+  });
 }
 
 /// 排空事件循环：用于"某件事不应该发生"的负向断言。

--- a/test/unit/utils/optimized_image_loader_base_test.dart
+++ b/test/unit/utils/optimized_image_loader_base_test.dart
@@ -41,6 +41,45 @@ void main() {
       });
     });
 
+    group('decodeHeightBudgetFor', () {
+      test('高度上限乘以解码宽度不超过总像素预算', () {
+        for (final width in <int>[160, 688, 1032, 2048]) {
+          final budget = decodeHeightBudgetFor(width);
+
+          expect(budget, isNotNull);
+          expect(
+            budget! * width <= maxDecodePixels,
+            isTrue,
+            reason: 'width=$width',
+          );
+        }
+      });
+
+      test('常规照片与长截图的自然高度都在预算之内，不会被缩', () {
+        // 卡片解码宽度约 688（344 逻辑宽 × 2 倍率）。
+        const decodeWidth = 688;
+        final budget = decodeHeightBudgetFor(decodeWidth)!;
+
+        // 4:3 竖图
+        expect(decodeWidth * 4 ~/ 3 < budget, isTrue);
+        // 1080×24000 的十屏拼接长截图，等比到 688 宽后的高度
+        expect((decodeWidth * 24000 / 1080).round() < budget, isTrue);
+      });
+
+      test('病态超长图会被预算挡住', () {
+        const decodeWidth = 688;
+        final budget = decodeHeightBudgetFor(decodeWidth)!;
+
+        // 1080×100000：等比到 688 宽后约 63700 高，必须超出预算
+        expect((decodeWidth * 100000 / 1080).round() > budget, isTrue);
+      });
+
+      test('没有宽度上限时也不设高度上限', () {
+        expect(decodeHeightBudgetFor(null), isNull);
+        expect(decodeHeightBudgetFor(0), isNull);
+      });
+    });
+
     group('wrapWithDecodeLimit', () {
       final base = MemoryImage(Uint8List.fromList(const [1, 2, 3]));
 

--- a/test/unit/utils/optimized_image_loader_base_test.dart
+++ b/test/unit/utils/optimized_image_loader_base_test.dart
@@ -1,8 +1,35 @@
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/utils/optimized_image_loader_base.dart';
 
 void main() {
   group('OptimizedImageLoaderBase', () {
+    group('wrapWithDecodeLimit', () {
+      final base = MemoryImage(Uint8List.fromList(const [1, 2, 3]));
+
+      test('没有解码上限时原样返回', () {
+        expect(identical(wrapWithDecodeLimit(base, null, null), base), isTrue);
+      });
+
+      test('只给宽度时保持默认策略，高度按比例推算', () {
+        final resized = wrapWithDecodeLimit(base, 800, null) as ResizeImage;
+
+        expect(resized.width, 800);
+        expect(resized.height, isNull);
+        expect(resized.policy, ResizeImagePolicy.exact);
+      });
+
+      test('同时给宽高时必须用 fit 策略，否则长图会被拉变形', () {
+        final resized = wrapWithDecodeLimit(base, 800, 1600) as ResizeImage;
+
+        expect(resized.width, 800);
+        expect(resized.height, 1600);
+        expect(resized.policy, ResizeImagePolicy.fit);
+      });
+    });
+
     group('isDataUrl', () {
       test('returns true for valid data URL', () {
         const source =

--- a/test/unit/utils/optimized_image_loader_base_test.dart
+++ b/test/unit/utils/optimized_image_loader_base_test.dart
@@ -6,6 +6,41 @@ import 'package:thoughtecho/utils/optimized_image_loader_base.dart';
 
 void main() {
   group('OptimizedImageLoaderBase', () {
+    group('decodeDimensionFor', () {
+      test('按逻辑尺寸乘以像素比换算成设备像素', () {
+        expect(decodeDimensionFor(344, 2.0), 688);
+      });
+
+      test('尺寸过小时抬到下限，避免解成马赛克', () {
+        expect(decodeDimensionFor(10, 2.0), minDecodeDimension);
+      });
+
+      test('尺寸过大时压到上限，避免单张解码撑爆内存', () {
+        expect(decodeDimensionFor(4000, 3.0), maxDecodeDimension);
+      });
+
+      test('非法尺寸返回 null，表示不设解码上限', () {
+        expect(decodeDimensionFor(0, 2.0), isNull);
+        expect(decodeDimensionFor(-1, 2.0), isNull);
+        expect(decodeDimensionFor(double.infinity, 2.0), isNull);
+        expect(decodeDimensionFor(double.nan, 2.0), isNull);
+      });
+
+      test('像素比封顶后的解码宽度不会超过屏幕宽度 × 该上限', () {
+        // 卡片宽度不会超过屏幕宽度；旗舰机的 dpr 会被调用方钳到 2.0。
+        const screenWidth = 430.0;
+        const cappedRatio = 2.0;
+        final ceiling = (screenWidth * cappedRatio).round();
+
+        for (final width in <double>[120, 344, 400, screenWidth]) {
+          final decoded = decodeDimensionFor(width, cappedRatio);
+
+          expect(decoded, isNotNull);
+          expect(decoded! <= ceiling, isTrue, reason: 'width=$width');
+        }
+      });
+    });
+
     group('wrapWithDecodeLimit', () {
       final base = MemoryImage(Uint8List.fromList(const [1, 2, 3]));
 

--- a/test/unit/utils/optimized_image_loader_base_test.dart
+++ b/test/unit/utils/optimized_image_loader_base_test.dart
@@ -26,8 +26,21 @@ void main() {
         expect(decodeDimensionFor(double.nan, 2.0), isNull);
       });
 
-      test('像素比封顶后的解码宽度不会超过屏幕宽度 × 该上限', () {
-        // 卡片宽度不会超过屏幕宽度；旗舰机的 dpr 会被调用方钳到 2.0。
+      test('非法像素比同样返回 null，不能当成"尺寸没问题"照解', () {
+        // 尺寸合法但像素比非法时，把关的是 devicePixels 那道校验。
+        // 少了它，pixelRatio=0 会退化成"抬到下限 160"，静悄悄解出一张错图。
+        for (final pixelRatio in <double>[0, -1, double.infinity, double.nan]) {
+          expect(
+            decodeDimensionFor(344, pixelRatio),
+            isNull,
+            reason: 'pixelRatio=$pixelRatio',
+          );
+        }
+      });
+
+      test('像素比封顶到 2.0 后，解码宽度不会超过屏幕宽度 × 2', () {
+        // 卡片宽度不会超过屏幕宽度；dpr 由调用方（quill_editor_extensions
+        // 的 _previewMaxPixelRatio）钳到 2.0，这里验证钳完之后的内存上界。
         const screenWidth = 430.0;
         const cappedRatio = 2.0;
         final ceiling = (screenWidth * cappedRatio).round();
@@ -38,6 +51,9 @@ void main() {
           expect(decoded, isNotNull);
           expect(decoded! <= ceiling, isTrue, reason: 'width=$width');
         }
+
+        // 不封顶的话这条上界就守不住——这正是调用方要钳 dpr 的原因。
+        expect(decodeDimensionFor(screenWidth, 3.0)! > ceiling, isTrue);
       });
     });
 

--- a/test/unit/widgets/note_list_scroll_anchor_test.dart
+++ b/test/unit/widgets/note_list_scroll_anchor_test.dart
@@ -36,6 +36,18 @@ void main() {
       expect(decision.action, ScrollAnchorAction.none);
     });
 
+    test('普通分页事件中用户正向上滑，绝不能被拽回事件发生前的位置', () {
+      // 分页追加数据时用户还在惯性上滑：内容装得下原偏移，说明没被夹掉，
+      // 这只是用户自己滑走了。若把原偏移当还原目标就会打断惯性。
+      final decision = _resolve(
+        previousOffset: 5000,
+        currentPixels: 4800,
+        maxScrollExtent: 20000,
+      );
+
+      expect(decision.action, ScrollAnchorAction.none);
+    });
+
     test('内容变短装不下原偏移时记住目标', () {
       final decision = _resolve(
         previousOffset: 800,

--- a/test/unit/widgets/note_list_scroll_anchor_test.dart
+++ b/test/unit/widgets/note_list_scroll_anchor_test.dart
@@ -153,4 +153,68 @@ void main() {
       expect(decision.action, ScrollAnchorAction.none);
     });
   });
+
+  group('ScrollAnchorTracker', () {
+    ScrollAnchorTracker newTracker() =>
+        ScrollAnchorTracker(retention: const Duration(milliseconds: 1500));
+
+    test('记住的目标可以在有效期内取出，取出后即清空', () {
+      final tracker = newTracker();
+      final now = DateTime(2026, 8, 7, 12);
+
+      tracker.remember(800, now);
+      expect(tracker.hasPending, isTrue);
+
+      expect(tracker.consume(now.add(const Duration(milliseconds: 500))), 800);
+      // consume 是一次性的，调用方要按决策结果决定是否重新 remember。
+      expect(tracker.hasPending, isFalse);
+      expect(tracker.consume(now), isNull);
+    });
+
+    test('超过有效期的目标不再拽用户', () {
+      final tracker = newTracker();
+      final now = DateTime(2026, 8, 7, 12);
+
+      tracker.remember(800, now);
+
+      expect(tracker.consume(now.add(const Duration(seconds: 2))), isNull);
+    });
+
+    test('cancel 清空目标', () {
+      final tracker = newTracker();
+      final now = DateTime(2026, 8, 7, 12);
+
+      tracker.remember(800, now);
+      tracker.cancel();
+
+      expect(tracker.hasPending, isFalse);
+      expect(tracker.consume(now), isNull);
+    });
+
+    test('cancel 让已排队的帧回调作废——只清字段拦不住在途回调', () {
+      final tracker = newTracker();
+      final now = DateTime(2026, 8, 7, 12);
+      tracker.remember(800, now);
+
+      // 模拟排 post-frame 回调时取版本号。
+      final queued = tracker.generation;
+      expect(tracker.isCurrent(queued), isTrue);
+
+      // 用户重新拖拽 / 筛选回顶。
+      tracker.cancel();
+
+      // 回调这时才执行，必须自行退出。
+      expect(tracker.isCurrent(queued), isFalse);
+    });
+
+    test('没有 cancel 时排队的回调仍然有效', () {
+      final tracker = newTracker();
+      final now = DateTime(2026, 8, 7, 12);
+
+      final queued = tracker.generation;
+      tracker.remember(800, now);
+
+      expect(tracker.isCurrent(queued), isTrue);
+    });
+  });
 }

--- a/test/unit/widgets/note_list_scroll_anchor_test.dart
+++ b/test/unit/widgets/note_list_scroll_anchor_test.dart
@@ -158,43 +158,62 @@ void main() {
     ScrollAnchorTracker newTracker() =>
         ScrollAnchorTracker(retention: const Duration(milliseconds: 1500));
 
-    test('记住的目标可以在有效期内取出，取出后即清空', () {
-      final tracker = newTracker();
-      final now = DateTime(2026, 8, 7, 12);
+    final t0 = DateTime(2026, 8, 7, 12);
 
-      tracker.remember(800, now);
+    test('记住的目标在有效期内可以反复读取', () {
+      final tracker = newTracker();
+
+      tracker.remember(800, t0);
       expect(tracker.hasPending, isTrue);
-
-      expect(tracker.consume(now.add(const Duration(milliseconds: 500))), 800);
-      // consume 是一次性的，调用方要按决策结果决定是否重新 remember。
-      expect(tracker.hasPending, isFalse);
-      expect(tracker.consume(now), isNull);
+      expect(tracker.peek(t0.add(const Duration(milliseconds: 500))), 800);
+      // peek 不清空：调用方按决策结果再决定 remember 还是 clear。
+      expect(tracker.peek(t0.add(const Duration(milliseconds: 900))), 800);
     });
 
-    test('超过有效期的目标不再拽用户', () {
+    test('超过有效期的目标不再拽用户，并就地丢弃', () {
       final tracker = newTracker();
-      final now = DateTime(2026, 8, 7, 12);
 
-      tracker.remember(800, now);
+      tracker.remember(800, t0);
 
-      expect(tracker.consume(now.add(const Duration(seconds: 2))), isNull);
+      expect(tracker.peek(t0.add(const Duration(seconds: 2))), isNull);
+      expect(tracker.hasPending, isFalse);
     });
 
-    test('cancel 清空目标', () {
+    test('同一目标反复顺延时保留最初时刻，有效期不会被无限续期', () {
       final tracker = newTracker();
-      final now = DateTime(2026, 8, 7, 12);
 
-      tracker.remember(800, now);
-      tracker.cancel();
+      // 数据事件一个接一个地来，每次都重新挂起同一个目标。
+      tracker.remember(800, t0);
+      tracker.remember(800, t0.add(const Duration(milliseconds: 600)));
+      tracker.remember(800, t0.add(const Duration(milliseconds: 1200)));
+
+      // 若每次都重新计时，这里还在有效期内，用户会在很久后被忽然拽回去。
+      expect(tracker.peek(t0.add(const Duration(milliseconds: 1600))), isNull);
+    });
+
+    test('目标本身变了算新的夹紧事件，重新计时', () {
+      final tracker = newTracker();
+
+      tracker.remember(800, t0);
+      tracker.remember(1200, t0.add(const Duration(milliseconds: 1400)));
+
+      expect(tracker.peek(t0.add(const Duration(milliseconds: 2000))), 1200);
+    });
+
+    test('clear 清空目标但不影响版本号', () {
+      final tracker = newTracker();
+      final queued = tracker.generation;
+
+      tracker.remember(800, t0);
+      tracker.clear();
 
       expect(tracker.hasPending, isFalse);
-      expect(tracker.consume(now), isNull);
+      expect(tracker.isCurrent(queued), isTrue);
     });
 
     test('cancel 让已排队的帧回调作废——只清字段拦不住在途回调', () {
       final tracker = newTracker();
-      final now = DateTime(2026, 8, 7, 12);
-      tracker.remember(800, now);
+      tracker.remember(800, t0);
 
       // 模拟排 post-frame 回调时取版本号。
       final queued = tracker.generation;
@@ -205,16 +224,7 @@ void main() {
 
       // 回调这时才执行，必须自行退出。
       expect(tracker.isCurrent(queued), isFalse);
-    });
-
-    test('没有 cancel 时排队的回调仍然有效', () {
-      final tracker = newTracker();
-      final now = DateTime(2026, 8, 7, 12);
-
-      final queued = tracker.generation;
-      tracker.remember(800, now);
-
-      expect(tracker.isCurrent(queued), isTrue);
+      expect(tracker.hasPending, isFalse);
     });
   });
 }

--- a/test/unit/widgets/note_list_scroll_anchor_test.dart
+++ b/test/unit/widgets/note_list_scroll_anchor_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/widgets/note_list/scroll_alignment.dart';
+
+ScrollAnchorDecision _resolve({
+  double? previousOffset,
+  double? pendingOffset,
+  double currentPixels = 0,
+  double maxScrollExtent = 0,
+  bool isDragging = false,
+}) {
+  return resolveScrollAnchorAction(
+    previousOffset: previousOffset,
+    pendingOffset: pendingOffset,
+    currentPixels: currentPixels,
+    maxScrollExtent: maxScrollExtent,
+    isDragging: isDragging,
+    tolerance: 1.0,
+  );
+}
+
+void main() {
+  group('resolveScrollAnchorAction', () {
+    test('没有偏移也没有挂起目标时什么都不做', () {
+      final decision = _resolve(maxScrollExtent: 1000);
+
+      expect(decision.action, ScrollAnchorAction.none);
+    });
+
+    test('内容仍装得下原偏移时不动位置（惯性滑动中偏移本就在变）', () {
+      final decision = _resolve(
+        previousOffset: 800,
+        currentPixels: 900,
+        maxScrollExtent: 2000,
+      );
+
+      expect(decision.action, ScrollAnchorAction.none);
+    });
+
+    test('内容变短装不下原偏移时记住目标', () {
+      final decision = _resolve(
+        previousOffset: 800,
+        currentPixels: 300,
+        maxScrollExtent: 300,
+      );
+
+      expect(decision.action, ScrollAnchorAction.remember);
+      expect(decision.targetOffset, 800);
+    });
+
+    test('列表补长到够得着时还原到原偏移', () {
+      final decision = _resolve(
+        previousOffset: 300,
+        pendingOffset: 800,
+        currentPixels: 300,
+        maxScrollExtent: 900,
+      );
+
+      expect(decision.action, ScrollAnchorAction.restore);
+      expect(decision.targetOffset, 800);
+    });
+
+    test('只补长了一半时必须继续挂着更深的目标，不能悄悄丢掉', () {
+      // 先被夹到 300，本次事件把内容补到 600，但原偏移是 800。
+      final decision = _resolve(
+        previousOffset: 300,
+        pendingOffset: 800,
+        currentPixels: 300,
+        maxScrollExtent: 600,
+      );
+
+      expect(decision.action, ScrollAnchorAction.remember);
+      expect(decision.targetOffset, 800);
+    });
+
+    test('列表被压到没有滚动范围时，previousOffset 为 0 也要保住已挂起的目标', () {
+      final decision = _resolve(
+        previousOffset: 0,
+        pendingOffset: 800,
+        currentPixels: 0,
+        maxScrollExtent: 0,
+      );
+
+      expect(decision.action, ScrollAnchorAction.remember);
+      expect(decision.targetOffset, 800);
+    });
+
+    test('连续变短时取更深的目标，不会越记越浅', () {
+      final decision = _resolve(
+        previousOffset: 400,
+        pendingOffset: 800,
+        currentPixels: 200,
+        maxScrollExtent: 200,
+      );
+
+      expect(decision.action, ScrollAnchorAction.remember);
+      expect(decision.targetOffset, 800);
+    });
+
+    test('原偏移比挂起目标更深时改用原偏移', () {
+      final decision = _resolve(
+        previousOffset: 1200,
+        pendingOffset: 800,
+        currentPixels: 200,
+        maxScrollExtent: 200,
+      );
+
+      expect(decision.action, ScrollAnchorAction.remember);
+      expect(decision.targetOffset, 1200);
+    });
+
+    test('用户正在拖拽时只记不跳，避免打断手势', () {
+      final decision = _resolve(
+        previousOffset: 300,
+        pendingOffset: 800,
+        currentPixels: 300,
+        maxScrollExtent: 900,
+        isDragging: true,
+      );
+
+      expect(decision.action, ScrollAnchorAction.remember);
+      expect(decision.targetOffset, 800);
+    });
+
+    test('用户已经滑得比目标更深时不再往回拽', () {
+      final decision = _resolve(
+        pendingOffset: 800,
+        currentPixels: 1500,
+        maxScrollExtent: 2000,
+      );
+
+      expect(decision.action, ScrollAnchorAction.none);
+    });
+
+    test('目标就在容差内时视作已到位', () {
+      final decision = _resolve(
+        pendingOffset: 800,
+        currentPixels: 799.5,
+        maxScrollExtent: 2000,
+      );
+
+      expect(decision.action, ScrollAnchorAction.none);
+    });
+  });
+}

--- a/test/unit/widgets/note_list_scroll_anchor_test.dart
+++ b/test/unit/widgets/note_list_scroll_anchor_test.dart
@@ -191,13 +191,71 @@ void main() {
       expect(tracker.peek(t0.add(const Duration(milliseconds: 1600))), isNull);
     });
 
-    test('目标本身变了算新的夹紧事件，重新计时', () {
+    test('同一轮夹紧里目标越记越深也不重新计时', () {
+      final tracker = newTracker();
+
+      // 内容一次比一次短，挂起的目标随之变深，但仍是同一轮夹紧。
+      tracker.remember(800, t0);
+      tracker.remember(1200, t0.add(const Duration(milliseconds: 700)));
+      tracker.remember(1500, t0.add(const Duration(milliseconds: 1400)));
+
+      // 计时从第一次挂起算起，到这里已经超时。
+      expect(tracker.peek(t0.add(const Duration(milliseconds: 1600))), isNull);
+    });
+
+    test('过期之后本轮夹紧彻底作废，同一次决策里不能换个目标重新计时', () {
       final tracker = newTracker();
 
       tracker.remember(800, t0);
-      tracker.remember(1200, t0.add(const Duration(milliseconds: 1400)));
 
-      expect(tracker.peek(t0.add(const Duration(milliseconds: 2000))), 1200);
+      // peek 判定过期。紧接着决策又拿仍被夹紧的 previousOffset 来挂新目标 ——
+      // 这正是"有效期被无限续期"的入口，必须挡住。
+      final now = t0.add(const Duration(seconds: 2));
+      expect(tracker.peek(now), isNull);
+      expect(tracker.isExpired, isTrue);
+      expect(tracker.remember(1200, now), isFalse);
+      expect(tracker.hasPending, isFalse);
+      expect(tracker.peek(now), isNull);
+    });
+
+    test('连续刷新超过有效期后不再挂起，直到一次「无需还原」的事件翻篇', () {
+      final tracker = newTracker();
+      var now = t0;
+
+      tracker.remember(800, now);
+
+      // 数据事件每 300ms 来一次，每次都想挂起一个（可能更深的）目标。
+      var pending = 800.0;
+      for (var i = 0; i < 10; i++) {
+        now = now.add(const Duration(milliseconds: 300));
+        tracker.peek(now);
+        pending += 10;
+        tracker.remember(pending, now);
+      }
+
+      // 无论刷新多密集，1.5s 之后都不该还剩下任何待还原目标。
+      expect(tracker.peek(now), isNull);
+      expect(tracker.hasPending, isFalse);
+
+      // 列表恢复正常（决策为 none → clear）后才重新开张。
+      tracker.clear();
+      expect(tracker.isExpired, isFalse);
+      expect(tracker.remember(900, now), isTrue);
+      expect(tracker.peek(now.add(const Duration(milliseconds: 500))), 900);
+    });
+
+    test('cancel 同样解除过期封锁', () {
+      final tracker = newTracker();
+
+      tracker.remember(800, t0);
+      final now = t0.add(const Duration(seconds: 2));
+      expect(tracker.peek(now), isNull);
+
+      tracker.cancel();
+
+      expect(tracker.isExpired, isFalse);
+      expect(tracker.remember(1200, now), isTrue);
+      expect(tracker.peek(now.add(const Duration(milliseconds: 500))), 1200);
     });
 
     test('clear 清空目标但不影响版本号', () {

--- a/test/unit/widgets/note_list_scroll_anchor_test.dart
+++ b/test/unit/widgets/note_list_scroll_anchor_test.dart
@@ -170,6 +170,17 @@ void main() {
       expect(tracker.peek(t0.add(const Duration(milliseconds: 900))), 800);
     });
 
+    test('恰好卡在有效期上时目标仍然有效', () {
+      final tracker = newTracker();
+
+      tracker.remember(800, t0);
+
+      // 判定用的是 `> retention`，等于有效期这一刻还算数。
+      expect(tracker.peek(t0.add(const Duration(milliseconds: 1500))), 800);
+      expect(tracker.isExpired, isFalse);
+      expect(tracker.peek(t0.add(const Duration(milliseconds: 1501))), isNull);
+    });
+
     test('超过有效期的目标不再拽用户，并就地丢弃', () {
       final tracker = newTracker();
 

--- a/test/widget/note_list_scroll_controller_test.dart
+++ b/test/widget/note_list_scroll_controller_test.dart
@@ -228,7 +228,7 @@ class _FakeDatabaseService extends DatabaseService {
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
     int? refillCount,
-    List<Quote>? skipNotifyIfSameAs,
+    bool suppressNotify = false,
   }) async {
     loadMoreCallCount++;
   }

--- a/test/widget/note_list_scroll_controller_test.dart
+++ b/test/widget/note_list_scroll_controller_test.dart
@@ -227,6 +227,8 @@ class _FakeDatabaseService extends DatabaseService {
     List<String>? selectedWeathers,
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
+    int? refillCount,
+    List<Quote>? skipNotifyIfSameAs,
   }) async {
     loadMoreCallCount++;
   }

--- a/test/widget/note_list_search_transition_test.dart
+++ b/test/widget/note_list_search_transition_test.dart
@@ -270,7 +270,7 @@ class _SearchFakeDatabase extends DatabaseService {
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
     int? refillCount,
-    List<Quote>? skipNotifyIfSameAs,
+    bool suppressNotify = false,
   }) async {}
 
   @override

--- a/test/widget/note_list_search_transition_test.dart
+++ b/test/widget/note_list_search_transition_test.dart
@@ -269,6 +269,8 @@ class _SearchFakeDatabase extends DatabaseService {
     List<String>? selectedWeathers,
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
+    int? refillCount,
+    List<Quote>? skipNotifyIfSameAs,
   }) async {}
 
   @override

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -1122,6 +1122,8 @@ class _FakeDatabaseService extends DatabaseService {
     List<String>? selectedWeathers,
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
+    int? refillCount,
+    List<Quote>? skipNotifyIfSameAs,
   }) async {}
 
   @override
@@ -1189,6 +1191,8 @@ class _PagingFakeDatabaseService extends _DelayedFakeDatabaseService {
     List<String>? selectedWeathers,
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
+    int? refillCount,
+    List<Quote>? skipNotifyIfSameAs,
   }) async {
     loadMoreCallCount++;
     _hasMoreQuotes = true;

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -808,6 +808,47 @@ void main() {
     );
 
     testWidgets(
+      '分页结束后底部加载指示器一定会收起（即使列表仍被标记为滚动中）',
+      (tester) async {
+        // 用极短的分页，保证底部那一格落在 cacheExtent 内、确实被构建出来。
+        final databaseService = _ShortPageFakeDatabaseService();
+        final settingsService = _FakeSettingsService();
+
+        await tester.pumpWidget(
+          _TestApp(
+            databaseService: databaseService,
+            settingsService: settingsService,
+          ),
+        );
+
+        await tester.pump();
+        databaseService.emitInitialPage();
+        await tester.pump();
+        // 等 AnimatedSwitcher 把首屏 loading 完全淡出，避免误判。
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byType(AppLoadingView), findsNothing);
+
+        final listViewContext = tester.element(find.byType(ListView));
+        _dispatchPreloadScrollUpdate(listViewContext);
+        await tester.pump();
+
+        // 分页进行中：底部那一格显示加载动画。
+        expect(find.byType(AppLoadingView), findsOneWidget);
+
+        // 收尾闸门（320ms）走完后必须收起。此前这一步在"列表仍在滚动"时
+        // 只改字段、不触发重建，若之后恰好没有别的 setState，
+        // 转圈就会一直挂在列表底部收不回去。
+        await tester.pump(const Duration(milliseconds: 400));
+        expect(find.byType(AppLoadingView), findsNothing);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 2));
+        await databaseService.disposeStream();
+      },
+    );
+
+    testWidgets(
         'uses an extended cache extent to preload variable-height items', (
       tester,
     ) async {
@@ -1123,7 +1164,7 @@ class _FakeDatabaseService extends DatabaseService {
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
     int? refillCount,
-    List<Quote>? skipNotifyIfSameAs,
+    bool suppressNotify = false,
   }) async {}
 
   @override
@@ -1192,7 +1233,7 @@ class _PagingFakeDatabaseService extends _DelayedFakeDatabaseService {
     List<String>? selectedDayPeriods,
     bool? includeDeleted,
     int? refillCount,
-    List<Quote>? skipNotifyIfSameAs,
+    bool suppressNotify = false,
   }) async {
     loadMoreCallCount++;
     _hasMoreQuotes = true;
@@ -1202,6 +1243,29 @@ class _PagingFakeDatabaseService extends _DelayedFakeDatabaseService {
   void emitInitialPage() {
     _hasMoreQuotes = true;
     _controller.add(_makeQuotes(20));
+  }
+}
+
+/// 每页只给两三条的假数据源：列表足够短，底部那一格才会真的被构建。
+class _ShortPageFakeDatabaseService extends _DelayedFakeDatabaseService {
+  @override
+  Future<void> loadMoreQuotes({
+    List<String>? tagIds,
+    String? categoryId,
+    String? searchQuery,
+    List<String>? selectedWeathers,
+    List<String>? selectedDayPeriods,
+    bool? includeDeleted,
+    int? refillCount,
+    bool suppressNotify = false,
+  }) async {
+    _hasMoreQuotes = true;
+    _controller.add(_makeQuotes(3));
+  }
+
+  void emitInitialPage() {
+    _hasMoreQuotes = true;
+    _controller.add(_makeQuotes(2));
   }
 }
 

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -808,6 +808,48 @@ void main() {
     );
 
     testWidgets(
+      '分页结束后底部加载指示器一定会收起（即使列表仍被标记为滚动中）',
+      (tester) async {
+        // 笔记内容必须足够短：底部那一格要落在视口 + cacheExtent 之内才会被
+        // 真正构建出来，否则 find 永远是 0（内容一长就会踩这个坑）。
+        final databaseService = _ShortPageFakeDatabaseService();
+        final settingsService = _FakeSettingsService();
+
+        await tester.pumpWidget(
+          _TestApp(
+            databaseService: databaseService,
+            settingsService: settingsService,
+          ),
+        );
+
+        await tester.pump();
+        databaseService.emitInitialPage();
+        await tester.pump();
+        // 等 AnimatedSwitcher 把首屏 loading 完全淡出，避免误判。
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byType(AppLoadingView), findsNothing);
+
+        final listViewContext = tester.element(find.byType(ListView));
+        _dispatchPreloadScrollUpdate(listViewContext);
+        await tester.pump();
+
+        // 分页进行中：底部那一格显示加载动画。
+        expect(find.byType(AppLoadingView), findsOneWidget);
+
+        // 收尾闸门（320ms）走完后必须收起。此前这一步在"列表仍在滚动"时
+        // 只改字段、不触发重建，若之后恰好没有别的 setState，
+        // 转圈就会一直挂在列表底部收不回去。
+        await tester.pump(const Duration(milliseconds: 400));
+        expect(find.byType(AppLoadingView), findsNothing);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 2));
+        await databaseService.disposeStream();
+      },
+    );
+
+    testWidgets(
         'uses an extended cache extent to preload variable-height items', (
       tester,
     ) async {
@@ -1203,6 +1245,41 @@ class _PagingFakeDatabaseService extends _DelayedFakeDatabaseService {
     _hasMoreQuotes = true;
     _controller.add(_makeQuotes(20));
   }
+}
+
+/// 每页只给两三条**短**笔记：列表总高不超过视口 + cacheExtent，
+/// 底部那一格才会被真正构建出来。
+class _ShortPageFakeDatabaseService extends _DelayedFakeDatabaseService {
+  @override
+  Future<void> loadMoreQuotes({
+    List<String>? tagIds,
+    String? categoryId,
+    String? searchQuery,
+    List<String>? selectedWeathers,
+    List<String>? selectedDayPeriods,
+    bool? includeDeleted,
+    int? refillCount,
+    bool suppressNotify = false,
+  }) async {
+    _hasMoreQuotes = true;
+    _controller.add(_makeShortQuotes(3));
+  }
+
+  void emitInitialPage() {
+    _hasMoreQuotes = true;
+    _controller.add(_makeShortQuotes(2));
+  }
+}
+
+List<Quote> _makeShortQuotes(int count) {
+  return List<Quote>.generate(
+    count,
+    (index) => Quote(
+      id: 'quote-$index',
+      content: '短笔记 $index',
+      date: DateTime(2026, 5, 10, 8, index).toIso8601String(),
+    ),
+  );
 }
 
 List<Quote> _makeQuotes(int count) {

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -808,47 +808,6 @@ void main() {
     );
 
     testWidgets(
-      '分页结束后底部加载指示器一定会收起（即使列表仍被标记为滚动中）',
-      (tester) async {
-        // 用极短的分页，保证底部那一格落在 cacheExtent 内、确实被构建出来。
-        final databaseService = _ShortPageFakeDatabaseService();
-        final settingsService = _FakeSettingsService();
-
-        await tester.pumpWidget(
-          _TestApp(
-            databaseService: databaseService,
-            settingsService: settingsService,
-          ),
-        );
-
-        await tester.pump();
-        databaseService.emitInitialPage();
-        await tester.pump();
-        // 等 AnimatedSwitcher 把首屏 loading 完全淡出，避免误判。
-        await tester.pump(const Duration(milliseconds: 300));
-
-        expect(find.byType(AppLoadingView), findsNothing);
-
-        final listViewContext = tester.element(find.byType(ListView));
-        _dispatchPreloadScrollUpdate(listViewContext);
-        await tester.pump();
-
-        // 分页进行中：底部那一格显示加载动画。
-        expect(find.byType(AppLoadingView), findsOneWidget);
-
-        // 收尾闸门（320ms）走完后必须收起。此前这一步在"列表仍在滚动"时
-        // 只改字段、不触发重建，若之后恰好没有别的 setState，
-        // 转圈就会一直挂在列表底部收不回去。
-        await tester.pump(const Duration(milliseconds: 400));
-        expect(find.byType(AppLoadingView), findsNothing);
-
-        await tester.pumpWidget(const SizedBox.shrink());
-        await tester.pump(const Duration(seconds: 2));
-        await databaseService.disposeStream();
-      },
-    );
-
-    testWidgets(
         'uses an extended cache extent to preload variable-height items', (
       tester,
     ) async {
@@ -1243,29 +1202,6 @@ class _PagingFakeDatabaseService extends _DelayedFakeDatabaseService {
   void emitInitialPage() {
     _hasMoreQuotes = true;
     _controller.add(_makeQuotes(20));
-  }
-}
-
-/// 每页只给两三条的假数据源：列表足够短，底部那一格才会真的被构建。
-class _ShortPageFakeDatabaseService extends _DelayedFakeDatabaseService {
-  @override
-  Future<void> loadMoreQuotes({
-    List<String>? tagIds,
-    String? categoryId,
-    String? searchQuery,
-    List<String>? selectedWeathers,
-    List<String>? selectedDayPeriods,
-    bool? includeDeleted,
-    int? refillCount,
-    bool suppressNotify = false,
-  }) async {
-    _hasMoreQuotes = true;
-    _controller.add(_makeQuotes(3));
-  }
-
-  void emitInitialPage() {
-    _hasMoreQuotes = true;
-    _controller.add(_makeQuotes(2));
   }
 }
 


### PR DESCRIPTION
## 问题

滚动中列表突然「飞走 / 弹回顶部 + 底部转圈 + 大片空白」。性能日志里有完整现场：

```
scroll-7: quotes={total=115 ...}
scroll-8: quotes={total=100 ...}          ← 列表变短
          extent={start=28066, end=21799, range=11883-29147}
          activity={dataΔ=2, loadMoreStartΔ=1}
```

`total` 从 115 掉回 100，`maxScrollExtent` 最低到过 **11883**（正好一页 50 条的高度），而用户当时停在 **28066**。列表在手指底下从 115 条塌回 50 条，滚动位置被夹到 11883 —— 这就是「飞回顶部」；夹紧后 `_hasMore` 重新变 true、尾部占位格冒出来 —— 这就是「加载图标闪一下」；中间那一两帧列表只有 50 条 —— 这就是「大片空白」。`dataΔ=2 + loadMoreStartΔ=1`（先推 50 条、再补一页到 100 条）与之完全吻合。

根因在数据层，与滚动代码无关：**`_refreshQuotesStream()` 只把第一页取回来**。它的调用方遍布全应用——保存笔记、收藏、离线位置回填、启动 12 秒后的回收站过期清理、WebDAV 同步、导入——任何一个触发，正在深处滚动的列表就塌一次。触发时机随机且频繁，与反馈的复现率一致。

## 改动

### 数据层（治本）

- `_refreshQuotesStream` 按刷新前已加载的条数**一次性回填**（`loadMoreQuotes` 新增 `refillCount`），列表长度保持不变，中途不再出现更短的中间态。单次查询设 500 条上限，避免极深列表把刷新拖成慢查询。
- 回填结果与刷新前完全一致时**跳过整表推送**。回收站过期清理、同步后的例行刷新等场景可见列表一条都没变，白白重建上百个 item 就是滚动帧里的一次卡顿（对应日志中的 `built=153`、`worstBuild=97ms`）。判定要求每条都有 `lastModified`，缺失即视为「不确定」照常推送，宁可多推也不漏掉真实更新。
- `watchQuotes` 复用已有流时不再把 `_watchOffset` 归零。这是一个独立 bug：归零会让下一次分页重查第一页、结果全被去重掉，列表一条不涨却把 `_watchHasMore` 重置回 true——底部加载指示器就此常驻并反复触发无效查询。

### 列表页

- `_hasMore` 直接取数据库的真实分页状态。此前先用 `list.length >= pageSize` 推断（100 条也算 true），再在 `setState` **外面**纠正，导致每个数据事件都会先渲染一帧多出来的尾部格子。
- 底部加载指示器改由 `ValueNotifier` 驱动：切换只重建那一格，不牵动已加载的上百个 item，且加载结束后一定会收起。原先 `_settleLoadMoreLoadingFlag` 在滚动中只改字段不重建（为了不在滚动帧里重建整列表），之后若恰好没有别的 `setState`，转圈会一直挂在列表底部。
- 新增滚动锚点兜底：数据事件后若内容短到装不下原偏移，记下偏移并在列表补长后无动画还原；用户重新按住列表则放弃还原。**只判断 `maxScrollExtent` 是否装得下，不比较 `pixels`**——数据事件常发生在惯性滑动中，按偏移差纠正等于和惯性打架。

### 图片

- 列表内嵌图片 `filterQuality` 由 `medium` 降为 `low`。解码尺寸已按 `displayWidth × devicePixelRatio` 精确匹配显示尺寸，绘制基本是 1:1 采样，`medium` 的 mipmap 生成属于纯开销，画面无差异。

## 视觉变化（一处，已与作者确认）

底部「还有下一页」占位格：空闲态 48、加载态 80 的 Lottie 外加上下各 16 内边距（合计 112）。**每翻转一次列表总高就跳 64 像素**，贴着底部滑动时肉眼可见。两种状态统一为 80 高。

该格永远处在「还有下一页」的过渡区，正常滑动看不到；代价是列表最底部多出约 32 像素空白。备选方案是保持 48、把加载动画缩到 48。

## 测试

`test/unit/services/database_pagination_test.dart` 新增 3 个回归测试：

- 刷新按已加载条数一次性回填，过程中任何一个事件都不得把列表截短，且只发一次 `offset=0, limit=6` 的查询
- 筛选条件未变时重新订阅不会把分页偏移重置回 0
- 刷新结果与刷新前完全一致时不再整表推送

另同步更新了 5 处 `loadMoreQuotes` 的 fake / mock 签名。

## 未包含（需要单独决策）

- **图片解码分辨率**：日志显示 `imageCache` 平均每张 **2.8MB**、29 张即顶到 100MB 上限，滑回来就要重新解码。把列表预览的解码 dpr 从 3 降到 2 可让占用降到约 36MB，代价是卡片内小图理论上略软。属画质取舍，待确认。
- **富文本列表渲染**：列表内跑的是完整 `QuillEditor`，单次文档解析最高 14ms（`docWorstUs=14358`），40 个 `QuillController` 常驻且 `ctrlDispose=0`。属结构性改造，另开一轮。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJzeeKb5wQiXxPJs6dxz6K

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJzeeKb5wQiXxPJs6dxz6K)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复刷新导致列表塌回第一页/飞回顶部与底部指示器常驻；滚动锚点更稳且不打断惯性滑动。卡片图片解码限宽 + 总像素预算，降低内存与卡顿；回填失败整体回滚并保住分页状态。

- **Bug Fixes**
  - 数据层：刷新按已加载数分块回填（单次≤500，沿用在途目标），全部到位后一次推送；失败不推半成品并整体回滚列表/ID/分页游标与 `hasMore`；`loadMoreQuotes` 新增 `refillCount`/`suppressNotify` 且抑制期间所有错误上抛；`watchQuotes` 复用流不重置 offset；`_hasMore` 直接取数据库值。
  - 列表页：引入滚动锚点 `ScrollAnchorTracker`（有效期、防续期、generation 作废）；仅在被 `maxScrollExtent` 夹紧时记锚点，拖拽中只记不跳，筛选回顶/用户接管时作废；底部指示器用 `ValueNotifier` 驱动，加载结束必收起，空闲/加载统一高 80。
  - 图片：卡片预览解码倍率封顶 2×（随设备 dpr）；新增总解码像素预算防超长图炸内存；同时给宽高时用 `ResizeImagePolicy.fit`；内嵌图 `filterQuality=low`；导出 `decodeSizeFor`/`decodeHeightBudget`/`wrapWithDecodeLimit`。

<sup>Written for commit d15030e31f2054bee0a1489d96c6b4709eb7bfc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 刷新笔记列表时保留已加载数量，减少内容跳动。
  * 优化图片解码尺寸控制，提升图片加载效率。
* **问题修复**
  * 改善列表数据更新后的滚动位置保持与恢复。
  * 修复筛选切换、拖动及分页结束时的滚动和加载提示异常。
  * 回填失败时恢复原列表状态，避免数据显示不完整。
  * 数据未变化时避免重复刷新列表。
* **性能优化**
  * 优化列表加载提示更新，减少不必要的整体重建。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->