### PR TITLE
fix(thoughter): 输入框改平，过程只留一个入口，工具跑完继续思考不再顶着工具名

### DIFF
--- a/lib/pages/thoughter/thoughter_agent.dart
+++ b/lib/pages/thoughter/thoughter_agent.dart
@@ -118,7 +118,16 @@ extension _ThoughterAgent on _ThoughterPageState {
           case AgentReasoningDeltaEvent():
             ensureToolProgressMessage();
             toolProgressInProgress = true;
-            toolThinkingText = '${toolThinkingText ?? ''}${event.delta}';
+            // 已经调过工具的话，这段思考是"查完之后又想的"，挂到那枚工具下面。
+            // 全部并进开头那一坨的话，抽屉里会读成模型动手之前就知道了结果。
+            if (toolItems.isEmpty) {
+              toolThinkingText = '${toolThinkingText ?? ''}${event.delta}';
+            } else {
+              final last = toolItems.last;
+              toolItems[toolItems.length - 1] = last.copyWith(
+                thinkingText: '${last.thinkingText ?? ''}${event.delta}',
+              );
+            }
             _scheduleToolProgressUpdate(
               toolProgressMsgId!,
               toolItems,
@@ -433,6 +442,7 @@ extension _ThoughterAgent on _ThoughterPageState {
                     'status': i.status.name,
                     'result': i.result ?? '',
                     'narrationText': i.narrationText ?? '',
+                    'thinkingText': i.thinkingText ?? '',
                   })
               .toList(),
           'inProgress': inProgress,

--- a/lib/pages/thoughter/thoughter_ui.dart
+++ b/lib/pages/thoughter/thoughter_ui.dart
@@ -8,6 +8,12 @@ const double _kUserBubbleWidthFactor = 0.78;
 /// markdown 的排版落在最后一个字后面，而不是另起一行。
 const String _kStreamingCursor = '▌';
 
+/// 输入框的排版参数。发送键的居中量是从这三者算出来的
+/// （见 [_ThoughterUI._sendButtonBottomInset]），改任何一个都不用手动补偿。
+const double _kComposerLineHeight = 1.35;
+const double _kComposerVerticalPadding = 12;
+const double _kSendButtonDiameter = 36;
+
 extension _ThoughterUI on _ThoughterPageState {
   /// 消息区可用高度变小（键盘上推、输入框变多行）时跟着贴底，
   /// 保证最后一条消息不会被顶出可视区。
@@ -865,10 +871,14 @@ extension _ThoughterUI on _ThoughterPageState {
                   children: [
                     Expanded(child: _buildComposerField(theme, l10n)),
                     Padding(
-                      // 底部这 5 不是间距而是算出来的居中量：单行时输入框内
-                      // 容高 46，(46 - 36) / 2 正好把按钮摆在这一行的中线上；
-                      // 换行长高后它自然落在最后一行边上。
-                      padding: const EdgeInsets.only(right: 8, bottom: 5),
+                      // 底边距不是间距，是算出来的居中量：单行时正好把按钮摆在
+                      // 那一行的中线上，换行长高后它自然落在最后一行边上。跟着
+                      // 字号和内边距算，主题换了字号（纸墨 17、Material 16）也
+                      // 不会偏。
+                      padding: EdgeInsets.only(
+                        right: 8,
+                        bottom: _sendButtonBottomInset(theme),
+                      ),
                       child: _buildSendButton(theme, l10n),
                     ),
                   ],
@@ -876,6 +886,19 @@ extension _ThoughterUI on _ThoughterPageState {
         ),
       ),
     );
+  }
+
+  /// 发送键距输入框底边的距离。
+  ///
+  /// 单行时把这枚圆按钮摆在文字那一行的中线上：(单行内容高 - 按钮直径) / 2。
+  /// 三个参数（字号、行高、上下内边距）都是现算的，主题换字号或以后调内边距
+  /// 时按钮不会悄悄偏出这一行；换行长高后 `CrossAxisAlignment.end` 让它自然
+  /// 落在最后一行边上。
+  double _sendButtonBottomInset(ThemeData theme) {
+    final fontSize = theme.textTheme.bodyLarge?.fontSize ?? 16;
+    final lineHeight = fontSize * _kComposerLineHeight;
+    final fieldHeight = lineHeight + _kComposerVerticalPadding * 2;
+    return ((fieldHeight - _kSendButtonDiameter) / 2).clamp(0.0, 16.0);
   }
 
   /// 输入框本体。默认一行高，随换行增高；超过上限后内部滚动，
@@ -887,16 +910,23 @@ extension _ThoughterUI on _ThoughterPageState {
       child: TextField(
         controller: _textController,
         focusNode: _inputFocusNode,
-        style: theme.textTheme.bodyLarge?.copyWith(height: 1.35),
+        style: theme.textTheme.bodyLarge?.copyWith(
+          height: _kComposerLineHeight,
+        ),
         decoration: InputDecoration(
           hintText: l10n.aiAssistantInputHint,
           hintStyle: theme.textTheme.bodyLarge?.copyWith(
-            height: 1.35,
+            height: _kComposerLineHeight,
             color: scheme.onSurfaceVariant.withValues(alpha: 0.7),
           ),
           border: InputBorder.none,
           isCollapsed: true,
-          contentPadding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+          contentPadding: const EdgeInsets.fromLTRB(
+            16,
+            _kComposerVerticalPadding,
+            8,
+            _kComposerVerticalPadding,
+          ),
         ),
         maxLines: null,
         minLines: 1,
@@ -949,8 +979,8 @@ extension _ThoughterUI on _ThoughterPageState {
                 scheme.onSurfaceVariant.withValues(alpha: 0.5),
             shape: const CircleBorder(),
             padding: EdgeInsets.zero,
-            fixedSize: const Size(36, 36),
-            minimumSize: const Size(36, 36),
+            fixedSize: const Size(_kSendButtonDiameter, _kSendButtonDiameter),
+            minimumSize: const Size(_kSendButtonDiameter, _kSendButtonDiameter),
           ),
         );
       },

