### PR TITLE
feat(home,push): 每日思考 AI 入口随时可点，推送频率拨盘只留滑块

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3486,6 +3486,8 @@
   "smartPushTimeSettings": "Push Time",
   "smartPushAddTime": "Add Push Time",
   "smartPushFrequency": "Push Frequency",
+  "smartPushIntensityFewer": "Fewer",
+  "smartPushIntensityMore": "More",
   "smartPushFrequencyDaily": "Daily",
   "smartPushFrequencyWeekdays": "Weekdays",
   "smartPushFrequencyWeekends": "Weekends",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3356,6 +3356,8 @@
   "smartPushTimeSettings": "Temps de poussée",
   "smartPushAddTime": "Ajouter un temps de poussée",
   "smartPushFrequency": "Fréquence de poussée",
+  "smartPushIntensityFewer": "Moins",
+  "smartPushIntensityMore": "Plus",
   "smartPushFrequencyDaily": "Tous les jours",
   "smartPushFrequencyWeekdays": "Jours de la semaine",
   "smartPushFrequencyWeekends": "Week-ends",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -3370,6 +3370,8 @@
   "smartPushTimeSettings": "時間設定",
   "smartPushAddTime": "時間追加",
   "smartPushFrequency": "頻度",
+  "smartPushIntensityFewer": "少なめ",
+  "smartPushIntensityMore": "多め",
   "smartPushFrequencyDaily": "毎日",
   "smartPushFrequencyWeekdays": "平日",
   "smartPushFrequencyWeekends": "週末",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -3370,6 +3370,8 @@
   "smartPushTimeSettings": "푸시 시간",
   "smartPushAddTime": "푸시 시간 추가",
   "smartPushFrequency": "푸시 빈도",
+  "smartPushIntensityFewer": "적게",
+  "smartPushIntensityMore": "많게",
   "smartPushFrequencyDaily": "일일",
   "smartPushFrequencyWeekdays": "평일",
   "smartPushFrequencyWeekends": "주말",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3485,6 +3485,8 @@
   "smartPushTimeSettings": "推送时间",
   "smartPushAddTime": "添加推送时间",
   "smartPushFrequency": "推送频率",
+  "smartPushIntensityFewer": "更少",
+  "smartPushIntensityMore": "更多",
   "smartPushFrequencyDaily": "每天",
   "smartPushFrequencyWeekdays": "工作日",
   "smartPushFrequencyWeekends": "周末",

--- a/lib/models/smart_push_settings.dart
+++ b/lib/models/smart_push_settings.dart
@@ -72,33 +72,6 @@ class PushQuotaProfile {
 }
 
 extension PushIntensityX on PushIntensity {
-  String get label {
-    switch (this) {
-      case PushIntensity.rare:
-        return '很少';
-      case PushIntensity.restrained:
-        return '克制';
-      case PushIntensity.balanced:
-        return '适中';
-      case PushIntensity.frequent:
-        return '多一些';
-    }
-  }
-
-  /// 拨盘底下那行实时文案 —— 只说体感，不暴露内部上限数字
-  String get description {
-    switch (this) {
-      case PushIntensity.rare:
-        return '大约每周 2-3 条，安静时更少';
-      case PushIntensity.restrained:
-        return '大约每天 1 条，安静时更少';
-      case PushIntensity.balanced:
-        return '每天 1-2 条，安静时更少';
-      case PushIntensity.frequent:
-        return '每天最多 3 条，安静时更少';
-    }
-  }
-
   /// 查配额矩阵：拨盘档位在行，参与度分档在列
   PushQuotaProfile quotaFor(EngagementTier tier) {
     switch (this) {

--- a/lib/pages/home/daily_prompt_panel.dart
+++ b/lib/pages/home/daily_prompt_panel.dart
@@ -169,16 +169,9 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
     });
   }
 
