### PR TITLE
perf(thoughter,explore): 周期统计合并为单遍遍历，去掉冗余 list 遍历

### DIFF
--- a/lib/pages/explore/explore_data_loading.dart
+++ b/lib/pages/explore/explore_data_loading.dart
@@ -81,33 +81,19 @@ extension _ExploreDataLoading on _ExplorePageState {
     if (!mounted || token != _loadToken) return;
     final l10n = AppLocalizations.of(context);
 
-    // 计算总字数
-    final totalWords = _periodQuotes.fold<int>(
-      0,
-      (sum, q) => sum + q.content.length,
-    );
-
-    // 生成数据签名 (用于判断数据是否发生变化)
-    // 签名组成: 周期类型_开始日期_结束日期_笔记数量_总字数
-    final rangeText = _getDateRangeText(l10n);
-    final dataSignature =
-        '${_selectedPeriod}_${rangeText}_${_periodQuotes.length}_$totalWords';
-
-    // 最常见时间段
+    // 计算总字数、最常见时间段、最常见天气和标签，单遍遍历完成
+    var totalWords = 0;
     final Map<String, int> periodCounts = {};
+    final Map<String, int> weatherCategoryCounts = {};
+    final Map<String, int> tagCounts = {};
     for (final q in _periodQuotes) {
+      totalWords += q.content.length;
+
       final p = q.dayPeriod?.trim();
       if (p != null && p.isNotEmpty) {
         periodCounts[p] = (periodCounts[p] ?? 0) + 1;
       }
-    }
-    final mostPeriod = periodCounts.entries.isNotEmpty
-        ? periodCounts.entries.reduce((a, b) => a.value >= b.value ? a : b).key
-        : null;
 
-    // 最常见天气 - 按分类统计（小雨、大雨、雷雨归为"雨"类）
-    final Map<String, int> weatherCategoryCounts = {};
-    for (final q in _periodQuotes) {
       final w = q.weather?.trim();
       if (w != null && w.isNotEmpty) {
         // 先尝试通过key获取分类，如果失败则直接用原值
@@ -123,7 +109,22 @@ extension _ExploreDataLoading on _ExplorePageState {
         weatherCategoryCounts[finalCategory] =
             (weatherCategoryCounts[finalCategory] ?? 0) + 1;
       }
+
+      for (final tagId in q.tagIds) {
+        tagCounts[tagId] = (tagCounts[tagId] ?? 0) + 1;
+      }
     }
+
+    // 生成数据签名 (用于判断数据是否发生变化)
+    // 签名组成: 周期类型_开始日期_结束日期_笔记数量_总字数
+    final rangeText = _getDateRangeText(l10n);
+    final dataSignature =
+        '${_selectedPeriod}_${rangeText}_${_periodQuotes.length}_$totalWords';
+
+    final mostPeriod = periodCounts.entries.isNotEmpty
+        ? periodCounts.entries.reduce((a, b) => a.value >= b.value ? a : b).key
+        : null;
+
     final mostWeather = weatherCategoryCounts.entries.isNotEmpty
         ? weatherCategoryCounts.entries
             .reduce((a, b) => a.value >= b.value ? a : b)
@@ -135,12 +136,6 @@ extension _ExploreDataLoading on _ExplorePageState {
     String? topTagId;
     dynamic topTagIcon;
     try {
-      final Map<String, int> tagCounts = {};
-      for (final q in _periodQuotes) {
-        for (final tagId in q.tagIds) {
-          tagCounts[tagId] = (tagCounts[tagId] ?? 0) + 1;
-        }
-      }
       if (tagCounts.isNotEmpty) {
         topTagId =
             tagCounts.entries.reduce((a, b) => a.value >= b.value ? a : b).key;

--- a/lib/pages/thoughter/thoughter_session.dart
+++ b/lib/pages/thoughter/thoughter_session.dart
@@ -377,31 +377,36 @@ extension _ThoughterSession on _ThoughterPageState {
       if (quotes.isEmpty) return;
 
       final noteCount = quotes.length;
-      final totalWords =
-          quotes.fold<int>(0, (sum, q) => sum + q.content.length);
-      final activeDays =
-          quotes.map((q) => q.date.substring(0, 10)).toSet().length;
-
-      // 最常用时段
+      var totalWords = 0;
+      final activeDayKeys = <String>{};
       final periodCounts = <String, int>{};
+      final weatherCounts = <String, int>{};
+      final tagCounts = <String, int>{};
       for (final q in quotes) {
-        if (q.dayPeriod != null && q.dayPeriod!.isNotEmpty) {
-          periodCounts[q.dayPeriod!] = (periodCounts[q.dayPeriod!] ?? 0) + 1;
+        totalWords += q.content.length;
+        activeDayKeys.add(q.date.substring(0, 10));
+
+        final period = q.dayPeriod;
+        if (period != null && period.isNotEmpty) {
+          periodCounts[period] = (periodCounts[period] ?? 0) + 1;
+        }
+
+        final weather = q.weather;
+        if (weather != null && weather.isNotEmpty) {
+          weatherCounts[weather] = (weatherCounts[weather] ?? 0) + 1;
+        }
+
+        for (final tagId in q.tagIds) {
+          tagCounts[tagId] = (tagCounts[tagId] ?? 0) + 1;
         }
       }
+
       final topPeriod = periodCounts.entries.isNotEmpty
           ? periodCounts.entries
               .reduce((a, b) => a.value >= b.value ? a : b)
               .key
           : null;
 
-      // 最常用天气
-      final weatherCounts = <String, int>{};
-      for (final q in quotes) {
-        if (q.weather != null && q.weather!.isNotEmpty) {
-          weatherCounts[q.weather!] = (weatherCounts[q.weather!] ?? 0) + 1;
-        }
-      }
       final topWeather = weatherCounts.entries.isNotEmpty
           ? weatherCounts.entries
               .reduce((a, b) => a.value >= b.value ? a : b)
@@ -410,12 +415,6 @@ extension _ThoughterSession on _ThoughterPageState {
 
       // 最常用标签（解析为名称）
       String? topTag;
-      final tagCounts = <String, int>{};
-      for (final q in quotes) {
-        for (final tagId in q.tagIds) {
-          tagCounts[tagId] = (tagCounts[tagId] ?? 0) + 1;
-        }
-      }
       if (tagCounts.isNotEmpty) {
         final topTagId =
             tagCounts.entries.reduce((a, b) => a.value >= b.value ? a : b).key;
@@ -431,7 +430,7 @@ extension _ThoughterSession on _ThoughterPageState {
         mostTimePeriod: topPeriod,
         mostWeather: topWeather,
         topTag: topTag,
-        activeDays: activeDays,
+        activeDays: activeDayKeys.length,
         noteCount: noteCount,
         totalWordCount: totalWords,
       );


### PR DESCRIPTION
## 背景

修复「Redundant List Traversals for Period Counts」类问题：对完整笔记列表做多次独立遍历来统计周期数据，可合并为单遍。

## 改动

- **lib/pages/thoughter/thoughter_session.dart** `_generateAndShowDynamicInsight`：原本 5 遍遍历（fold 总字数、map+toSet 活跃天数、时段/天气/标签三个计数循环）合并为单遍。
- **lib/pages/explore/explore_data_loading.dart** `_computeExtrasAndInsight`：同样模式（fold + 三个计数循环）合并为单遍。

行为完全不变，仅减少对列表的重复遍历。

## 验证

`flutter analyze` 无问题。CI 测试由 GitHub Actions 执行。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
合并 thoughter 和 explore 的周期统计为单次遍历，去掉对完整笔记列表的多次独立遍历。行为不变，减少 CPU/内存开销，提升大列表下的性能。

- **Refactors**
  - `lib/pages/thoughter/thoughter_session.dart` `_generateAndShowDynamicInsight`：将“总字数/活跃天数/时段/天气/标签”原先多次遍历合并为一次循环，使用计数 Map 与集合统计；`activeDays` 由去重日期集合长度得到。
  - `lib/pages/explore/explore_data_loading.dart` `_computeExtrasAndInsight`：单次循环同时统计总字数、最常见时段、分类后的天气与标签计数，再生成数据签名与 Top 指标。

<sup>Written for commit d0c4ef926ac3680ddb5052b1e56c4a449f6d8ab5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **性能优化**
  - 优化探索页和思考会话中的数据统计流程，减少重复计算。
  - 洞察信息现可更高效地汇总字数、活跃日期、时段、天气和标签等数据。
  - 保持常用时段、天气、标签及数据签名等统计结果不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->