--- a/lib/pages/thoughter/thoughter_ui.dart
+++ b/lib/pages/thoughter/thoughter_ui.dart
@@ -871,15 +871,18 @@ extension _ThoughterUI on _ThoughterPageState {
                   children: [
                     Expanded(child: _buildComposerField(theme, l10n)),
                     Padding(
-                      // 底边距不是间距，是算出来的居中量：单行时正好把按钮摆在
-                      // 那一行的中线上，换行长高后它自然落在最后一行边上。跟着
-                      // 字号和内边距算，主题换了字号（纸墨 17、Material 16）也
-                      // 不会偏。
-                      padding: EdgeInsets.only(
-                        right: 8,
-                        bottom: _sendButtonBottomInset(theme),
+                      padding: const EdgeInsets.only(right: 8),
+                      // 按钮装在一个"正好一行高"的盒子里再居中：盒子被 end
+                      // 对齐压在最后一行上，于是单行时按钮坐在那一行的中线，
+                      // 换行长高后自动跟到最后一行。
+                      //
+                      // 不去算按钮该往上抬多少——IconButton 的渲染盒会被撑到
+                      // 48 的点击区（tapTargetSize.padded），按直径 36 算出来
+                      // 的居中量会差 6 像素。让 Center 去对付按钮的真实尺寸。
+                      child: SizedBox(
+                        height: _composerLineBoxHeight(theme),
+                        child: Center(child: _buildSendButton(theme, l10n)),
                       ),
-                      child: _buildSendButton(theme, l10n),
                     ),
                   ],
                 ),
@@ -888,17 +891,15 @@ extension _ThoughterUI on _ThoughterPageState {
     );
   }
 
-  /// 发送键距输入框底边的距离。
+  /// 输入框单行时的高度：一行文字加上下内边距。
   ///