-  /// 提示还在生成时不给点：此时手上只有半截文本，
-  /// 带进对话会让 Thoughter 看到一句没说完的话。
-  /// 生成流由本面板持有，跳走也不会中断，回来就是完整的。
-  bool get _canAskThoughter =>
-      !_isGeneratingDailyPrompt && _accumulatedPromptText.trim().isNotEmpty;
-
   static const double _askButtonSize = 32;
 
   Widget _buildAskThoughterButton(ThemeData theme, AppLocalizations l10n) {
-    final enabled = _canAskThoughter;
     return SizedBox(
       width: _askButtonSize,
       height: _askButtonSize,
@@ -186,14 +179,30 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
         padding: EdgeInsets.zero,
         iconSize: widget.isVerySmallScreen ? 16 : 18,
         tooltip: l10n.askNote,
-        onPressed: enabled ? _openThoughterWithPrompt : null,
+        onPressed: _openThoughterWithPrompt,
         icon: Icon(
           Icons.auto_awesome,
-          color: enabled
-              ? theme.colorScheme.primary
-              : theme.colorScheme.onSurface.withValues(alpha: 0.3),
+          color: theme.colorScheme.primary,
         ),
       ),
+    );
+  }
+
+  /// 进对话时用的开场白。
+  ///
+  /// 面板上那句话生成完了就用它；还在流式生成（手上只有半截话）或者压根
+  /// 没生成时，用本地模板按当前时段/天气/城市现拼一句——入口任何时候都
+  /// 能点，不会因为提示没加载出来就变灰。
+  String _openingMessage() {
+    final prompt = _accumulatedPromptText.trim();
+    if (!_isGeneratingDailyPrompt && prompt.isNotEmpty) return prompt;
+
+    final weatherService = context.read<WeatherService>();
+    return DailyPromptGenerator.generatePromptBasedOnContext(
+      AppLocalizations.of(context),
+      city: context.read<LocationService>().city,
+      weather: weatherService.currentWeather,
+      temperature: weatherService.temperature,
     );
   }
 
@@ -203,13 +212,11 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
   /// 第一句，也进入模型上下文——不需要再让 AI 生成一次开场，也不替用户
   /// 先问一句，接下来说什么由用户决定。
   void _openThoughterWithPrompt() {
-    final prompt = _accumulatedPromptText.trim();
-    if (prompt.isEmpty) return;
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => ThoughterPage(
           entrySource: ThoughterEntrySource.explore,
-          openingMessage: prompt,
+          openingMessage: _openingMessage(),
         ),
       ),
     );

--- a/lib/pages/smart_push_settings_page.dart
+++ b/lib/pages/smart_push_settings_page.dart
@@ -264,13 +264,12 @@ class _SmartPushSettingsPageState extends State<SmartPushSettingsPage>
 
             const SizedBox(height: 16),
 
