### PR TITLE
refactor(thoughter): 思考图标换灯泡，工具/思考折叠行字号升一档

### DIFF
--- a/lib/pages/thoughter/thoughter_ui.dart
+++ b/lib/pages/thoughter/thoughter_ui.dart
@@ -762,7 +762,7 @@ extension _ThoughterUI on _ThoughterPageState {
   }
 
   /// 深度思考开关。带文字的 chip 而不是一枚图标按钮：图标按钮在这一行里
-  /// 左边一大片空白，且"大脑图标亮着"表达不出它是个可切换的模式。
+  /// 左边一大片空白，且"灯泡图标亮着"表达不出它是个可切换的模式。
   Widget _buildThinkingChip(ThemeData theme, AppLocalizations l10n) {
     final on = _enableThinking;
     final foreground = on
@@ -787,7 +787,7 @@ extension _ThoughterUI on _ThoughterPageState {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Icon(
-                    on ? Icons.psychology : Icons.psychology_outlined,
+                    on ? Icons.lightbulb : Icons.lightbulb_outline,
                     size: 16,
                     color: foreground,
                   ),

--- a/lib/widgets/ai/thinking_widget.dart
+++ b/lib/widgets/ai/thinking_widget.dart
@@ -157,7 +157,7 @@ class _ThinkingWidgetState extends State<ThinkingWidget>
                       Padding(
                         padding: const EdgeInsets.only(right: 8),
                         child: Icon(
-                          Icons.psychology_outlined,
+                          Icons.lightbulb_outline,
                           size: 16,
                           color: muted,
                         ),
@@ -168,7 +168,7 @@ class _ThinkingWidgetState extends State<ThinkingWidget>
                     Flexible(
                       child: Text(
                         widget.inProgress ? l10n.aiThinking : l10n.thinking,
-                        style: theme.textTheme.bodySmall?.copyWith(
+                        style: theme.textTheme.bodyMedium?.copyWith(
                           color: muted,
                         ),
                         overflow: TextOverflow.ellipsis,

--- a/lib/widgets/ai/tool_progress_panel.dart
+++ b/lib/widgets/ai/tool_progress_panel.dart
@@ -278,7 +278,7 @@ class _ProcessThinkingBlock extends StatelessWidget {
                   if (showLabel)
                     Row(
                       children: [
-                        Icon(Icons.psychology_outlined, size: 16, color: muted),
+                        Icon(Icons.lightbulb_outline, size: 16, color: muted),
                         const SizedBox(width: 8),
                         Text(
                           l10n.thinking,
@@ -543,7 +543,7 @@ class _ToolProgressPanelState extends State<ToolProgressPanel> {
                           // 收条，而这一轮什么都没做，只是想了想。
                           widget.doneIcon ??
                               (widget.items.isEmpty
-                                  ? Icons.psychology_outlined
+                                  ? Icons.lightbulb_outline
                                   : Icons.check),
                           size: 15,
                           color: foreground,
@@ -559,7 +559,7 @@ class _ToolProgressPanelState extends State<ToolProgressPanel> {
                     // 执行中标题会随当前工具变化，key 要跟着文案走，
                     // 否则中途换名字是硬切、只有最后完成那一下有动画
                     key: ValueKey(title),
-                    style: theme.textTheme.bodySmall?.copyWith(
+                    style: theme.textTheme.bodyMedium?.copyWith(
                       color: foreground,
                     ),
                     overflow: TextOverflow.ellipsis,

--- a/test/widget/pages/thoughter_page_test.dart
+++ b/test/widget/pages/thoughter_page_test.dart
@@ -707,8 +707,8 @@ void main() {
       await tester.enterText(find.byType(TextField), '触发重建');
       await tester.pump();
 
-      expect(find.byIcon(Icons.psychology), findsNothing);
-      expect(find.byIcon(Icons.psychology_outlined), findsNothing);
+      expect(find.byIcon(Icons.lightbulb), findsNothing);
+      expect(find.byIcon(Icons.lightbulb_outline), findsNothing);
     });
 
     testWidgets('note entry keeps note context and defaults to agent',


### PR DESCRIPTION
## 改动内容

### 1. 思考图标从「大脑」换成「灯泡」
Thoughter 会话里所有表示"思考"的 `Icons.psychology`（大脑）图标统一替换为 `Icons.lightbulb` / `Icons.lightbulb_outline`（灯泡）：
- 输入区「深度思考」切换 chip（`lib/pages/thoughter/thoughter_ui.dart`）
- 思考折叠行标题图标（`lib/widgets/ai/thinking_widget.dart`）
- 工具进度折叠行"只思考没调工具"的图标（`lib/widgets/ai/tool_progress_panel.dart`）
- 工具进度抽屉里「思考」小标题的图标（`lib/widgets/ai/tool_progress_panel.dart`）

### 2. 「执行了几个工具 / 思考」折叠行字号升一档
两处折叠状态行标题原用 `bodySmall`（12px），改为 `bodyMedium`（14px），仍走 `textTheme`，符合项目"字号取自 theme"的规范：
- 工具进度折叠行标题（`tool_progress_panel.dart`）
- 思考折叠行标题（`thinking_widget.dart`）

## 测试
- `test/widget/pages/thoughter_page_test.dart`：更新「Agent 模式隐藏思考开关」断言为检查 `Icons.lightbulb` / `Icons.lightbulb_outline` 不出现 —— **40 个用例全部通过**
- `test/widget/widgets/ai/tool_progress_panel_test.dart` —— **14 个用例全部通过**
- `flutter analyze`：无新增告警

> 本 PR 由 AI 代理（OpenHands）在用户要求下创建。

@Shangjin-Xiao can click here to [continue refining the PR](https://app.all-hands.dev/conversations/927e607a-7833-4d8c-8af9-c85b2d63debd)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将思考相关图标统一从大脑换为灯泡，并把工具/思考折叠行标题字号从 `bodySmall` 提升到 `bodyMedium`，提升辨识度与可读性。

- **Refactors**
  - 图标：将 `Icons.psychology`/`Icons.psychology_outlined` 全面替换为 `Icons.lightbulb`/`Icons.lightbulb_outline`（深度思考 chip、思考折叠行、工具进度折叠行与抽屉内「思考」标题）。
  - 字号：折叠行标题改用 `textTheme.bodyMedium`（原 `bodySmall`）。
  - 测试：更新 `thoughter_page_test.dart` 断言为灯泡图标；全部用例通过。

<sup>Written for commit b7d9dc2a920545718398c665b34f17ae206b2359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