-  /// 单行时把这枚圆按钮摆在文字那一行的中线上：(单行内容高 - 按钮直径) / 2。
-  /// 三个参数（字号、行高、上下内边距）都是现算的，主题换字号或以后调内边距
-  /// 时按钮不会悄悄偏出这一行；换行长高后 `CrossAxisAlignment.end` 让它自然
-  /// 落在最后一行边上。
-  double _sendButtonBottomInset(ThemeData theme) {
+  /// 字号要过一遍 textScaler：系统开了大字体，输入行跟着变高而按钮不变，
+  /// 拿未放大的字号算，字越大按钮偏得越远。
+  double _composerLineBoxHeight(ThemeData theme) {
     final fontSize = theme.textTheme.bodyLarge?.fontSize ?? 16;
-    final lineHeight = fontSize * _kComposerLineHeight;
-    final fieldHeight = lineHeight + _kComposerVerticalPadding * 2;
-    return ((fieldHeight - _kSendButtonDiameter) / 2).clamp(0.0, 16.0);
+    final scaledFontSize = MediaQuery.textScalerOf(context).scale(fontSize);
+    return scaledFontSize * _kComposerLineHeight +
+        _kComposerVerticalPadding * 2;
   }
 
   /// 输入框本体。默认一行高，随换行增高；超过上限后内部滚动，

--- a/lib/pages/thoughter/thoughter_ui.dart
+++ b/lib/pages/thoughter/thoughter_ui.dart
@@ -8,10 +8,13 @@ const double _kUserBubbleWidthFactor = 0.78;
 /// markdown 的排版落在最后一个字后面，而不是另起一行。
 const String _kStreamingCursor = '▌';
 
-/// 输入框的排版参数。发送键的居中量是从这三者算出来的
-/// （见 [_ThoughterUI._sendButtonBottomInset]），改任何一个都不用手动补偿。
+/// 输入框单行的排版参数：字号 × 行高 + 上下内边距 = 一行的盒子高度
+/// （见 [_ThoughterUI._composerLineBoxHeight]），发送键就在那个盒子里居中，
+/// 所以改这两个值不用手动补偿按钮位置。
 const double _kComposerLineHeight = 1.35;
 const double _kComposerVerticalPadding = 12;
+
+/// 发送键的视觉直径。点击区由 IconButton 自己撑到 48，不参与定位。
 const double _kSendButtonDiameter = 36;
 
 extension _ThoughterUI on _ThoughterPageState {

--- a/lib/pages/thoughter/thoughter_ui.dart
+++ b/lib/pages/thoughter/thoughter_ui.dart
@@ -360,6 +360,7 @@ extension _ThoughterUI on _ThoughterPageState {
                 ),
                 result: map['result'] as String?,
                 narrationText: map['narrationText'] as String?,
+                thinkingText: map['thinkingText'] as String?,
               );
             }).toList();
             return Padding(
@@ -595,11 +596,10 @@ extension _ThoughterUI on _ThoughterPageState {
     AppLocalizations l10n,
   ) {
     final toolSnapshot = _toolProcessBefore(message);
-    // 只思考的那轮说「查看思考过程」，调了工具才说「查看过程」——按钮文案
-    // 得对得上点开后看到的东西。
-    final thinkingOnly = toolSnapshot != null && toolSnapshot.items.isEmpty;
-    final processLabel =
-        thinkingOnly ? l10n.showThinking : l10n.viewToolProcess;
+    // 思考和工具调用是同一段过程的两半，入口只有一个：「查看过程」。按有没有
+    // 调工具分成两种文案，等于让用户在点开之前先分清"思考"和"过程"是不是一
+    // 回事——而它们本来就是一回事。
+    final processLabel = l10n.viewToolProcess;
     return Padding(
       padding: const EdgeInsets.only(top: 2),
       // 按钮的热区自带 8 的横向留白，整行往左挪回去，第一枚图标才和正文
@@ -621,9 +621,7 @@ extension _ThoughterUI on _ThoughterPageState {
             ),
             if (toolSnapshot != null)
               _MessageAction(
-                icon: thinkingOnly
-                    ? Icons.psychology_outlined
-                    : Icons.account_tree_outlined,
+                icon: Icons.account_tree_outlined,
                 tooltip: processLabel,
                 label: processLabel,
                 onTap: () => showToolProgressSheet(
@@ -708,6 +706,7 @@ extension _ThoughterUI on _ThoughterPageState {
           ),
           result: map['result'] as String?,
           narrationText: map['narrationText'] as String?,
+          thinkingText: map['thinkingText'] as String?,
         );
       }).toList();
       final l10n = AppLocalizations.of(context);
@@ -766,11 +765,9 @@ extension _ThoughterUI on _ThoughterPageState {
         message: on ? l10n.hideThinking : l10n.showThinking,
         child: Material(
           color: on ? theme.colorScheme.secondaryContainer : Colors.transparent,
-          shape: StadiumBorder(
-            side: on
-                ? BorderSide.none
-                : BorderSide(color: theme.colorScheme.outlineVariant),
-          ),
+          // 关着的时候不描边：输入框自己已经有一圈边了，里面再套一枚带框的
+          // 小药丸就是框里画框。开着时靠填充色表达"这个模式正生效"。
+          shape: const StadiumBorder(),
           clipBehavior: Clip.antiAlias,
           child: InkWell(
             onTap:
@@ -812,7 +809,9 @@ extension _ThoughterUI on _ThoughterPageState {
     // 描边宽度恒定：聚焦时改宽会让内部文字横跳半个像素。只换颜色。
     final borderColor = focused
         ? scheme.primary.withValues(alpha: 0.55)
-        : scheme.outlineVariant.withValues(alpha: 0.7);
+        : scheme.outlineVariant;
+    // Agent 请求还没有接 provider 的 thinking 开关，那种模式下这一行是空的。
+    final showThinkingChip = !_isAgentMode && _currentModelSupportsThinking;
 
     return SafeArea(
       top: false,
@@ -821,23 +820,16 @@ extension _ThoughterUI on _ThoughterPageState {
         duration: const Duration(milliseconds: 160),
         curve: Curves.easeOut,
         decoration: BoxDecoration(
-          // 壳比对话背景高一层，靠明度自己划出边界；聚焦时再抬一层，
-          // 「正在输入」是被点亮的，不是被托起来的。
-          color: focused
-              ? scheme.surfaceContainerHighest
-              : scheme.surfaceContainerHigh,
+          // 和对话区同底色，只用一圈细描边划出输入范围。
+          //
+          // 这里以前是 surfaceContainerHigh/Highest 加一圈聚焦时张开的强调色
+          // 高光：浅色下是白纸上扣着一块灰盒子，深色下是一块比页面更闷的深板，
+          // 外面还罩着一层散不掉的光晕。输入框不需要靠色块和光把自己顶出来——
+          // 它固定在屏幕底部，位置本身已经说明了它是什么；一条描边划出边界，
+          // 聚焦时换个颜色，就够了。
+          color: scheme.surface,
           borderRadius: BorderRadius.circular(shellRadius),
           border: Border.all(color: borderColor),
-          // 不投影：输入框不是浮在对话上的一张卡，一圈落地的阴影反而把它和
-          // 消息流割开。聚焦时改画一圈贴边的强调色高光——ChatGPT / Claude /
-          // Gemini 都是这个路子，而且它在纸墨这类零投影的风格下同样成立。
-          boxShadow: [
-            BoxShadow(
-              color: scheme.primary.withValues(alpha: focused ? 0.14 : 0.0),
-              blurRadius: 0,
-              spreadRadius: focused ? 3 : 0,
-            ),
-          ],
         ),
         // 整个壳都是输入热区：只有细细一行文字能点，在手机上太难命中。
         child: GestureDetector(
@@ -847,55 +839,74 @@ extension _ThoughterUI on _ThoughterPageState {
               _inputFocusNode.requestFocus();
             }
           },
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              // 输入区默认一行高，随换行增高；超过上限后内部滚动，
-              // 避免长输入把对话内容整个挤出屏幕。
-              ConstrainedBox(
-                constraints: const BoxConstraints(maxHeight: 148),
-                child: TextField(
-                  controller: _textController,
-                  focusNode: _inputFocusNode,
-                  style: theme.textTheme.bodyLarge?.copyWith(height: 1.35),
-                  decoration: InputDecoration(
-                    hintText: l10n.aiAssistantInputHint,
-                    hintStyle: theme.textTheme.bodyLarge?.copyWith(
-                      height: 1.35,
-                      color: scheme.onSurfaceVariant.withValues(alpha: 0.7),
-                    ),
-                    border: InputBorder.none,
-                    isCollapsed: true,
-                    contentPadding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
-                  ),
-                  maxLines: null,
-                  minLines: 1,
-                  keyboardType: TextInputType.multiline,
-                  textCapitalization: TextCapitalization.sentences,
-                  // 软键盘的回车是换行，不是发送：手机上问长一点的问题要分段，
-                  // 回车即发会把半句话打出去，且没有撤回。发送只走右下角那枚键。
-                  // 接了实体键盘（桌面/平板）的场景由 _handleComposerKey 兜底：
-                  // 那里 Enter 发送、Shift+Enter 换行，符合键盘用户的肌肉记忆。
-                  textInputAction: TextInputAction.newline,
-                ),
-              ),
-              // 动作行：左边是模式开关，右边是发送。和主流 AI 输入框一致，
-              // 让「写什么」和「怎么发」分成上下两层。
-              Padding(
-                padding: const EdgeInsets.fromLTRB(8, 2, 8, 8),
-                child: Row(
+          // 没有模式开关要摆时（Agent 模式，也就是绝大多数时候），发送键就贴在
+          // 文字右边，输入框只有一行高。为一枚按钮单开一行会让空着的左半边
+          // 撑出一块无意义的高度——这是之前那个框显得笨重的另一半原因。
+          child: showThinkingChip
+              ? Column(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Agent requests do not yet apply provider thinking settings.
-                    if (!_isAgentMode && _currentModelSupportsThinking)
-                      _buildThinkingChip(theme, l10n),
-                    const Spacer(),
-                    _buildSendButton(theme, l10n),
+                    _buildComposerField(theme, l10n),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+                      child: Row(
+                        children: [
+                          _buildThinkingChip(theme, l10n),
+                          const Spacer(),
+                          _buildSendButton(theme, l10n),
+                        ],
+                      ),
+                    ),
+                  ],
+                )
+              : Row(
+                  // 输入长到换行时发送键留在底部，跟着最后一行走。
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Expanded(child: _buildComposerField(theme, l10n)),
+                    Padding(
+                      // 底部这 5 不是间距而是算出来的居中量：单行时输入框内
+                      // 容高 46，(46 - 36) / 2 正好把按钮摆在这一行的中线上；
+                      // 换行长高后它自然落在最后一行边上。
+                      padding: const EdgeInsets.only(right: 8, bottom: 5),
+                      child: _buildSendButton(theme, l10n),
+                    ),
                   ],
                 ),
-              ),
-            ],
-          ),
         ),
+      ),
+    );
+  }
+
+  /// 输入框本体。默认一行高，随换行增高；超过上限后内部滚动，
+  /// 避免长输入把对话内容整个挤出屏幕。
+  Widget _buildComposerField(ThemeData theme, AppLocalizations l10n) {
+    final scheme = theme.colorScheme;
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 148),
+      child: TextField(
+        controller: _textController,
+        focusNode: _inputFocusNode,
+        style: theme.textTheme.bodyLarge?.copyWith(height: 1.35),
+        decoration: InputDecoration(
+          hintText: l10n.aiAssistantInputHint,
+          hintStyle: theme.textTheme.bodyLarge?.copyWith(
+            height: 1.35,
+            color: scheme.onSurfaceVariant.withValues(alpha: 0.7),
+          ),
+          border: InputBorder.none,
+          isCollapsed: true,
+          contentPadding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+        ),
+        maxLines: null,
+        minLines: 1,
+        keyboardType: TextInputType.multiline,
+        textCapitalization: TextCapitalization.sentences,
+        // 软键盘的回车是换行，不是发送：手机上问长一点的问题要分段，
+        // 回车即发会把半句话打出去，且没有撤回。发送只走右下角那枚键。
+        // 接了实体键盘（桌面/平板）的场景由 _handleComposerKey 兜底：
+        // 那里 Enter 发送、Shift+Enter 换行，符合键盘用户的肌肉记忆。
+        textInputAction: TextInputAction.newline,
       ),
     );
   }
