### PR TITLE
fix(database): 消除 SQL 拼接注入面，统一使用查询构建器

### DIFF
--- a/lib/services/database/database_query_mixin.dart
+++ b/lib/services/database/database_query_mixin.dart
@@ -459,13 +459,15 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     for (int i = 0; i < quoteIds.length; i += 900) {
       final end = (i + 900 < quoteIds.length) ? i + 900 : quoteIds.length;
       final batchIds = quoteIds.sublist(i, end);
+      // 占位符只包含字面量 '?'，实际值始终经 whereArgs 参数绑定
       final placeholders = List.filled(batchIds.length, '?').join(',');
 
-      batch.rawQuery('''
-        SELECT quote_id, tag_id
-        FROM quote_tags
-        WHERE quote_id IN ($placeholders)
-        ''', batchIds);
+      batch.query(
+        'quote_tags',
+        columns: ['quote_id', 'tag_id'],
+        where: 'quote_id IN ($placeholders)',
+        whereArgs: batchIds,
+      );
     }
 
     final allTagMaps = await batch.commit();

--- a/lib/services/database/database_quote_crud_mixin.dart
+++ b/lib/services/database/database_quote_crud_mixin.dart
@@ -224,9 +224,11 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
         final batchIds = quoteIds.sublist(i, end);
         final placeholders = List.filled(batchIds.length, '?').join(',');
 
-        batch.rawQuery(
-          'SELECT quote_id, tag_id FROM quote_tags WHERE quote_id IN ($placeholders)',
-          batchIds,
+        batch.query(
+          'quote_tags',
+          columns: ['quote_id', 'tag_id'],
+          where: 'quote_id IN ($placeholders)',
+          whereArgs: batchIds,
         );
       }
 
@@ -352,9 +354,11 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
         final batchIds = quoteIds.sublist(i, endIdx);
         final placeholders = List.filled(batchIds.length, '?').join(',');
 
-        batch.rawQuery(
-          'SELECT quote_id, tag_id FROM quote_tags WHERE quote_id IN ($placeholders)',
-          batchIds,
+        batch.query(
+          'quote_tags',
+          columns: ['quote_id', 'tag_id'],
+          where: 'quote_id IN ($placeholders)',
+          whereArgs: batchIds,
         );
       }
 