-            // 推送频率拨盘（上限，疲劳系统在其内做减法）
-            _buildIntensityCard(l10n, theme, colorScheme),
-
-            // 自定义模式：显示完整高级选项
-            if (_settings.pushMode == PushMode.custom) ...[
-              const SizedBox(height: 16),
-
+            // 智能模式：推送频率拨盘（上限，疲劳系统在其内做减法）
+            // 自定义模式不显示——时段和频率都由用户自己排，再叠一层上限
+            // 只会让用户排的东西推不出来
+            if (_settings.pushMode == PushMode.smart)
+              _buildIntensityCard(l10n, theme, colorScheme)
+            else ...[
               // 推送时间设置
               _buildTimeSettingsCard(l10n, theme, colorScheme),
 

--- a/lib/pages/smart_push_settings_page_basic_sections.dart
+++ b/lib/pages/smart_push_settings_page_basic_sections.dart
@@ -137,11 +137,11 @@ extension _SmartPushSettingsPageBasicSections on _SmartPushSettingsPageState {
     );
   }
 
-  /// 推送频率拨盘卡片
+  /// 推送频率拨盘卡片（仅智能模式）
   ///
   /// 拨盘定的是**上限**：向右只是放宽天花板，不会突破连续未点击的降级逻辑。
-  /// 所以文案只说体感（"大约每天 1 条"），不暴露内部数字，免得用户
-  /// 拨到最右却没天天收到、以为坏了。
+  /// 正因为给不出准数，这里不写"大约每天几条"之类的承诺，只留一个
+  /// 少↔多的滑块，免得用户拨到最右却没天天收到、以为坏了。
   Widget _buildIntensityCard(
     AppLocalizations l10n,
     ThemeData theme,
@@ -171,15 +171,8 @@ extension _SmartPushSettingsPageBasicSections on _SmartPushSettingsPageState {
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  '推送频率',
+                  l10n.smartPushFrequency,
                   style: theme.textTheme.titleSmall?.copyWith(
-                    color: colorScheme.primary,
-                  ),
-                ),
-                const Spacer(),
-                Text(
-                  _settings.pushIntensity.label,
-                  style: theme.textTheme.labelLarge?.copyWith(
                     color: colorScheme.primary,
                   ),
                 ),
@@ -191,7 +184,6 @@ extension _SmartPushSettingsPageBasicSections on _SmartPushSettingsPageState {
               min: 0,
               max: (values.length - 1).toDouble(),
               divisions: values.length - 1,
-              label: _settings.pushIntensity.label,
               onChanged: (value) {
                 final next = values[value.round()];
                 if (next == _settings.pushIntensity) return;
@@ -206,32 +198,18 @@ extension _SmartPushSettingsPageBasicSections on _SmartPushSettingsPageState {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Text(
-                    values.first.label,
+                    l10n.smartPushIntensityFewer,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: colorScheme.onSurfaceVariant,
                     ),
                   ),
                   Text(
-                    values.last.label,
+                    l10n.smartPushIntensityMore,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: colorScheme.onSurfaceVariant,
                     ),
                   ),
                 ],
-              ),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              _settings.pushIntensity.description,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: colorScheme.onSurfaceVariant,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              '长期不打开时会自动减少，一直不理会时会进一步放缓。',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.8),
               ),
             ),
           ],

--- a/lib/services/smart_push/smart_push_execution.dart
+++ b/lib/services/smart_push/smart_push_execution.dart
@@ -187,21 +187,25 @@ extension SmartPushExecution on SmartPushService {
         // 顺序不能反：结算会推进/复位连续未点击计数，配额裁定要读它。
         await _analytics.settlePendingSend();
 
-        allowance = await _analytics.checkPushAllowance(
-          intensity: _settings.pushIntensity,
-          lastPushTime: _settings.lastPushTime,
-        );
-
-        if (!allowance.allowed) {
-          AppLogger.w(
-            '智能推送被跳过 [${allowance.tier.name}/${_settings.pushIntensity.name}]: '
-            '${allowance.reason}',
+        // 配额拨盘只管智能模式。自定义模式下时段和频率都是用户自己排的，
+        // 设置页里也没有这个拨盘，这里再拿它做减法就成了看不见的克扣。
+        if (_settings.pushMode == PushMode.smart) {
+          allowance = await _analytics.checkPushAllowance(
+            intensity: _settings.pushIntensity,
+            lastPushTime: _settings.lastPushTime,
           );
-          // 仍然重新调度下次推送
-          if (!isBackground) {
-            await scheduleNextPush();
+
+          if (!allowance.allowed) {
+            AppLogger.w(
+              '智能推送被跳过 [${allowance.tier.name}/${_settings.pushIntensity.name}]: '
+              '${allowance.reason}',
+            );
+            // 仍然重新调度下次推送
+            if (!isBackground) {
+              await scheduleNextPush();
+            }
+            return;
           }
-          return;
         }
       }
 

--- a/test/widget/pages/home/daily_prompt_panel_test.dart
+++ b/test/widget/pages/home/daily_prompt_panel_test.dart
@@ -217,5 +217,27 @@ void main() {
       expect(promptText, findsOneWidget);
       expect(tester.widget<Text>(promptText).data, isNotEmpty);
     });
+
+    testWidgets('Thoughter 入口在提示还没生成完时也能点', (WidgetTester tester) async {
+      // 提示加载不出来（或还在流式生成）时入口不该变灰：开场白改用本地
+      // 模板现拼一句，点得动才是关键。
+      final controller = StreamController<String>();
+      addTearDown(controller.close);
+      mockAIService._mockStream = controller.stream;
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      final state = tester
+          .state<HomeDailyPromptPanelState>(find.byType(HomeDailyPromptPanel));
+      unawaited(state.refreshPrompt());
+      await tester.pump();
+
+      final askButton = find.ancestor(
+        of: find.byIcon(Icons.auto_awesome),
+        matching: find.byType(IconButton),
+      );
+      expect(askButton, findsOneWidget);
+      expect(tester.widget<IconButton>(askButton).onPressed, isNotNull);
+    });
   });
 }