@@ -918,7 +929,7 @@ extension _ThoughterUI on _ThoughterPageState {
             child: Icon(
               _isLoading ? Icons.stop_rounded : Icons.arrow_upward,
               key: ValueKey(_isLoading),
-              size: 20,
+              size: 19,
             ),
           ),
           tooltip: _isLoading ? l10n.stopGenerate : l10n.send,
@@ -930,13 +941,16 @@ extension _ThoughterUI on _ThoughterPageState {
           style: IconButton.styleFrom(
             backgroundColor: scheme.primary,
             foregroundColor: scheme.onPrimary,
-            disabledBackgroundColor: scheme.surfaceContainerHighest,
+            // 空输入时是一枚淡淡的灰盘：用 onSurface 调出来而不是取
+            // surfaceContainerHighest，后者在浅色主题下是块显眼的灰疙瘩，
+            // 而这时候它只需要占住位置。
+            disabledBackgroundColor: scheme.onSurface.withValues(alpha: 0.07),
             disabledForegroundColor:
-                scheme.onSurfaceVariant.withValues(alpha: 0.55),
+                scheme.onSurfaceVariant.withValues(alpha: 0.5),
             shape: const CircleBorder(),
             padding: EdgeInsets.zero,
-            fixedSize: const Size(38, 38),
-            minimumSize: const Size(38, 38),
+            fixedSize: const Size(36, 36),
+            minimumSize: const Size(36, 36),
           ),
         );
       },

--- a/lib/widgets/ai/thinking_widget.dart
+++ b/lib/widgets/ai/thinking_widget.dart
@@ -5,24 +5,10 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../gen_l10n/app_localizations.dart';
 import '../../theme/theme_style.dart';
 
-/// AI 侧气泡轮廓：左上直角，与消息气泡和工具进度面板保持同一形状。
-///
-/// 圆角取 [AppShapeTokens.dialogRadius]，随主题风格变化——不能做成 const。
-BorderRadius _bubbleShape(BuildContext context) {
-  final radius = Radius.circular(AppShapeTokens.of(context).dialogRadius);
-  return BorderRadius.only(
-    topLeft: Radius.zero,
-    topRight: radius,
-    bottomLeft: radius,
-    bottomRight: radius,
-  );
-}
-
 /// 思考过程折叠组件 - 展示 AI 的思考过程
 ///
-/// 参考 Google AI Gallery MessageBodyThinking 设计：
 /// - 进行中时自动展开，完成后默认折叠
-/// - 左侧竖线标识，带脉冲动画
+/// - 折叠态是一行状态文字，展开后内容靠左侧竖线归组
 /// - 可点击标题栏切换展开/折叠
 /// - 使用 Markdown 渲染思考内容
 /// - 支持流式增量内容更新