--- a/lib/services/database/database_trash_mixin.dart
+++ b/lib/services/database/database_trash_mixin.dart
@@ -129,13 +129,15 @@ mixin _DatabaseTrashMixin on _DatabaseServiceBase {
     for (int i = 0; i < quoteIds.length; i += 900) {
       final end = (i + 900 < quoteIds.length) ? i + 900 : quoteIds.length;
       final batchIds = quoteIds.sublist(i, end);
+      // 占位符只包含字面量 '?'，实际值始终经 whereArgs 参数绑定
       final placeholders = List.filled(batchIds.length, '?').join(',');
 
-      batch.rawQuery('''
-        SELECT quote_id, tag_id
-        FROM quote_tags
-        WHERE quote_id IN ($placeholders)
-        ''', batchIds);
+      batch.query(
+        'quote_tags',
+        columns: ['quote_id', 'tag_id'],
+        where: 'quote_id IN ($placeholders)',
+        whereArgs: batchIds,
+      );
     }
 
     final allTagMaps = await batch.commit();
@@ -418,9 +420,11 @@ mixin _DatabaseTrashMixin on _DatabaseServiceBase {
         for (final idBatch in _chunkIds(uniqueIds)) {
           final placeholders = List.filled(idBatch.length, '?').join(',');
 
-          final fullRows = await txn.rawQuery(
-            'SELECT id, delta_content, content, date FROM quotes WHERE is_deleted = 1 AND id IN ($placeholders)',
-            idBatch,
+          final fullRows = await txn.query(
+            'quotes',
+            columns: ['id', 'delta_content', 'content', 'date'],
+            where: 'is_deleted = 1 AND id IN ($placeholders)',
+            whereArgs: idBatch,
           );
 
           if (fullRows.isEmpty) {
@@ -481,9 +485,10 @@ mixin _DatabaseTrashMixin on _DatabaseServiceBase {
                 conflictAlgorithm: ConflictAlgorithm.replace);
           }
 
-          await txn.rawDelete(
-            'DELETE FROM quotes WHERE is_deleted = 1 AND id IN ($actualPlaceholders)',
-            batchDeletedIds,
+          await txn.delete(
+            'quotes',
+            where: 'is_deleted = 1 AND id IN ($actualPlaceholders)',
+            whereArgs: batchDeletedIds,
           );
         }
 

--- a/lib/services/database/schema_repair_adapter.dart
+++ b/lib/services/database/schema_repair_adapter.dart
@@ -1,5 +1,18 @@
 part of '../database_schema_manager.dart';
 
+/// Quotes an SQLite identifier (table/column name) for use in DDL/DML.
+///
+/// SQLite identifiers cannot be bound as query parameters, so the name is
+/// validated against a strict identifier whitelist and then double-quoted.
+/// The whitelist excludes quotes and whitespace entirely, which both blocks
+/// injection and protects reserved words (e.g. `date`, `order`).
+String _quoteIdentifier(String identifier) {
+  if (!RegExp(r'^[a-zA-Z_][a-zA-Z0-9_]*$').hasMatch(identifier)) {
+    throw StateError('不安全的列名: $identifier');
+  }
+  return '"$identifier"';
+}
+
 /// Validates the full current schema after creation, upgrade and repair.
 class SchemaValidationAdapter {
   SchemaValidationAdapter(this._definitions);
@@ -65,16 +78,13 @@ class SchemaRepairAdapter {
           if (!quoteColumns.contains(entry.key)) {
             final colName = entry.key;
             final colDef = entry.value;
-            // 🛡️ Sentinel: 安全校验，防止 DDL 注入
-            if (!RegExp(r'^[a-zA-Z_][a-zA-Z0-9_]*$').hasMatch(colName)) {
-              throw StateError('不安全的列名: $colName');
-            }
+            // colDef 不是标识符且不可参数化，用白名单校验后拼入 DDL
             if (!RegExp(
                     r"^[a-zA-Z0-9_ ]+(?:DEFAULT (?:'[a-zA-Z0-9_]*'|[0-9]+))?$")
                 .hasMatch(colDef)) {
               throw StateError('不安全的列定义: $colDef');
             }
-            final safeColName = '"${colName.replaceAll('"', '""')}"';
+            final safeColName = _quoteIdentifier(colName);
             final query = 'ALTER TABLE quotes ADD COLUMN $safeColName $colDef';
             await transaction.execute(query);
             logDebug('数据库repair添加 quotes.$colName');
@@ -365,13 +375,8 @@ class SchemaDataBackfillAdapter {
     if (columns.contains(columnName)) {
       return;
     }
-    // 🛡️ Sentinel: 安全校验，防止 DDL 注入
-    if (!RegExp(r'^[a-zA-Z_][a-zA-Z0-9_]*$').hasMatch(columnName) ||
-        !RegExp(r'^[a-zA-Z_][a-zA-Z0-9_]*$').hasMatch(sourceColumn)) {
-      throw StateError('不安全的列名: $columnName 或 $sourceColumn');
-    }
-    final safeColumnName = '"${columnName.replaceAll('"', '""')}"';
-    final safeSourceColumn = '"${sourceColumn.replaceAll('"', '""')}"';
+    final safeColumnName = _quoteIdentifier(columnName);
+    final safeSourceColumn = _quoteIdentifier(sourceColumn);
 
     final queryAlter = 'ALTER TABLE quotes ADD COLUMN $safeColumnName TEXT';
     await transaction.execute(queryAlter);


### PR DESCRIPTION
## 背景

安全扫描报告了三处潜在的 SQL 注入面（均为「字符串插值拼 SQL」模式）。本 PR 逐一修复，并将同类问题一并清理，全部改为 sqflite 查询构建器 + `whereArgs` 参数绑定。

## 变更内容

### 1. `lib/services/database/schema_repair_adapter.dart`

`_ensureBackupColumn` 的 `queryAlter` / `queryUpdate` 此前用字符串插值拼列名，配合正则 + `replaceAll` 转义。本次抽取共享辅助函数 `_quoteIdentifier()`：

- 对标识符执行严格白名单校验（`^[a-zA-Z_][a-zA-Z0-9_]*$`），通过后双引号引用；
- 白名单本身已排除引号与空白，可同时阻断注入并保护保留字（如 `date`、`order`），因此删除了冗余的 `replaceAll` 转义；
- `SchemaRepairAdapter.repair()` 中相同的内联模式一并改用该函数（`colDef` 的既有白名单校验保留）。

> 说明：SQLite 标识符无法作为查询参数绑定，因此此处的正确防御是「严格白名单 + 引用」，而非参数化。

### 2. `lib/services/database/database_query_mixin.dart`

标签批量查询由 `batch.rawQuery(...)` 改为 `batch.query` 构建器，`IN` 占位符只包含字面量 `?`，实际值经 `whereArgs` 绑定。

### 3. `lib/services/database/database_trash_mixin.dart`

- 回收站列表标签批量查询：`batch.rawQuery` → `batch.query`
- 硬删除前完整行查询：`txn.rawQuery` → `txn.query`
- 硬删除：`txn.rawDelete` → `txn.delete`

### 4. `lib/services/database/database_quote_crud_mixin.dart`

两处标签批量查询：`batch.rawQuery` → `batch.query`（与 `database_query_helpers_mixin.dart` 既有写法保持一致）。

## 未改动项（已确认安全）

其余 `rawQuery` 均为无插值的静态 SQL，或值已通过 `?` 参数绑定（如 `WHERE q.id = ?`），不存在注入面。

## 验证

⚠️ 当前环境未安装 Flutter/Dart SDK，无法运行 `flutter analyze` 与测试。改动为纯等价重构，且与代码库既有约定（`batch.query` / `txn.query` / `txn.delete` 构建器模式）一致，建议在 CI 或本地跑以下验证：

```bash
dart format lib/services/database/schema_repair_adapter.dart lib/services/database/database_query_mixin.dart lib/services/database/database_trash_mixin.dart lib/services/database/database_quote_crud_mixin.dart
flutter analyze --no-fatal-infos
timeout 60s flutter test --reporter compact test/unit/services/database_trash_flow_test.dart
timeout 60s flutter test --reporter compact test/unit/services/database_service_test.dart
timeout 60s flutter test --reporter compact test/unit/services/database_schema_lifecycle_test.dart
```

@Shangjin-Xiao can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c08a2eec-a975-4245-bd3f-ce3d618d9075)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
移除数据库层字符串拼接，统一改用 `sqflite` 查询构建器与 `whereArgs` 参数绑定，消除潜在 SQL 注入面。新增 `_quoteIdentifier()` 对列名做严格白名单校验与引用，覆盖 schema repair/backfill 场景。

- **Bug Fixes**
  - `schema_repair_adapter`: 抽取 `_quoteIdentifier()`；`repair()` 与 `_ensureBackupColumn()` 统一使用；移除冗余转义。
  - `database_query_mixin` / `database_quote_crud_mixin` / `database_trash_mixin`: 将标签批量查询与删除从 `rawQuery`/`rawDelete` 改为 `batch.query`/`txn.query`/`txn.delete`；`IN (?)` 仅含字面 `?`，值经 `whereArgs` 绑定。
  - 其余 `rawQuery` 为静态 SQL 或已参数化，已确认安全。

<sup>Written for commit 2ca8a33ed5ba118c42c88c6f6d0dece6b3b6ef52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化标签、笔记及回收站数据的查询与删除处理，提升数据操作的稳定性和安全性。
  * 修复数据库结构修复过程中的字段名称处理，降低异常字段导致修复失败或数据错误的风险。
  * 保持现有查询结果、筛选条件及删除行为不变，确保相关功能正常运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->