### PR TITLE
⚡ Bolt: [优化流式响应解析性能，降低 GC 压力]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -84,3 +84,6 @@
 ## 2026-08-07 - [String splitting memory optimization in SSE parsers]
 **Learning:** Dart's `String.split('\n')` creates numerous intermediate string lists and string objects, putting significant pressure on the Garbage Collector, especially during real-time Server-Sent Events (SSE) processing where partial chunks are frequently accumulated and parsed.
 **Action:** Replace `String.split` with manual `String.indexOf('\n')` and `String.substring` in high-frequency string parsing paths like AI stream parsers and network managers to reduce memory allocations and GC pauses.
+## 2024-05-24 - [优化流式响应解析性能]
+**Learning:** 在高频流式数据处理（如大语言模型流式输出）中，使用 `String.split('\n')` 会产生大量短生命周期的列表和字符串对象，从而显著增加垃圾回收（GC）压力并导致可能的性能卡顿。
+**Action:** 在此类场景中，应始终采用手动寻找分隔符（如 `String.indexOf` 和 `String.substring`）的方法来遍历文本。

--- a/lib/utils/dio_network_utils.dart
+++ b/lib/utils/dio_network_utils.dart
@@ -168,11 +168,20 @@ class DioNetworkUtils {
     try {
       await for (final chunk in stream) {
         final text = utf8.decode(chunk);
-        final lines = (partialLine + text).split('\n');
+        final currentChunk = partialLine + text;
 
-        partialLine = lines.removeLast(); // 保存最后一个可能不完整的行
+        int startIndex = 0;
+        while (true) {
+          final newlineIndex = currentChunk.indexOf('\n', startIndex);
+          if (newlineIndex == -1) {
+            // 保存最后一个可能不完整的行
+            partialLine = currentChunk.substring(startIndex);
+            break;
+          }
 
-        for (final line in lines) {
+          final line = currentChunk.substring(startIndex, newlineIndex);
+          startIndex = newlineIndex + 1;
+
           if (line.trim().isEmpty) continue;
 
           if (line.startsWith('data: ')) {


### PR DESCRIPTION
💡 **What:** 
重构了 `lib/utils/dio_network_utils.dart` 中处理流式响应 (`_processStreamResponse`) 的字符串解析逻辑。将原来的 `String.split('\n')` 替换为手动使用 `String.indexOf` 结合 `String.substring`，并通过一个 `while` 循环进行逐行抽取。

🎯 **Why:** 
原先在高频流式数据处理（如大型语言模型的流式输出响应）中，使用 `String.split('\n')` 会在每个数据块（chunk）到来时产生大量的、短生命周期的列表和字符串对象。这种做法在长时间的流式请求下，会显著增加系统垃圾回收（GC）的压力，极端情况下可能引起界面卡顿或内存波动。

📊 **Impact:** 
避免了不必要的列表和字符串分配，大大减少了短生命周期对象的产生数量。从内存维度来看，降低了流式数据接收过程中的 GC 频率，提高了大型或长时间流请求的稳定性和解析性能。代码改动不超过 50 行，且未牺牲可读性。

🔬 **Measurement:** 
可通过向支持流式传输的大模型接口发起长文本生成请求来验证。观察内存分配（Memory Profiler 中跟踪临时对象的产生）和帧渲染是否更加稳定。确保未影响原有功能，所有相关的流式测试功能依然正常工作。

---
*PR created automatically by Jules for task [1416185743398549562](https://jules.google.com/task/1416185743398549562) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
重构流式响应行解析，改用手动扫描替代 `String.split('\n')`，显著减少内存分配与 GC 压力，提升长时 SSE/LLM 流的稳定性与性能。改动集中在 `lib/utils/dio_network_utils.dart` 的 `_processStreamResponse`，不影响现有功能。

- **Refactors**
  - 使用 `indexOf('\n')` + `substring` 逐行解析，替代 `split('\n')`。
  - 将未完整行保存在 `partialLine`，确保按行稳定处理。
  - 减少短生命周期对象创建，降低 GC 频率与卡顿风险。

<sup>Written for commit ddbfda1ff73bd67ae80f97945975b68118f1ac17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化流式响应解析方式，减少高频数据处理过程中的临时对象创建与垃圾回收压力。
  * 支持跨数据块拼接并正确处理不完整行，提升流式内容解析的稳定性与效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->