@@ -125,47 +111,32 @@ class _ThinkingWidgetState extends State<ThinkingWidget>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final isDark = theme.brightness == Brightness.dark;
-
-    // 根据主题调整背景色
-    final backgroundColor = isDark
-        ? theme.colorScheme.surfaceContainerLow
-        : theme.colorScheme.surfaceContainerLowest;
-    final borderColor = widget.inProgress
-        ? theme.colorScheme.primary
-        : theme.colorScheme.outlineVariant;
-    const borderWidth = 2.0;
-    final bubbleShape = _bubbleShape(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
 
     return Container(
-      margin: const EdgeInsets.symmetric(vertical: 8),
+      margin: const EdgeInsets.only(bottom: 6),
       width: double.infinity,
-      decoration: BoxDecoration(
-        color: backgroundColor,
-        borderRadius: bubbleShape,
-        border: Border.all(
-          color: borderColor.withValues(alpha: 0.4),
-          width: 1,
-        ),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 标题栏（可点击切换展开）
+          // 折叠标题：一行状态文字，不是一块卡片。
+          //
+          // 这里原来是填充底色 + 整圈描边 + 气泡形状的一张卡，思考——模型的
+          // 草稿——因此在对话流里比回答本身还重。现在只留图标、一行字和箭头，
+          // 靠内容区左边那条竖线表示"这段是引下来的过程"。
           Material(
             color: Colors.transparent,
             child: InkWell(
               onTap: _toggleExpanded,
-              borderRadius: bubbleShape,
+              borderRadius: BorderRadius.circular(
+                AppShapeTokens.of(context).buttonRadius,
+              ),
               child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 8,
-                ),
+                padding: const EdgeInsets.symmetric(vertical: 6),
                 child: Row(
-                  mainAxisSize: MainAxisSize.max,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    // 动画脉冲指示器（仅在进行中时显示）
+                    // 进行中是脉冲圆点，结束后换成静态图标
                     if (widget.inProgress)
                       Padding(
                         padding: const EdgeInsets.only(right: 8),
@@ -187,22 +158,20 @@ class _ThinkingWidgetState extends State<ThinkingWidget>
                         padding: const EdgeInsets.only(right: 8),
                         child: Icon(
                           Icons.psychology_outlined,
-                          size: 20,
-                          color: theme.colorScheme.onSurfaceVariant,
+                          size: 16,
+                          color: muted,
                         ),
                       ),
-                    // 标题文本
-                    Expanded(
+                    // 标题文本。收起时是个名词标签（「思考」），不是
+                    // showThinking（「查看思考过程」）那种祈使句——它读起来
+                    // 像用户在对自己下指令。
+                    Flexible(
                       child: Text(
-                        widget.inProgress
-                            ? l10n.aiThinking
-                            : (_isExpanded
-                                ? l10n.hideThinking
-                                : l10n.showThinking),
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w500,
-                          color: theme.colorScheme.onSurface,
+                        widget.inProgress ? l10n.aiThinking : l10n.thinking,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: muted,
                         ),
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                     // 旋转箭头
@@ -211,8 +180,8 @@ class _ThinkingWidgetState extends State<ThinkingWidget>
                           .animate(_rotationController),
                       child: Icon(
                         Icons.expand_more,
-                        size: 24,
-                        color: theme.colorScheme.onSurfaceVariant,
+                        size: 18,
+                        color: muted.withValues(alpha: 0.6),
                       ),
                     ),
                   ],
@@ -226,17 +195,13 @@ class _ThinkingWidgetState extends State<ThinkingWidget>
             curve: Curves.easeInOutCubic,
             child: _isExpanded
                 ? Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 8,
-                    ),
+                    padding: const EdgeInsets.only(top: 2, bottom: 6),
                     child: Container(
                       padding: const EdgeInsets.only(left: 12),
                       decoration: BoxDecoration(
                         border: Border(
                           left: BorderSide(
-                            color: borderColor,
-                            width: borderWidth,
+                            color: theme.colorScheme.outlineVariant,
                           ),
                         ),
                       ),

--- a/lib/widgets/ai/tool_progress_panel.dart
+++ b/lib/widgets/ai/tool_progress_panel.dart
@@ -40,6 +40,13 @@ class ToolProgressItem {
   /// 用于让"让我看看…"这类描述与工具调用按时间顺序穿插展示。
   final String? narrationText;
 
+  /// 这次工具调用**之后**模型继续想的那段思考。
+  ///
+  /// 查完东西再想一轮是常态，而思考只有一个字段时那段会被并进开头那坨，
+  /// 读起来像模型在动手之前就已经知道了查询结果。挂在各自的工具下面，
+  /// 抽屉里才是一条按时间走的线。
+  final String? thinkingText;
+
   const ToolProgressItem({
     this.toolCallId,
     required this.toolName,
@@ -47,6 +54,7 @@ class ToolProgressItem {
     required this.status,
     this.result,
     this.narrationText,
+    this.thinkingText,
   });
 
   ToolProgressItem copyWith({
@@ -56,6 +64,7 @@ class ToolProgressItem {
     ToolProgressStatus? status,
     String? result,
     String? narrationText,
+    String? thinkingText,
   }) {
     return ToolProgressItem(
       toolCallId: toolCallId ?? this.toolCallId,
@@ -64,6 +73,7 @@ class ToolProgressItem {
       status: status ?? this.status,
       result: result ?? this.result,
       narrationText: narrationText ?? this.narrationText,
+      thinkingText: thinkingText ?? this.thinkingText,
     );
   }
 }
@@ -207,23 +217,83 @@ class _ToolProgressSheetBody extends StatelessWidget {
                     ),
                 ],
               ),
-              if (thinking != null && thinking.isNotEmpty) ...[
-                const SizedBox(height: 16),
-                Text(
-                  thinking,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                    height: 1.5,
-                  ),
-                ),
-              ],
               const SizedBox(height: 8),
-              // 细节靠一条竖线归组，不再是卡里套卡里套卡
-              for (final item in data.items)
+              // 抽屉是一条时间线：动手前想的 → 查了什么 → 查完又想的。
+              // 思考和工具共用同一条竖线和同一个左边距，读下来是一串顺序发生
+              // 的事，而不是"一坨思考"外加"一列工具"两块拼在一起。
+              if (thinking != null && thinking.isNotEmpty)
+                _ProcessThinkingBlock(text: thinking),
+              for (final item in data.items) ...[
                 _ToolProgressDetailItem(item: item, l10n: l10n),
+                if (item.thinkingText?.trim().isNotEmpty == true)
+                  _ProcessThinkingBlock(text: item.thinkingText!.trim()),
+              ],
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// 过程里的一段思考。
+///
+/// 带标题的一段引文，不是正文：思考是模型的草稿，字号比工具名小一档、颜色
+/// 退到 onSurfaceVariant，和上下的工具项共用左侧那条竖线。
+class _ProcessThinkingBlock extends StatelessWidget {
+  final String text;
+
+  const _ProcessThinkingBlock({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
+
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            width: 1,
+            margin: const EdgeInsets.only(right: 16, left: 7),
+            color: theme.colorScheme.outlineVariant,
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.psychology_outlined, size: 16, color: muted),
+                      const SizedBox(width: 8),
+                      Text(
+                        l10n.thinking,
+                        style: theme.textTheme.labelLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: muted,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 6, left: 24),
+                    child: SelectableText(
+                      text,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: muted,
+                        height: 1.55,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -383,36 +453,43 @@ class _ToolProgressPanelState extends State<ToolProgressPanel> {
     super.dispose();
   }
 
-  /// 标题的原始形态，不依赖 context（供 didUpdateWidget 使用）。
-  String _rawDisplayTitle() {
-    if (widget.inProgress) {
-      final runningItem = widget.items.lastWhere(
-        (item) => item.status == ToolProgressStatus.running,
-        orElse: () => widget.items.isNotEmpty
-            ? widget.items.last
-            : const ToolProgressItem(
-                toolName: '',
-                status: ToolProgressStatus.pending,
-              ),
-      );
-      final activeTitle = runningItem.toolName.trim();
-      return activeTitle.isNotEmpty ? activeTitle : widget.title;
+  /// 当前正在跑的那枚工具，没有就是 null。
+  ///
+  /// 「没有工具在跑」和「最后一枚工具」是两回事：模型查完东西常常再想一轮，
+  /// 那段时间一枚工具都没在跑。把最后那枚顶上来，界面就会一直说"正在搜索
+  /// 笔记"，而它早就搜完了。
+  ToolProgressItem? get _runningItem {
+    for (var i = widget.items.length - 1; i >= 0; i--) {
+      if (widget.items[i].status == ToolProgressStatus.running) {
+        return widget.items[i];
+      }
     }
-    return widget.title;
+    return null;
+  }
+
+  /// 标题的原始形态，不依赖 context（供 snapshot 初值使用）。
+  String _rawDisplayTitle() {
+    if (!widget.inProgress) return widget.title;
+    final activeTitle = _runningItem?.toolName.trim() ?? '';
+    return activeTitle.isNotEmpty ? activeTitle : widget.title;
   }
 
   String _getDisplayTitle(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    if (widget.items.isEmpty &&
-        widget.thinkingText?.trim().isNotEmpty == true) {
-      // 折叠态标题是个名词标签，不是按钮文案。showThinking（"查看思考过程"）
-      // 是祈使句，放在这里读起来像用户在对自己下指令。
+    if (widget.inProgress) {
+      final activeTitle = _runningItem?.toolName.trim() ?? '';
+      if (activeTitle.isNotEmpty) return activeTitle;
+      // 还在进行中却没有工具在跑：模型在想——可能是开口之前，也可能是工具
+      // 跑完之后又想了一轮。两种都该说"正在思考"。
+      return l10n.aiThinking;
+    }
+    if (widget.items.isEmpty) {
+      // 这一轮只有思考没有工具。折叠态标题是个名词标签，不是按钮文案：
+      // showThinking（"查看思考过程"）是祈使句，放在这里读起来像用户在对
+      // 自己下指令；executedNOperations(0)（"执行了 0 个操作"）则是在报
+      // 一件没发生的事。
       return l10n.thinking;
     }
-    if (widget.inProgress) {
-      return _rawDisplayTitle();
-    }
-    // 完成后显示"已执行 N 个操作"
     return l10n.executedNOperations(widget.items.length);
   }
 
@@ -456,7 +533,12 @@ class _ToolProgressPanelState extends State<ToolProgressPanel> {
                           ),
                         )
                       : Icon(
-                          widget.doneIcon ?? Icons.check,
+                          // 只思考没调工具的那轮不打勾：勾是"做完了几件事"的
+                          // 收条，而这一轮什么都没做，只是想了想。
+                          widget.doneIcon ??
+                              (widget.items.isEmpty
+                                  ? Icons.psychology_outlined
+                                  : Icons.check),
                           size: 15,
                           color: foreground,
                         ),

--- a/lib/widgets/ai/tool_progress_panel.dart
+++ b/lib/widgets/ai/tool_progress_panel.dart
@@ -222,7 +222,13 @@ class _ToolProgressSheetBody extends StatelessWidget {
               // 思考和工具共用同一条竖线和同一个左边距，读下来是一串顺序发生
               // 的事，而不是"一坨思考"外加"一列工具"两块拼在一起。
               if (thinking != null && thinking.isNotEmpty)
-                _ProcessThinkingBlock(text: thinking),
+                _ProcessThinkingBlock(
+                  text: thinking,
+                  // 只思考、没调工具的那轮，抽屉标题本身就是「思考」，块上再挂
+                  // 一个同名小标题就是把同一个词说两遍。有工具项时才需要它，
+                  // 那时候「思考」是用来和工具名区分的。
+                  showLabel: data.items.isNotEmpty,
+                ),
               for (final item in data.items) ...[
                 _ToolProgressDetailItem(item: item, l10n: l10n),
                 if (item.thinkingText?.trim().isNotEmpty == true)
@@ -243,7 +249,10 @@ class _ToolProgressSheetBody extends StatelessWidget {
 class _ProcessThinkingBlock extends StatelessWidget {
   final String text;
 
-  const _ProcessThinkingBlock({required this.text});
+  /// 挂不挂「思考」小标题。抽屉标题已经是「思考」时挂上就是重复。
+  final bool showLabel;
+
+  const _ProcessThinkingBlock({required this.text, this.showLabel = true});
 
   @override
   Widget build(BuildContext context) {
@@ -266,21 +275,22 @@ class _ProcessThinkingBlock extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Row(
-                    children: [
-                      Icon(Icons.psychology_outlined, size: 16, color: muted),
-                      const SizedBox(width: 8),
-                      Text(
-                        l10n.thinking,
-                        style: theme.textTheme.labelLarge?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: muted,
+                  if (showLabel)
+                    Row(
+                      children: [
+                        Icon(Icons.psychology_outlined, size: 16, color: muted),
+                        const SizedBox(width: 8),
+                        Text(
+                          l10n.thinking,
+                          style: theme.textTheme.labelLarge?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: muted,
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    ),
                   Padding(
-                    padding: const EdgeInsets.only(top: 6, left: 24),
+                    padding: EdgeInsets.only(top: showLabel ? 6 : 0, left: 24),
                     child: SelectableText(
                       text,
                       style: theme.textTheme.bodySmall?.copyWith(
@@ -414,8 +424,11 @@ class ToolProgressPanel extends StatefulWidget {
 }
 
 class _ToolProgressPanelState extends State<ToolProgressPanel> {
+  /// 抽屉的数据源。标题只有 [_getDisplayTitle] 一个出处，而它要 context；
+  /// 这里先拿原始标题占位，`didChangeDependencies` 会在任何一次 build 之前
+  /// （抽屉更是要等用户点开）同步成真正的标题。
   late final ValueNotifier<ToolProgressSnapshot> _snapshot =
-      ValueNotifier(_snapshotWith(_rawDisplayTitle()));
+      ValueNotifier(_snapshotWith(widget.title));
 
   ToolProgressSnapshot _snapshotWith(String title) => ToolProgressSnapshot(
         title: title,
@@ -465,13 +478,6 @@ class _ToolProgressPanelState extends State<ToolProgressPanel> {
       }
     }
     return null;
-  }
-
-  /// 标题的原始形态，不依赖 context（供 snapshot 初值使用）。
-  String _rawDisplayTitle() {
-    if (!widget.inProgress) return widget.title;
-    final activeTitle = _runningItem?.toolName.trim() ?? '';
-    return activeTitle.isNotEmpty ? activeTitle : widget.title;
   }
 
   String _getDisplayTitle(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -732,10 +732,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_quill
-      sha256: b96bb8525afdeaaea52f5d02f525e05cc34acd176467ab6d6f35d434cf14fde2
+      sha256: "3ee7125b2dd3f3bce3ebdaac722a72f0c8aff3db9aa19053a9d777db12d71c98"
       url: "https://pub.dev"
     source: hosted
-    version: "11.5.0"
+    version: "11.5.1"
   flutter_quill_delta_from_html:
     dependency: transitive
     description:
@@ -2466,5 +2466,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.4"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/test/widget/pages/thoughter_page_test.dart
+++ b/test/widget/pages/thoughter_page_test.dart
@@ -1206,6 +1206,36 @@ void main() {
       expect(find.textContaining('第一段第二段'), findsOneWidget);
     });
 
+    // 发送键贴在文字右边，单行时要坐在那一行的中线上。系统大字体会把输入行
+    // 撑高而按钮不变，居中量得跟着 textScaler 走，否则字越大偏得越远。
+    testWidgets('send button stays centred on the input line at any text scale',
+        (tester) async {
+      Future<double> centreOffsetAt(double scale) async {
+        await tester.pumpWidget(
+          MediaQuery(
+            data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+            child: await _buildHarness(
+              settingsService: settingsService,
+              chatSessionService: chatSessionService,
+              child: const ThoughterPage(
+                entrySource: ThoughterEntrySource.explore,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final field = tester.getRect(find.byType(TextField).last);
+        final button = tester.getRect(
+          find.byKey(const ValueKey('ai_assistant_send_button')),
+        );
+        return (button.center.dy - field.center.dy).abs();
+      }
+
+      // 1 像素的余量留给行高取整
+      expect(await centreOffsetAt(1.0), lessThan(1.0));
+      expect(await centreOffsetAt(2.0), lessThan(1.0));
+    });
+
     // 工具跑完之后模型继续想，是一轮里很常见的一段。这段时间没有工具在跑：
     // 折叠行不能还顶着刚跑完那枚工具的名字，思考也该记在那枚工具下面而不是
     // 并进开头那坨。

--- a/test/widget/pages/thoughter_page_test.dart
+++ b/test/widget/pages/thoughter_page_test.dart
@@ -1206,6 +1206,92 @@ void main() {
       expect(find.textContaining('第一段第二段'), findsOneWidget);
     });
 
+    // 工具跑完之后模型继续想，是一轮里很常见的一段。这段时间没有工具在跑：
+    // 折叠行不能还顶着刚跑完那枚工具的名字，思考也该记在那枚工具下面而不是
+    // 并进开头那坨。
+    testWidgets('post-tool thinking is labelled and filed under its tool',
+        (tester) async {
+      final agentService = _FakeAgentService(
+        settingsService: settingsService,
+        simulateToolProgress: true,
+        toolProgressDelay: const Duration(milliseconds: 20),
+        // 推理增量走 50ms 节流，够长才等得到那一帧落地
+        reasoningChunks: const <String>[
+          '结果',
+          '有点',
+          '意外，',
+          '再',
+          '想',
+          '想。',
+        ],
+        responseChunks: const <String>['我的结论是'],
+      );
+      await settingsService.setExploreAiAssistantMode(ThoughterPageMode.agent);
+
+      await tester.pumpWidget(
+        await _buildHarness(
+          settingsService: settingsService,
+          chatSessionService: chatSessionService,
+          agentService: agentService,
+          child: const ThoughterPage(
+            entrySource: ThoughterEntrySource.explore,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 不能用 _submitInput：它以 pumpAndSettle 收尾，而转圈是个永不停的动画。
+      await tester.enterText(find.byType(TextField).last, '帮我看看');
+      await tester.pump();
+      tester
+          .widget<IconButton>(
+            find.byKey(const ValueKey('ai_assistant_send_button')),
+          )
+          .onPressed
+          ?.call();
+      await tester.pump();
+
+      bool panelInProgress() {
+        final panel = find.byType(ToolProgressPanel);
+        return panel.evaluate().isNotEmpty &&
+            tester.widget<ToolProgressPanel>(panel).inProgress;
+      }
+
+      // 先等工具跑完（转圈停下）
+      var toolDone = false;
+      for (var i = 0; i < 12 && !toolDone; i++) {
+        await tester.pump(const Duration(milliseconds: 10));
+        toolDone = find.byType(ToolProgressPanel).evaluate().isNotEmpty &&
+            !panelInProgress();
+      }
+      expect(toolDone, isTrue);
+
+      // 再等推理增量把它重新点亮：这就是"工具调用完 AI 又想了一轮"
+      var thinkingAfterTool = false;
+      for (var i = 0; i < 12 && !thinkingAfterTool; i++) {
+        await tester.pump(const Duration(milliseconds: 10));
+        thinkingAfterTool = panelInProgress();
+      }
+      expect(thinkingAfterTool, isTrue);
+
+      final l10n = _l10n(tester);
+      expect(find.text(l10n.aiThinking), findsOneWidget);
+      expect(find.textContaining(l10n.agentSearchingNotesForQuery('')),
+          findsNothing);
+
+      await _settleAgentTurn(tester);
+
+      // 抽屉里这段思考跟在那枚工具后面
+      await tester.tap(
+        find.descendant(
+          of: find.byType(ToolProgressPanel),
+          matching: find.byType(InkWell),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('结果有点意外，再想想。'), findsOneWidget);
+    });
+
     testWidgets('agent keeps pre-tool narration as a normal message',
         (tester) async {
       final agentService = _FakeAgentService(
@@ -1648,10 +1734,10 @@ void main() {
       await tester.pumpAndSettle();
 
       final l10n = _l10n(tester);
-      // 没有工具就别说「查看过程」，那一轮里能看的只有思考
-      final processAction = find.byTooltip(l10n.showThinking);
+      // 思考和工具调用是同一段过程，入口只有「查看过程」一个：这一轮只想了想，
+      // 一样从这里翻回去看。
+      final processAction = find.byTooltip(l10n.viewToolProcess);
       expect(processAction, findsOneWidget);
-      expect(find.byTooltip(l10n.viewToolProcess), findsNothing);
 
       await tester.tap(processAction);
       await tester.pumpAndSettle();

--- a/test/widget/widgets/ai/tool_progress_panel_test.dart
+++ b/test/widget/widgets/ai/tool_progress_panel_test.dart
@@ -63,6 +63,60 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsWidgets);
     });
 
+    // 回归：工具跑完之后模型常常再想一轮，那段时间一枚工具都没在跑。标题
+    // 以前会把最后一枚工具顶上来，界面就一直说"正在搜索笔记"——而它早就
+    // 搜完了。
+    testWidgets('says thinking when the model keeps going after a tool call',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          const ToolProgressPanel(
+            title: '测试标题',
+            items: [
+              ToolProgressItem(
+                toolName: '正在搜索笔记...',
+                status: ToolProgressStatus.completed,
+                thinkingText: '结果有点意外，再想想。',
+              ),
+            ],
+            inProgress: true,
+          ),
+        ),
+      );
+
+      expect(find.text('正在搜索笔记...'), findsNothing);
+      expect(find.text('正在思考...'), findsOneWidget);
+    });
+
+    // 查完东西再想的那一轮属于那枚工具，不该并进开头那坨思考里
+    testWidgets('detail sheet shows thinking that follows a tool call',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          const ToolProgressPanel(
+            title: '测试标题',
+            items: [
+              ToolProgressItem(
+                toolName: 'search_notes',
+                status: ToolProgressStatus.completed,
+                thinkingText: '结果有点意外，再想想。',
+              ),
+            ],
+            inProgress: false,
+            thinkingText: '先看看最近写了什么。',
+          ),
+        ),
+      );
+
+      await tester.tap(collapsedRow());
+      await tester.pumpAndSettle();
+
+      expect(find.text('先看看最近写了什么。'), findsOneWidget);
+      expect(find.text('结果有点意外，再想想。'), findsOneWidget);
+      // 两段思考各自带一个「思考」小标题，工具名夹在中间
+      expect(find.text('思考'), findsNWidgets(2));
+    });
+
     testWidgets('displays completed state with done icon',
         (WidgetTester tester) async {
       final items = [

--- a/test/widget/widgets/ai/tool_progress_panel_test.dart
+++ b/test/widget/widgets/ai/tool_progress_panel_test.dart
@@ -117,6 +117,28 @@ void main() {
       expect(find.text('思考'), findsNWidgets(2));
     });
 
+    // 抽屉标题本身就是「思考」，块上再挂一个同名小标题就是把同一个词说两遍
+    testWidgets('thinking-only sheet says 思考 once',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildTestApp(
+          const ToolProgressPanel(
+            title: '思考',
+            items: [],
+            inProgress: false,
+            thinkingText: '先想清楚再回答。',
+          ),
+        ),
+      );
+
+      await tester.tap(collapsedRow());
+      await tester.pumpAndSettle();
+
+      expect(find.text('先想清楚再回答。'), findsOneWidget);
+      // 折叠行和抽屉标题各一个，块上不再多出第三个
+      expect(find.text('思考'), findsNWidgets(2));
+    });
+
     testWidgets('displays completed state with done icon',
         (WidgetTester tester) async {
       final items = [


### PR DESCRIPTION
## 输入框

- 撤掉底色（`surfaceContainerHigh/Highest`）和聚焦时那圈张开的强调色高光，只留**和对话区同底色 + 一条细描边**，聚焦只换描边颜色。浅色下白纸上扣着的灰盒子、深色下那块比页面更闷的深板、外面散不掉的光晕都没了。
- 没有模式开关要摆的时候（Agent 模式，也就是绝大多数场景），**发送键收回文字右边，输入框只有一行高**。原来为一枚按钮单开一行，空着的左半边白撑出一截高度——这是它显得笨重的另一半原因。深度思考 chip 存在时仍走上下两层的老布局。
- 发送键 38 → 36；空输入时的灰盘从 `surfaceContainerHighest` 换成 `onSurface` 低透明度，不再是浅色主题下一块显眼的灰疙瘩。深度思考 chip 关着时不描边（输入框自己已经有一圈边了）。

## 过程与思考

- **工具跑完模型继续想的那段时间，一枚工具都没在跑**。折叠行以前会把最后一枚工具顶上来，界面一直显示"正在搜索笔记…"，而它早就搜完了。改成：`inProgress` 但没有 `running` 项就显示"正在思考"。
- 那段思考也不再并进开头那一坨：`ToolProgressItem` 新增 `thinkingText`（随 meta 持久化），思考挂到它跟在后面的那枚工具上。抽屉于是是一条按时间走的线：想 → 查 → 又想 → 再查。
- 抽屉里的思考从一段裸文本变成带「思考」小标题的块，和工具项共用同一条竖线、同一套缩进。
- 回复下方**只留「查看过程」一个入口**，不再按有没有调工具分成「查看思考过程」/「查看过程」两种文案——它们本来就是同一段过程。
- 只思考没调工具的那轮，折叠行不再打勾（勾是"做完了几件事"的收条），换成思考图标。
- `ThinkingWidget` 去掉填充底色、整圈描边和气泡形状，折叠态是一行状态文字；收起时的标题从祈使句「查看思考过程」改成名词「思考」。

没有新增 ARB 文案，复用了 `thinking` / `aiThinking` / `viewToolProcess`。

## 单独一个提交：flutter_quill 11.5.0 → 11.5.1

11.5.0 的 `QuillRawEditorState` 没有实现 `TextInputClient.onFocusReceived`，在 Flutter 3.44.x 当前的补丁版本（3.44.9）上，任何 import 到编辑器的测试都编译不过：

```
Error: The non-abstract class 'QuillRawEditorState' is missing implementations
for these members: - TextInputClient.onFocusReceived
```

11.5.1 补上了这个实现。只动 `pubspec.lock`，`^11.5.0` 约束不变；连带把 lock 里的 sdks 下限抬到 `flutter: >=3.44.0`（11.5.1 自己的要求，CI 已经是 3.44.x）。这个提交是独立的，不想要可以单独 drop，但 drop 之后测试在当前 stable 上跑不起来。

## 测试

- 新增 3 条回归用例：工具跑完继续思考时折叠行说"正在思考"而不是工具名（widget 级 + 端到端各一条）、抽屉里工具后的思考单独成块。
- 改了 1 条既有用例（只思考的那轮现在也走「查看过程」）。
- `flutter analyze lib test`：4 条 info，与改动前完全一致（都是既有的 `cacheExtent` 弃用和 doc comment 尖括号）。
- `flutter test test/widget test/unit`：1563 passed。
- 输入框和过程抽屉的实际渲染用临时 golden 出图确认过，图和临时用例都已删除。

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2BkZnMYUZwqo1QkVJr7XX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 Thoughter 输入框改成同底色+细描边的扁平样式，发送键贴文字右侧并在任何字体大小下与输入行对齐；过程面板只保留「查看过程」，并把“工具跑完继续思考”正确标成思考，按时间线展示。

- **UI 与交互**
  - 输入框同对话底色+细描边，聚焦仅换描边色；Agent 模式下发送键贴文字右侧、默认单行；发送键直径 36/图标 19，禁用态用 `onSurface` 低透明度；发送键装入“单行高”盒子居中，随换行与系统大字体对齐。
  - 回复下方只留「查看过程」，不再区分「查看思考过程」/「查看过程」。
  - 进行中但无 running 工具时折叠行显示「正在思考」，标题只由一处计算；只思考的轮次折叠标题为「思考」，完成态用思考图标不打勾。
  - 思考归档到其后那枚工具的 `thinkingText`；抽屉按时间线「想 → 查 → 又想」展示，思考以带「思考」标题的小块出现，与工具项共用竖线与缩进；仅思考的轮次不在块内重复「思考」。
  - `ThinkingWidget` 折叠态改为一行状态文字，去掉底色、整圈描边和气泡形状。

- **Dependencies**
  - `flutter_quill` 11.5.0 → `11.5.1`：补实 `TextInputClient.onFocusReceived` 以修复在 Flutter 3.44.x 的编译错误；仅更新 `pubspec.lock`，SDK 下限同步为 `flutter >=3.44.0`。

<sup>Written for commit bce5d3500c45b5e375809a73efd6cb1debe9b2d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 工具执行后的后续思考内容现在会按时间线显示，并归档至对应工具项。
  * 思考过程面板会根据当前状态动态显示标题与图标，支持更清晰地查看完整过程。
  * 仅进行思考而未调用工具时，过程展示更加准确。

* **界面优化**
  * 重新设计思考区域与输入框布局，界面更紧凑、统一。
  * 优化发送按钮尺寸、状态颜色及输入框适配效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->