### PR DESCRIPTION
## 改动

### 1. 每日思考的 Thoughter 入口不再变灰

入口原先要等提示流生成完才可点，提示加载不出来时就一直是灰的。现在常亮：

- 提示已生成完 → 照旧把面板上那句话当开场白带进对话
- 还在流式生成 / 压根没生成 → 用 `DailyPromptGenerator` 按当前时段、天气、城市现拼一句本地模板作为开场白

半截文本不会被带进对话，所以不会出现「一句没说完的话」。

### 2. 推送频率拨盘只留一个滑块

- 去掉档位名（很少/克制/适中/多一些）和两行说明文案（「大约每天 1 条…」「长期不打开时会自动减少…」），只留「更少 ↔ 更多」的滑块。拨盘定的是上限而不是承诺，写死条数反而容易让人以为功能坏了
- 标题改用 `l10n.smartPushFrequency`，端点新增 `smartPushIntensityFewer` / `smartPushIntensityMore`（zh / en / fr / ja / ko）
- 随之空掉的 `PushIntensity.label` / `description` 一并删除，`quotaFor` 配额矩阵不变

### 3. 自定义模式不再显示拨盘

时段和频率都由用户自己排，再叠一层上限没有意义。除了隐藏卡片，推送执行时也跳过配额裁定（`checkPushAllowance`）——否则就成了设置页看不见的克扣。`settlePendingSend` 保留，内容评分和点击结算不受影响。顺带把「非 smart 的历史模式」也归到自定义分支，与模式选择卡片的 radio 显示保持一致。

## 验证

- `flutter analyze --no-fatal-infos`：无新增问题（剩余 4 条均为仓库既有 info）
- `dart format --set-exit-if-changed`：通过
- `flutter test test/widget/pages/home/daily_prompt_panel_test.dart test/unit/services/smart_push_analytics_test.dart test/widget/pages/home_page_test.dart test/unit/models`：全部通过
- 新增回归测试：提示流未结束时 Thoughter 入口的 `onPressed` 非空

---
_Generated by [Claude Code](https://claude.ai/code/session_018TcWZCyWpd7jeYRzDiSxrm)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
每日思考入口随时可点，提示未生成时用本地模板作开场。推送频率拨盘简化为“更少↔更多”的滑块。

- 新功能
  - Thoughter 入口常亮：提示流未结束或未生成时，用 `DailyPromptGenerator` 按时段/天气/城市现拼开场白，避免半句带入。
  - 推送频率卡片仅保留滑块；标题接入 `l10n.smartPushFrequency`，新增 `smartPushIntensityFewer`/`smartPushIntensityMore`（zh/en/fr/ja/ko）。

- 重构
  - 拨盘仅在智能模式显示；自定义模式隐藏并在执行时跳过 `checkPushAllowance`（保留 `settlePendingSend`），与设置页一致。
  - 移除 `PushIntensity.label`/`description` 及相关 UI；`quotaFor` 配额矩阵不变。

<sup>Written for commit efa6ee0c70053bc2d174432e6b14263ee7c5175e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增智能推送强度的“更少/更多”选项，并支持英语、法语、日语、韩语和中文。
  * 每日提示尚未生成完成或内容为空时，仍可使用 Thoughter 入口。

* **改进**
  * 推送频率调节器仅在智能推送模式下显示。
  * 优化频率设置说明与滑块标签，表达更加简洁直观。
  * 自定义推送模式不再受智能推送配额限制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->