### PR TITLE
refactor(storage): Windows 数据目录迁移改为整目录复制，去掉硬编码白名单

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -901,6 +901,9 @@
       }
     }
   },
+  "migrationTargetSameAsCurrent": "The selected directory is the same as the current data directory",
+  "migrationTargetAncestor": "The selected directory cannot be a parent of the current data directory",
+  "migrationTargetNested": "The selected directory cannot be inside the current data directory",
   "logsViewer": "Log Viewer",
   "logFilter": "Log Filter",
   "clearLogs": "Clear Logs",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -909,6 +909,9 @@
       }
     }
   },
+  "migrationTargetSameAsCurrent": "新目录与当前数据目录相同",
+  "migrationTargetAncestor": "新目录不能是当前数据目录的上级目录",
+  "migrationTargetNested": "新目录不能位于当前数据目录内部",
   "logsViewer": "日志查看",
   "logFilter": "日志过滤",
   "clearLogs": "清除日志",

--- a/lib/pages/storage_management_page.dart
+++ b/lib/pages/storage_management_page.dart
@@ -837,6 +837,21 @@ class _StorageManagementPageState extends State<StorageManagementPage> {
 
       if (result == null || !mounted) return;
 
+      // 先按真实路径检查（相同/祖先/嵌套），再验证目录写权限：被拒绝的
+      // 路径不应先触发目录创建和写探针等副作用。
+      final targetError =
+          await DataDirectoryService.validateMigrationTarget(result);
+      if (targetError != null) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(targetError),
+            duration: AppConstants.snackBarDurationError,
+          ),
+        );
+        return;
+      }
+
       // 验证目录
       final isValid = await DataDirectoryService.validateDirectory(result);
       if (!isValid) {

--- a/lib/pages/storage_management_page.dart
+++ b/lib/pages/storage_management_page.dart
@@ -11,6 +11,7 @@ import '../constants/app_constants.dart';
 import '../gen_l10n/app_localizations.dart';
 import '../theme/app_semantic_colors.dart';
 import '../theme/theme_style.dart';
+import '../widgets/app_snackbar.dart';
 import 'trash_page.dart';
 
 /// 把迁移目标被拒绝的原因映射为本地化文案。
@@ -861,12 +862,9 @@ class _StorageManagementPageState extends State<StorageManagementPage> {
           await DataDirectoryService.validateMigrationTarget(result);
       if (targetRejection != null) {
         if (!mounted) return;
-        final message = dataDirectoryRejectionMessage(l10n, targetRejection);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(message),
-            duration: AppConstants.snackBarDurationError,
-          ),
+        AppSnackBar.error(
+          context,
+          dataDirectoryRejectionMessage(l10n, targetRejection),
         );
         return;
       }
@@ -946,34 +944,45 @@ class _StorageManagementPageState extends State<StorageManagementPage> {
       _isMigrating = true;
     });
 
-    String? statusMessage;
-    double progress = 0.0;
+    // 进度对话框只推一次，靠 ValueNotifier 刷新内容：迁移期间进度回调非常
+    // 频繁，每次都 pop/push 路由会闪烁，还可能误关别的路由。
+    final migrationProgress =
+        ValueNotifier<({double progress, String? status})>(
+      (progress: 0.0, status: null),
+    );
+    var dialogVisible = false;
+
+    void closeProgressDialog() {
+      if (!dialogVisible || !mounted) return;
+      dialogVisible = false;
+      Navigator.of(context, rootNavigator: true).pop();
+    }
 
     try {
       // 显示进度对话框
       if (!mounted) return;
+      dialogVisible = true;
       showDialog(
         context: context,
         barrierDismissible: false,
         builder: (context) => PopScope(
           canPop: false,
-          child: StatefulBuilder(
-            builder: (context, setDialogState) {
-              return AlertDialog(
-                title: Text(l10n.migratingData),
-                content: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    LinearProgressIndicator(value: progress),
-                    const SizedBox(height: 16),
-                    Text(
-                      statusMessage ?? l10n.preparingProgress,
-                      style: const TextStyle(fontSize: 13),
-                    ),
-                  ],
-                ),
-              );
-            },
+          child: ValueListenableBuilder(
+            valueListenable: migrationProgress,
+            builder: (context, value, _) => AlertDialog(
+              title: Text(l10n.migratingData),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  LinearProgressIndicator(value: value.progress),
+                  const SizedBox(height: 16),
+                  Text(
+                    value.status ?? l10n.preparingProgress,
+                    style: const TextStyle(fontSize: 13),
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
       );
@@ -981,41 +990,14 @@ class _StorageManagementPageState extends State<StorageManagementPage> {
       // 执行迁移
       final success = await DataDirectoryService.migrateDataDirectory(
         newPath,
-        onProgress: (p) {
-          if (mounted) {
-            // 更新进度（通过重新构建对话框）
-            Navigator.of(context).pop();
-            progress = p;
-            showDialog(
-              context: context,
-              barrierDismissible: false,
-              builder: (context) => PopScope(
-                canPop: false,
-                child: AlertDialog(
-                  title: Text(l10n.migratingData),
-                  content: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      LinearProgressIndicator(value: progress),
-                      const SizedBox(height: 16),
-                      Text(
-                        statusMessage ?? '${(progress * 100).toInt()}%',
-                        style: const TextStyle(fontSize: 13),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            );
-          }
-        },
-        onStatusUpdate: (status) {
-          statusMessage = status;
-        },
+        onProgress: (p) => migrationProgress.value =
+            (progress: p, status: migrationProgress.value.status),
+        onStatusUpdate: (status) => migrationProgress.value =
+            (progress: migrationProgress.value.progress, status: status),
       );
 
       if (!mounted) return;
-      Navigator.of(context).pop(); // 关闭进度对话框
+      closeProgressDialog();
 
       if (success) {
         // 迁移成功，提示重启
@@ -1041,23 +1023,14 @@ class _StorageManagementPageState extends State<StorageManagementPage> {
         await _loadAppDataPath();
       } else {
         if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(l10n.migrationFailed),
-            duration: AppConstants.snackBarDurationError,
-          ),
-        );
+        AppSnackBar.error(context, l10n.migrationFailed);
       }
     } catch (e) {
       if (!mounted) return;
-      Navigator.of(context).pop(); // 关闭进度对话框
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(l10n.migrationFailedWithError(e.toString())),
-          duration: AppConstants.snackBarDurationError,
-        ),
-      );
+      closeProgressDialog();
+      AppSnackBar.error(context, l10n.migrationFailedWithError(e.toString()));
     } finally {
+      migrationProgress.dispose();
       if (mounted) {
         setState(() {
           _isMigrating = false;

--- a/lib/pages/storage_management_page.dart
+++ b/lib/pages/storage_management_page.dart
@@ -13,6 +13,24 @@ import '../theme/app_semantic_colors.dart';
 import '../theme/theme_style.dart';
 import 'trash_page.dart';
 
+/// 把迁移目标被拒绝的原因映射为本地化文案。
+///
+/// 拒绝原因由 [DataDirectoryService.validateMigrationTarget] 返回，页面只做
+/// 展示，不把服务内部的原始字符串直接暴露给用户。
+@visibleForTesting
+String dataDirectoryRejectionMessage(
+  AppLocalizations l10n,
+  DataDirectoryTargetRejection rejection,
+) =>
+    switch (rejection) {
+      DataDirectoryTargetRejection.sameDirectory =>
+        l10n.migrationTargetSameAsCurrent,
+      DataDirectoryTargetRejection.ancestorDirectory =>
+        l10n.migrationTargetAncestor,
+      DataDirectoryTargetRejection.nestedDirectory =>
+        l10n.migrationTargetNested,
+    };
+
 /// 存储管理页面
 /// 展示应用存储占用详情，提供缓存清理和数据目录管理功能
 class StorageManagementPage extends StatefulWidget {
@@ -839,13 +857,14 @@ class _StorageManagementPageState extends State<StorageManagementPage> {
 
       // 先按真实路径检查（相同/祖先/嵌套），再验证目录写权限：被拒绝的
       // 路径不应先触发目录创建和写探针等副作用。
-      final targetError =
+      final targetRejection =
           await DataDirectoryService.validateMigrationTarget(result);
-      if (targetError != null) {
+      if (targetRejection != null) {
         if (!mounted) return;
+        final message = dataDirectoryRejectionMessage(l10n, targetRejection);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(targetError),
+            content: Text(message),
             duration: AppConstants.snackBarDurationError,
           ),
         );

--- a/lib/services/data_directory_service.dart
+++ b/lib/services/data_directory_service.dart
@@ -295,20 +295,23 @@ class DataDirectoryService {
       onStatusUpdate?.call('正在验证新目录...');
       logDebug('开始迁移数据到: $newPath');
 
-      // 1. 验证新目录
-      if (!await validateDirectory(newPath)) {
-        throw Exception('新目录不可用或没有写权限');
+      // 1. 获取当前目录，并解析两个目录的真实路径（跟随 junction/symlink）。
+      //    不解析直接比较字符串，会放过指向当前目录自身的链接，导致文件
+      //    被复制进自己并截断。
+      final currentPath = await getCurrentDataDirectory();
+      final resolvedCurrent = await canonicalizePath(currentPath);
+      final resolvedNew = await canonicalizePath(newPath);
+
+      // 2. 相同/祖先检查必须发生在 validateDirectory 之前：被拒绝的路径
+      //    不应先触发目录创建和写权限探针等副作用。
+      final pathError = validateDataDirectoryPath(resolvedCurrent, resolvedNew);
+      if (pathError != null) {
+        throw Exception(pathError);
       }
 
-      // 2. 获取当前目录
-      final currentPath = await getCurrentDataDirectory();
-      if (currentPath == newPath) {
-        throw Exception('新目录与当前目录相同');
-      }
-      // 拒绝把数据迁移到当前目录的祖先目录：复制会把应用数据重新摊在
-      // 祖先目录（如文档根目录）下与用户文件混放，既不安全也难清理。
-      if (path.isWithin(newPath, currentPath)) {
-        throw Exception('新目录不能是当前数据目录的上级目录');
+      // 3. 验证新目录
+      if (!await validateDirectory(newPath)) {
+        throw Exception('新目录不可用或没有写权限');
       }
 
       onStatusUpdate?.call('正在准备迁移...');
@@ -328,7 +331,12 @@ class DataDirectoryService {
       final errors = result['errors'] as List<String>;
 
       if (errors.isNotEmpty) {
-        logDebug('收集文件时遇到 ${errors.length} 个错误');
+        // 收集阶段有文件访问失败：继续迁移会让部分数据在新目录缺失，
+        // 且配置已切换导致旧目录被"遗弃"，因此必须中止。
+        throw FileSystemException(
+          '收集迁移文件失败: ${errors.join('; ')}',
+          currentPath,
+        );
       }
 
       if (filesToCopy.isEmpty) {
@@ -504,6 +512,48 @@ class DataDirectoryService {
     }
 
     return {'files': filesToCopy, 'errors': errors};
+  }
+
+  /// 解析路径的真实位置（跟随 Windows junction/symlink）。
+  ///
+  /// 迁移目标是尚未创建的目录时，逐级解析最近已存在的祖先，剩余部分原样
+  /// 拼接。这样指向当前数据目录自身的链接会被解析成同一真实路径，从而被
+  /// 相同目录检查拦截，避免文件被复制进自身并截断。
+  @visibleForTesting
+  static Future<String> canonicalizePath(String p) async {
+    final normalized = path.normalize(p);
+    try {
+      return path.normalize(
+        await Directory(normalized).resolveSymbolicLinks(),
+      );
+    } on FileSystemException {
+      final parent = path.dirname(normalized);
+      if (parent == normalized) return normalized; // 已到根目录
+      return path.join(
+        await canonicalizePath(parent),
+        path.basename(normalized),
+      );
+    }
+  }
+
+  /// 校验迁移目标与当前数据目录的关系，返回错误原因；合法时返回 null。
+  ///
+  /// [currentPath] 与 [newPath] 必须是 [canonicalizePath] 解析后的真实
+  /// 路径。拒绝三种情况：同一目录（无意义）、目标位于当前目录内部（复制
+  /// 会把目标目录装进自己）、目标是当前目录的祖先（会把应用数据重新摊在
+  /// 祖先目录下与用户文件混放）。
+  @visibleForTesting
+  static String? validateDataDirectoryPath(String currentPath, String newPath) {
+    if (currentPath == newPath) {
+      return '新目录与当前目录相同';
+    }
+    if (path.isWithin(newPath, currentPath)) {
+      return '新目录不能是当前数据目录的上级目录';
+    }
+    if (path.isWithin(currentPath, newPath)) {
+      return '新目录不能位于当前数据目录内部';
+    }
+    return null;
   }
 
   /// 检查是否是 Windows 系统文件

--- a/lib/services/data_directory_service.dart
+++ b/lib/services/data_directory_service.dart
@@ -10,6 +10,21 @@ import 'chat_session_service.dart';
 import 'database_service.dart';
 import 'large_file_manager.dart';
 
+/// 迁移目标被拒绝的原因。
+///
+/// 供目录选择页映射为本地化文案，避免把服务内部的原始中文串直接展示给用户。
+enum DataDirectoryTargetRejection {
+  /// 新目录与当前数据目录相同，迁移无意义。
+  sameDirectory,
+
+  /// 新目录是当前数据目录的祖先（如 Documents 根目录），会把应用数据
+  /// 重新摊在祖先目录下与用户文件混放。
+  ancestorDirectory,
+
+  /// 新目录位于当前数据目录内部，复制会把目标目录装进自己。
+  nestedDirectory,
+}
+
 /// 数据目录管理服务（桌面平台专用）
 /// 允许用户自定义应用数据存储位置，并处理数据迁移
 class DataDirectoryService {
@@ -291,7 +306,7 @@ class DataDirectoryService {
       throw UnsupportedError('仅支持桌面平台');
     }
 
-    var databasesClosed = false;
+    var databasesCloseAttempted = false;
     try {
       onStatusUpdate?.call('正在验证新目录...');
       logDebug('开始迁移数据到: $newPath');
@@ -317,9 +332,11 @@ class DataDirectoryService {
 
       onStatusUpdate?.call('正在准备迁移...');
 
-      // 迁移前确保关闭并冲刷所有数据库连接
+      // 迁移前确保关闭并冲刷所有数据库连接。
+      // 先标记"已尝试关闭"再调用：_closeAllDatabases 可能中途失败（如
+      // DatabaseService 已销毁后 AI/会话库关闭失败），此时也需要恢复。
+      databasesCloseAttempted = true;
       await _closeAllDatabases();
-      databasesClosed = true;
 
       final currentDir = Directory(currentPath);
       if (!await currentDir.exists()) {
@@ -329,7 +346,7 @@ class DataDirectoryService {
       // 3. 整目录收集应用文件（数据已收敛在专属文件夹，无需维护白名单）
       // 使用 isolate 避免阻塞 UI；同时传入新目录以排除自身嵌套。
       final result = await compute(_collectAppFiles, (currentPath, newPath));
-      final filesToCopy = result['files'] as List<String>;
+      final fileEntries = (result['files'] as List).cast<(String, String)>();
       final errors = result['errors'] as List<String>;
 
       if (errors.isNotEmpty) {
@@ -341,26 +358,26 @@ class DataDirectoryService {
         );
       }
 
-      if (filesToCopy.isEmpty) {
+      if (fileEntries.isEmpty) {
         logDebug('没有需要迁移的文件');
         // 即使没有文件，也继续设置新目录
       } else {
-        logDebug('需要迁移 ${filesToCopy.length} 个文件');
+        logDebug('需要迁移 ${fileEntries.length} 个文件');
 
         // 4. 复制文件到新目录
         int copiedCount = 0;
         final Map<String, double> inProgressMap = {};
         const int chunkSize = 5;
-        for (int i = 0; i < filesToCopy.length; i += chunkSize) {
-          final chunk = filesToCopy.sublist(
+        for (int i = 0; i < fileEntries.length; i += chunkSize) {
+          final chunk = fileEntries.sublist(
               i,
-              i + chunkSize > filesToCopy.length
-                  ? filesToCopy.length
+              i + chunkSize > fileEntries.length
+                  ? fileEntries.length
                   : i + chunkSize);
-          await Future.wait(chunk.map((filePath) async {
+          await Future.wait(chunk.map((entry) async {
+            final (filePath, relativePath) = entry;
             try {
               final file = File(filePath);
-              final relativePath = path.relative(filePath, from: currentPath);
               final targetPath = path.join(newPath, relativePath);
 
               // 路径遍历防护：使用 PathSecurityUtils 深度验证
@@ -394,7 +411,7 @@ class DataDirectoryService {
                     final totalInProgress =
                         inProgressMap.values.fold(0.0, (a, b) => a + b);
                     final totalProgress =
-                        (copiedCount + totalInProgress) / filesToCopy.length;
+                        (copiedCount + totalInProgress) / fileEntries.length;
                     onProgress(totalProgress);
                   }
                 },
@@ -407,7 +424,7 @@ class DataDirectoryService {
                 final totalInProgress =
                     inProgressMap.values.fold(0.0, (a, b) => a + b);
                 onProgress(
-                    (copiedCount + totalInProgress) / filesToCopy.length);
+                    (copiedCount + totalInProgress) / fileEntries.length);
               }
             } catch (e) {
               logError('复制文件失败: $filePath, 错误: $e', error: e);
@@ -458,7 +475,7 @@ class DataDirectoryService {
     } catch (e, stackTrace) {
       // 迁移在关闭数据库之后失败时，恢复数据库服务，否则用户不重启应用
       // 后续数据库操作会持续失败。
-      if (databasesClosed) {
+      if (databasesCloseAttempted) {
         await _restoreDatabasesAfterFailedMigration();
       }
       logError('数据迁移失败: $e', error: e, stackTrace: stackTrace);
@@ -494,44 +511,156 @@ class DataDirectoryService {
 
   /// 收集数据目录下所有待迁移的文件（纯逻辑，供测试直接调用）。
   ///
-  /// 跳过系统文件（`desktop.ini`、`thumbs.db` 等）和 SQLite 共享内存临时
-  /// 文件（`-shm`）；WAL 日志保留。仅当 [excludePath] 位于 [currentPath]
-  /// 内部（用户把新目录选在数据目录内）时，才排除其中的文件，避免把
-  /// 目标目录复制进自身。若 [excludePath] 是 [currentPath] 的祖先或与其
-  /// 无关，不做排除——否则祖先目录会把所有文件误判为"目标内文件"。
+  /// 返回 `(源路径, 目标相对路径)` 列表，目标相对路径在复制时保持目录
+  /// 结构。跳过系统文件（`desktop.ini`、`thumbs.db` 等）和 SQLite 共享
+  /// 内存临时文件（`-shm`）；WAL 日志保留。
+  ///
+  /// 数据目录内的 junction/symlink 子目录会被展开收集（文件落在链接名
+  /// 对应的相对路径下）；链接指向数据目录内部时跳过，因为真实位置的文件
+  /// 会被正常收集，避免重复或错误的目标路径。
+  ///
+  /// 仅当 [excludePath] 位于 [currentPath] 内部（用户把新目录选在数据
+  /// 目录内）时才排除其中的文件，避免把目标目录复制进自身。若
+  /// [excludePath] 是 [currentPath] 的祖先或与其无关，不做排除。
   @visibleForTesting
   static Future<Map<String, dynamic>> collectFilesForMigration(
     String currentPath, {
     String? excludePath,
   }) async {
-    final filesToCopy = <String>[];
+    final filesToCopy = <(String, String)>[];
     final errors = <String>[];
 
-    try {
-      await for (final entity
-          in Directory(currentPath).list(recursive: true, followLinks: false)) {
-        try {
-          if (entity is! File) continue;
+    final dataDirReal = _resolveRealPathSync(currentPath);
+    final excludeReal =
+        excludePath == null ? null : _resolveRealPathSync(excludePath);
+    // 排除只在目标目录位于数据目录内部时生效。
+    final excludeApplied =
+        excludeReal != null && path.isWithin(dataDirReal, excludeReal);
 
-          final fileName = path.basename(entity.path).toLowerCase();
-          if (_isWindowsSystemFile(fileName) || fileName.endsWith('-shm')) {
-            continue;
+    await _collectMigrationEntries(
+      Directory(currentPath),
+      prefix: '',
+      dataDirReal: dataDirReal,
+      excludeReal: excludeApplied ? excludeReal : null,
+      visitedRealDirs: <String>{},
+      filesToCopy: filesToCopy,
+      errors: errors,
+    );
+
+    return {'files': filesToCopy, 'errors': errors};
+  }
+
+  /// 递归收集目录下的迁移文件（含展开外部链接）。
+  ///
+  /// [prefix] 是当前目录在数据目录内的相对前缀（数据目录根为 ''，外部
+  /// 链接展开后为链接相对路径）。[visitedRealDirs] 记录已展开过的真实目录，
+  /// 防止链接环导致无限递归。
+  static Future<void> _collectMigrationEntries(
+    Directory dir, {
+    required String prefix,
+    required String dataDirReal,
+    required String? excludeReal,
+    required Set<String> visitedRealDirs,
+    required List<(String, String)> filesToCopy,
+    required List<String> errors,
+  }) async {
+    final dirReal = _resolveRealPathSync(dir.path);
+    if (!visitedRealDirs.add(dirReal)) {
+      return; // 已展开过，防止链接环
+    }
+
+    try {
+      await for (final entity in dir.list(followLinks: false)) {
+        try {
+          final relative = prefix.isEmpty
+              ? path.basename(entity.path)
+              : path.join(prefix, path.basename(entity.path));
+
+          if (entity is File) {
+            final fileName = path.basename(entity.path).toLowerCase();
+            if (_isWindowsSystemFile(fileName) || fileName.endsWith('-shm')) {
+              continue;
+            }
+            if (excludeReal != null &&
+                _isUnderOrEqual(
+                    excludeReal, _resolveRealPathSync(entity.path))) {
+              continue;
+            }
+            filesToCopy.add((entity.path, relative));
+          } else if (entity is Link) {
+            final targetReal = _resolveRealPathSync(entity.path);
+            if (path.equals(targetReal, dataDirReal) ||
+                path.isWithin(dataDirReal, targetReal)) {
+              // 指向数据目录内部：真实位置的文件会被正常收集，跳过链接。
+              continue;
+            }
+            if (excludeReal != null &&
+                _isUnderOrEqual(excludeReal, targetReal)) {
+              continue;
+            }
+            final targetType =
+                FileSystemEntity.typeSync(entity.path, followLinks: true);
+            if (targetType == FileSystemEntityType.file) {
+              final fileName = path.basename(entity.path).toLowerCase();
+              if (!_isWindowsSystemFile(fileName) &&
+                  !fileName.endsWith('-shm')) {
+                filesToCopy.add((entity.path, relative));
+              }
+            } else if (targetType == FileSystemEntityType.directory) {
+              await _collectMigrationEntries(
+                Directory(entity.path), // 列出链接时 OS 会跟随到目标
+                prefix: relative,
+                dataDirReal: dataDirReal,
+                excludeReal: excludeReal,
+                visitedRealDirs: visitedRealDirs,
+                filesToCopy: filesToCopy,
+                errors: errors,
+              );
+            }
+            // 其余目标类型（悬空链接、特殊文件等）无法迁移，跳过。
+          } else if (entity is Directory) {
+            final dirRealPath = _resolveRealPathSync(entity.path);
+            if (excludeReal != null &&
+                _isUnderOrEqual(excludeReal, dirRealPath)) {
+              continue;
+            }
+            await _collectMigrationEntries(
+              entity,
+              prefix: relative,
+              dataDirReal: dataDirReal,
+              excludeReal: excludeReal,
+              visitedRealDirs: visitedRealDirs,
+              filesToCopy: filesToCopy,
+              errors: errors,
+            );
           }
-          if (excludePath != null &&
-              path.isWithin(currentPath, excludePath) &&
-              path.isWithin(excludePath, entity.path)) {
-            continue;
-          }
-          filesToCopy.add(entity.path);
         } catch (e) {
           errors.add('无法访问: ${entity.path}');
         }
       }
     } catch (e) {
-      errors.add('无法访问目录: $currentPath');
+      errors.add('无法访问目录: ${dir.path}');
     }
+  }
 
-    return {'files': filesToCopy, 'errors': errors};
+  /// 判断 [target] 是否等于 [parent] 或位于其内部。
+  static bool _isUnderOrEqual(String parent, String target) =>
+      path.equals(parent, target) || path.isWithin(parent, target);
+
+  /// 解析路径的真实位置（跟随 junction/symlink）；目录不存在时逐级向上
+  /// 解析已存在的祖先，剩余部分原样拼接。
+  static String _resolveRealPathSync(String p) {
+    final normalized = path.normalize(p);
+    try {
+      return path.normalize(Directory(normalized).resolveSymbolicLinksSync());
+    } on FileSystemException {
+      final parent = path.dirname(normalized);
+      if (parent == normalized) return normalized; // 已到根目录
+      return path.join(
+        _resolveRealPathSync(parent),
+        path.basename(normalized),
+      );
+    }
   }
 
   /// 解析路径的真实位置（跟随 Windows junction/symlink）。
@@ -556,7 +685,7 @@ class DataDirectoryService {
     }
   }
 
-  /// 校验迁移目标与当前数据目录的关系，返回错误原因；合法时返回 null。
+  /// 校验迁移目标与当前数据目录的关系，返回拒绝原因；合法时返回 null。
   ///
   /// [currentPath] 与 [newPath] 必须是 [canonicalizePath] 解析后的真实
   /// 路径。拒绝三种情况：同一目录（无意义）、目标位于当前目录内部（复制
@@ -564,34 +693,42 @@ class DataDirectoryService {
   /// 祖先目录下与用户文件混放）。
   @visibleForTesting
   static String? validateDataDirectoryPath(String currentPath, String newPath) {
-    if (currentPath == newPath) {
-      return '新目录与当前目录相同';
-    }
-    if (path.isWithin(newPath, currentPath)) {
-      return '新目录不能是当前数据目录的上级目录';
-    }
-    if (path.isWithin(currentPath, newPath)) {
-      return '新目录不能位于当前数据目录内部';
-    }
-    return null;
+    return switch (_rejectDataDirectoryTarget(currentPath, newPath)) {
+      DataDirectoryTargetRejection.sameDirectory => '新目录与当前数据目录相同',
+      DataDirectoryTargetRejection.ancestorDirectory => '新目录不能是当前数据目录的上级目录',
+      DataDirectoryTargetRejection.nestedDirectory => '新目录不能位于当前数据目录内部',
+      null => null,
+    };
   }
 
   /// 校验 [newPath] 是否可作为迁移目标（按真实路径比较）。
   ///
-  /// 返回错误原因；合法时返回 null。供目录选择页在写权限探针
+  /// 返回拒绝原因；合法时返回 null。供目录选择页在写权限探针
   /// （[validateDirectory]）之前调用，让被拒绝的路径（相同/祖先/嵌套）
-  /// 不产生目录创建和写探针等副作用。
-  static Future<String?> validateMigrationTarget(String newPath) async {
-    if (kIsWeb) {
-      return 'Web平台不支持数据目录迁移';
-    }
-    if (!Platform.isWindows && !Platform.isLinux && !Platform.isMacOS) {
-      return '仅支持桌面平台';
-    }
+  /// 不产生目录创建和写探针等副作用。页面负责把拒绝原因映射为本地化文案。
+  static Future<DataDirectoryTargetRejection?> validateMigrationTarget(
+    String newPath,
+  ) async {
     final currentPath = await getCurrentDataDirectory();
     final resolvedCurrent = await canonicalizePath(currentPath);
     final resolvedNew = await canonicalizePath(newPath);
-    return validateDataDirectoryPath(resolvedCurrent, resolvedNew);
+    return _rejectDataDirectoryTarget(resolvedCurrent, resolvedNew);
+  }
+
+  static DataDirectoryTargetRejection? _rejectDataDirectoryTarget(
+    String currentPath,
+    String newPath,
+  ) {
+    if (currentPath == newPath) {
+      return DataDirectoryTargetRejection.sameDirectory;
+    }
+    if (path.isWithin(newPath, currentPath)) {
+      return DataDirectoryTargetRejection.ancestorDirectory;
+    }
+    if (path.isWithin(currentPath, newPath)) {
+      return DataDirectoryTargetRejection.nestedDirectory;
+    }
+    return null;
   }
 
   /// 检查是否是 Windows 系统文件

--- a/lib/services/data_directory_service.dart
+++ b/lib/services/data_directory_service.dart
@@ -291,6 +291,7 @@ class DataDirectoryService {
       throw UnsupportedError('仅支持桌面平台');
     }
 
+    var databasesClosed = false;
     try {
       onStatusUpdate?.call('正在验证新目录...');
       logDebug('开始迁移数据到: $newPath');
@@ -318,6 +319,7 @@ class DataDirectoryService {
 
       // 迁移前确保关闭并冲刷所有数据库连接
       await _closeAllDatabases();
+      databasesClosed = true;
 
       final currentDir = Directory(currentPath);
       if (!await currentDir.exists()) {
@@ -454,9 +456,27 @@ class DataDirectoryService {
 
       return true;
     } catch (e, stackTrace) {
+      // 迁移在关闭数据库之后失败时，恢复数据库服务，否则用户不重启应用
+      // 后续数据库操作会持续失败。
+      if (databasesClosed) {
+        await _restoreDatabasesAfterFailedMigration();
+      }
       logError('数据迁移失败: $e', error: e, stackTrace: stackTrace);
       onStatusUpdate?.call('迁移失败: $e');
       return false;
+    }
+  }
+
+  /// 迁移失败后恢复数据库服务。
+  ///
+  /// `DatabaseService.closeDatabase(forMigration: true)` 会保持已销毁状态
+  /// （迁移成功后本就需要重启），失败时必须重置以便后续按需重新初始化。
+  /// AI 分析与会话数据库关闭后会在下次访问时惰性重开，无需额外恢复。
+  static Future<void> _restoreDatabasesAfterFailedMigration() async {
+    try {
+      await DatabaseService.closeDatabase(forMigration: false);
+    } catch (e, stackTrace) {
+      logError('迁移失败后恢复 DatabaseService 失败', error: e, stackTrace: stackTrace);
     }
   }
 
@@ -554,6 +574,24 @@ class DataDirectoryService {
       return '新目录不能位于当前数据目录内部';
     }
     return null;
+  }
+
+  /// 校验 [newPath] 是否可作为迁移目标（按真实路径比较）。
+  ///
+  /// 返回错误原因；合法时返回 null。供目录选择页在写权限探针
+  /// （[validateDirectory]）之前调用，让被拒绝的路径（相同/祖先/嵌套）
+  /// 不产生目录创建和写探针等副作用。
+  static Future<String?> validateMigrationTarget(String newPath) async {
+    if (kIsWeb) {
+      return 'Web平台不支持数据目录迁移';
+    }
+    if (!Platform.isWindows && !Platform.isLinux && !Platform.isMacOS) {
+      return '仅支持桌面平台';
+    }
+    final currentPath = await getCurrentDataDirectory();
+    final resolvedCurrent = await canonicalizePath(currentPath);
+    final resolvedNew = await canonicalizePath(newPath);
+    return validateDataDirectoryPath(resolvedCurrent, resolvedNew);
   }
 
   /// 检查是否是 Windows 系统文件

--- a/lib/services/data_directory_service.dart
+++ b/lib/services/data_directory_service.dart
@@ -305,6 +305,11 @@ class DataDirectoryService {
       if (currentPath == newPath) {
         throw Exception('新目录与当前目录相同');
       }
+      // 拒绝把数据迁移到当前目录的祖先目录：复制会把应用数据重新摊在
+      // 祖先目录（如文档根目录）下与用户文件混放，既不安全也难清理。
+      if (path.isWithin(newPath, currentPath)) {
+        throw Exception('新目录不能是当前数据目录的上级目录');
+      }
 
       onStatusUpdate?.call('正在准备迁移...');
 
@@ -462,9 +467,10 @@ class DataDirectoryService {
   /// 收集数据目录下所有待迁移的文件（纯逻辑，供测试直接调用）。
   ///
   /// 跳过系统文件（`desktop.ini`、`thumbs.db` 等）和 SQLite 共享内存临时
-  /// 文件（`-shm`）；WAL 日志保留。若 [excludePath] 位于 [currentPath]
-  /// 内部（用户把新目录选在数据目录内），其中的文件不参与收集，避免把
-  /// 目标目录复制进自身。
+  /// 文件（`-shm`）；WAL 日志保留。仅当 [excludePath] 位于 [currentPath]
+  /// 内部（用户把新目录选在数据目录内）时，才排除其中的文件，避免把
+  /// 目标目录复制进自身。若 [excludePath] 是 [currentPath] 的祖先或与其
+  /// 无关，不做排除——否则祖先目录会把所有文件误判为"目标内文件"。
   @visibleForTesting
   static Future<Map<String, dynamic>> collectFilesForMigration(
     String currentPath, {
@@ -483,7 +489,9 @@ class DataDirectoryService {
           if (_isWindowsSystemFile(fileName) || fileName.endsWith('-shm')) {
             continue;
           }
-          if (excludePath != null && path.isWithin(excludePath, entity.path)) {
+          if (excludePath != null &&
+              path.isWithin(currentPath, excludePath) &&
+              path.isWithin(excludePath, entity.path)) {
             continue;
           }
           filesToCopy.add(entity.path);

--- a/lib/services/data_directory_service.dart
+++ b/lib/services/data_directory_service.dart
@@ -273,8 +273,11 @@ class DataDirectoryService {
     }
   }
 
-  /// 迁移数据到新目录
-  /// 返回是否成功
+  /// 迁移整个数据目录到 [newPath]。
+  ///
+  /// 数据目录是应用专属文件夹，直接整目录复制（仅排除系统文件和 SQLite
+  /// `-shm` 临时文件），因此未来新增任何数据源都无需维护迁移清单。
+  /// 返回是否成功；成功后新路径写入配置，需要重启应用生效。
   static Future<bool> migrateDataDirectory(
     String newPath, {
     Function(double progress)? onProgress,
@@ -313,9 +316,9 @@ class DataDirectoryService {
         throw Exception('当前数据目录不存在');
       }
 
-      // 3. 只迁移应用相关的文件和目录
-      // 使用 isolate 避免阻塞 UI
-      final result = await compute(_collectAppFiles, currentPath);
+      // 3. 整目录收集应用文件（数据已收敛在专属文件夹，无需维护白名单）
+      // 使用 isolate 避免阻塞 UI；同时传入新目录以排除自身嵌套。
+      final result = await compute(_collectAppFiles, (currentPath, newPath));
       final filesToCopy = result['files'] as List<String>;
       final errors = result['errors'] as List<String>;
 
@@ -444,63 +447,55 @@ class DataDirectoryService {
     }
   }
 
-  /// 在 isolate 中收集应用相关的文件（避免阻塞 UI）
+  /// isolate 入口：收集数据目录下所有待迁移的文件（避免阻塞 UI）。
+  ///
+  /// 数据目录已是应用专属文件夹，直接整目录递归收集，不再维护
+  /// `databases / media / ai_analyses.db ...` 白名单，未来新增任何数据源
+  /// 都会被自动迁移。
   static Future<Map<String, dynamic>> _collectAppFiles(
-      String currentPath) async {
+    (String, String) args,
+  ) async {
+    final (currentPath, excludePath) = args;
+    return collectFilesForMigration(currentPath, excludePath: excludePath);
+  }
+
+  /// 收集数据目录下所有待迁移的文件（纯逻辑，供测试直接调用）。
+  ///
+  /// 跳过系统文件（`desktop.ini`、`thumbs.db` 等）和 SQLite 共享内存临时
+  /// 文件（`-shm`）；WAL 日志保留。若 [excludePath] 位于 [currentPath]
+  /// 内部（用户把新目录选在数据目录内），其中的文件不参与收集，避免把
+  /// 目标目录复制进自身。
+  @visibleForTesting
+  static Future<Map<String, dynamic>> collectFilesForMigration(
+    String currentPath, {
+    String? excludePath,
+  }) async {
     final filesToCopy = <String>[];
     final errors = <String>[];
 
-    // 只迁移应用相关的目录和文件
-    final appItems = [
-      'databases', // 数据库目录
-      'media', // 媒体文件目录
-      'ai_analyses.db', // AI 分析数据库
-      'ai_analyses.db-wal',
-      'chat.db',
-      'chat.db-wal',
-      'backups', // 备份目录
-    ];
+    try {
+      await for (final entity
+          in Directory(currentPath).list(recursive: true, followLinks: false)) {
+        try {
+          if (entity is! File) continue;
 
-    for (final item in appItems) {
-      final itemPath = path.join(currentPath, item);
-      final itemDir = Directory(itemPath);
-      final itemFile = File(itemPath);
-
-      try {
-        if (await itemDir.exists()) {
-          // 遍历目录中的文件
-          await for (final entity in itemDir.list(
-            recursive: true,
-            followLinks: false,
-          )) {
-            try {
-              if (entity is File) {
-                final fileName = path.basename(entity.path).toLowerCase();
-                // 跳过系统文件和 SQLite shm 临时文件
-                if (!_isWindowsSystemFile(fileName) &&
-                    !fileName.endsWith('-shm')) {
-                  filesToCopy.add(entity.path);
-                }
-              }
-            } catch (e) {
-              errors.add('无法访问: ${entity.path}');
-            }
+          final fileName = path.basename(entity.path).toLowerCase();
+          if (_isWindowsSystemFile(fileName) || fileName.endsWith('-shm')) {
+            continue;
           }
-        } else if (await itemFile.exists()) {
-          final fileName = path.basename(itemFile.path).toLowerCase();
-          if (!fileName.endsWith('-shm')) {
-            filesToCopy.add(itemFile.path);
+          if (excludePath != null && path.isWithin(excludePath, entity.path)) {
+            continue;
           }
+          filesToCopy.add(entity.path);
+        } catch (e) {
+          errors.add('无法访问: ${entity.path}');
         }
-      } catch (e) {
-        errors.add('无法访问目录: $itemPath');
       }
+    } catch (e) {
+      errors.add('无法访问目录: $currentPath');
     }
 
-    return {
-      'files': filesToCopy,
-      'errors': errors,
-    };
+    return {'files': filesToCopy, 'errors': errors};
   }
 
   /// 检查是否是 Windows 系统文件

--- a/lib/services/data_directory_service.dart
+++ b/lib/services/data_directory_service.dart
@@ -25,6 +25,15 @@ enum DataDirectoryTargetRejection {
   nestedDirectory,
 }
 
+/// 一次目录扫描的结果。
+///
+/// [files] 是 `(源文件绝对路径, 相对于数据目录的目标路径)`；[errors] 非空
+/// 表示有文件读不到，此时必须中止迁移而不是带着缺失继续。
+typedef MigrationFileScan = ({
+  List<(String, String)> files,
+  List<String> errors,
+});
+
 /// 数据目录管理服务（桌面平台专用）
 /// 允许用户自定义应用数据存储位置，并处理数据迁移
 class DataDirectoryService {
@@ -315,12 +324,13 @@ class DataDirectoryService {
       //    不解析直接比较字符串，会放过指向当前目录自身的链接，导致文件
       //    被复制进自己并截断。
       final currentPath = await getCurrentDataDirectory();
-      final resolvedCurrent = await canonicalizePath(currentPath);
-      final resolvedNew = await canonicalizePath(newPath);
 
       // 2. 相同/祖先检查必须发生在 validateDirectory 之前：被拒绝的路径
       //    不应先触发目录创建和写权限探针等副作用。
-      final pathError = validateDataDirectoryPath(resolvedCurrent, resolvedNew);
+      final pathError = validateDataDirectoryPath(
+        canonicalizePath(currentPath),
+        canonicalizePath(newPath),
+      );
       if (pathError != null) {
         throw Exception(pathError);
       }
@@ -330,137 +340,54 @@ class DataDirectoryService {
         throw Exception('新目录不可用或没有写权限');
       }
 
-      onStatusUpdate?.call('正在准备迁移...');
-
-      // 迁移前确保关闭并冲刷所有数据库连接。
-      // 先标记"已尝试关闭"再调用：_closeAllDatabases 可能中途失败（如
-      // DatabaseService 已销毁后 AI/会话库关闭失败），此时也需要恢复。
-      databasesCloseAttempted = true;
-      await _closeAllDatabases();
-
-      final currentDir = Directory(currentPath);
-      if (!await currentDir.exists()) {
+      if (!await Directory(currentPath).exists()) {
         throw Exception('当前数据目录不存在');
       }
 
-      // 3. 整目录收集应用文件（数据已收敛在专属文件夹，无需维护白名单）
-      // 使用 isolate 避免阻塞 UI；同时传入新目录以排除自身嵌套。
-      final result = await compute(_collectAppFiles, (currentPath, newPath));
-      final fileEntries = (result['files'] as List).cast<(String, String)>();
-      final errors = result['errors'] as List<String>;
+      onStatusUpdate?.call('正在准备迁移...');
 
-      if (errors.isNotEmpty) {
+      // 4. 迁移前确保关闭并冲刷所有数据库连接；必须在收集之前，否则收集到的
+      //    -wal 文件可能在复制前被 checkpoint 掉。
+      //    先标记"已尝试关闭"再调用：_closeAllDatabases 可能中途失败（如
+      //    DatabaseService 已销毁后 AI/会话库关闭失败），此时也需要恢复。
+      databasesCloseAttempted = true;
+      await _closeAllDatabases();
+
+      // 5. 整目录收集应用文件（数据已收敛在专属文件夹，无需维护白名单）
+      // 使用 isolate 避免阻塞 UI。
+      final scan = await compute(collectFilesForMigration, currentPath);
+
+      if (scan.errors.isNotEmpty) {
         // 收集阶段有文件访问失败：继续迁移会让部分数据在新目录缺失，
         // 且配置已切换导致旧目录被"遗弃"，因此必须中止。
         throw FileSystemException(
-          '收集迁移文件失败: ${errors.join('; ')}',
+          '收集迁移文件失败: ${scan.errors.join('; ')}',
           currentPath,
         );
       }
 
-      if (fileEntries.isEmpty) {
+      if (scan.files.isEmpty) {
         logDebug('没有需要迁移的文件');
         // 即使没有文件，也继续设置新目录
       } else {
-        logDebug('需要迁移 ${fileEntries.length} 个文件');
+        logDebug('需要迁移 ${scan.files.length} 个文件');
 
-        // 4. 复制文件到新目录
-        int copiedCount = 0;
-        final Map<String, double> inProgressMap = {};
-        const int chunkSize = 5;
-        for (int i = 0; i < fileEntries.length; i += chunkSize) {
-          final chunk = fileEntries.sublist(
-              i,
-              i + chunkSize > fileEntries.length
-                  ? fileEntries.length
-                  : i + chunkSize);
-          await Future.wait(chunk.map((entry) async {
-            final (filePath, relativePath) = entry;
-            try {
-              final file = File(filePath);
-              final targetPath = path.join(newPath, relativePath);
+        // 6. 复制文件到新目录（任一文件失败即中止）
+        await copyFilesForMigration(
+          scan.files,
+          newPath,
+          onProgress: onProgress,
+          onStatusUpdate: onStatusUpdate,
+        );
 
-              // 路径遍历防护：使用 PathSecurityUtils 深度验证
-              try {
-                PathSecurityUtils.validateExtractionPath(targetPath, newPath);
-              } catch (e) {
-                logError('路径安全检查失败，跳过: $relativePath ($e)');
-                return;
-              }
-
-              onStatusUpdate?.call('正在复制: $relativePath');
-
-              // 确保目标目录存在
-              final targetDir = Directory(path.dirname(targetPath));
-              if (!await targetDir.exists()) {
-                try {
-                  await targetDir.create(recursive: true);
-                } catch (_) {
-                  // 忽略并发创建目录时可能抛出的已存在异常
-                }
-              }
-
-              // 使用 LargeFileManager 复制文件（支持大文件）
-              await LargeFileManager.copyFileInChunks(
-                file.path,
-                targetPath,
-                onProgress: (current, total) {
-                  if (onProgress != null && total > 0) {
-                    final fileProgress = current / total;
-                    inProgressMap[filePath] = fileProgress;
-                    final totalInProgress =
-                        inProgressMap.values.fold(0.0, (a, b) => a + b);
-                    final totalProgress =
-                        (copiedCount + totalInProgress) / fileEntries.length;
-                    onProgress(totalProgress);
-                  }
-                },
-              );
-
-              copiedCount++;
-              inProgressMap.remove(filePath);
-
-              if (onProgress != null) {
-                final totalInProgress =
-                    inProgressMap.values.fold(0.0, (a, b) => a + b);
-                onProgress(
-                    (copiedCount + totalInProgress) / fileEntries.length);
-              }
-            } catch (e) {
-              logError('复制文件失败: $filePath, 错误: $e', error: e);
-              // 继续复制其他文件
-            }
-          }));
-        }
-
+        // 7. 复核关键数据库，防止复制层面"成功"但内容不完整
         onStatusUpdate?.call('验证文件完整性...');
-
-        // 5. 验证关键文件是否复制成功
-        final criticalFiles = [
-          'databases/thoughtecho.db',
-        ];
-
-        for (final relPath in criticalFiles) {
-          final sourceFile = File(path.join(currentPath, relPath));
-          final targetFile = File(path.join(newPath, relPath));
-
-          if (await sourceFile.exists()) {
-            if (!await targetFile.exists()) {
-              throw Exception('关键文件复制失败: $relPath');
-            }
-
-            final sourceSize = await sourceFile.length();
-            final targetSize = await targetFile.length();
-            if (sourceSize != targetSize) {
-              throw Exception('文件大小不匹配: $relPath');
-            }
-          }
-        }
+        await _verifyCriticalFiles(currentPath, newPath);
       }
 
       onStatusUpdate?.call('更新配置...');
 
-      // 6. 保存新路径配置
+      // 8. 保存新路径配置
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_customPathKey, newPath);
       await prefs.setBool(_isUsingCustomPathKey, true);
@@ -484,6 +411,93 @@ class DataDirectoryService {
     }
   }
 
+  /// 把收集到的文件复制到 [newPath]，保持相对目录结构。
+  ///
+  /// 任一文件复制失败都会抛出并中止迁移：配置一旦切换到新目录，缺失的文件
+  /// 对用户就等同于丢失。旧目录始终原样保留，用户修复后可重试。
+  @visibleForTesting
+  static Future<void> copyFilesForMigration(
+    List<(String, String)> files,
+    String newPath, {
+    Function(double progress)? onProgress,
+    Function(String status)? onStatusUpdate,
+  }) async {
+    final failures = <String>[];
+    var finished = 0;
+    final inProgress = <String, double>{};
+
+    void reportProgress() {
+      if (onProgress == null) return;
+      final partial = inProgress.values.fold(0.0, (a, b) => a + b);
+      onProgress((finished + partial) / files.length);
+    }
+
+    // 少量并发即可跑满磁盘，再高只会互相争抢。
+    const concurrency = 5;
+    for (var i = 0; i < files.length && failures.isEmpty; i += concurrency) {
+      final end =
+          i + concurrency < files.length ? i + concurrency : files.length;
+      await Future.wait(files.sublist(i, end).map((entry) async {
+        final (sourcePath, relativePath) = entry;
+        try {
+          final targetPath = path.join(newPath, relativePath);
+          // 深度防御：相对路径由 basename 逐级拼接而来，正常不会越界。
+          PathSecurityUtils.validateExtractionPath(targetPath, newPath);
+
+          onStatusUpdate?.call('正在复制: $relativePath');
+          // 使用 LargeFileManager 复制文件（支持大文件，自动建目标目录）
+          await LargeFileManager.copyFileInChunks(
+            sourcePath,
+            targetPath,
+            onProgress: (current, total) {
+              if (total > 0) {
+                inProgress[sourcePath] = current / total;
+                reportProgress();
+              }
+            },
+          );
+        } catch (e, stackTrace) {
+          logError('复制文件失败: $relativePath', error: e, stackTrace: stackTrace);
+          failures.add('$relativePath: $e');
+        } finally {
+          finished++;
+          inProgress.remove(sourcePath);
+          reportProgress();
+        }
+      }));
+    }
+
+    if (failures.isNotEmpty) {
+      throw Exception(
+        '复制文件失败（${failures.length} 个）: ${failures.take(3).join('; ')}',
+      );
+    }
+  }
+
+  /// 复核关键文件在新目录中存在且大小一致。
+  static Future<void> _verifyCriticalFiles(
+    String currentPath,
+    String newPath,
+  ) async {
+    const criticalFiles = [
+      ['databases', 'thoughtecho.db'],
+    ];
+
+    for (final parts in criticalFiles) {
+      final relPath = path.joinAll(parts);
+      final sourceFile = File(path.join(currentPath, relPath));
+      if (!await sourceFile.exists()) continue;
+
+      final targetFile = File(path.join(newPath, relPath));
+      if (!await targetFile.exists()) {
+        throw Exception('关键文件复制失败: $relPath');
+      }
+      if (await sourceFile.length() != await targetFile.length()) {
+        throw Exception('文件大小不匹配: $relPath');
+      }
+    }
+  }
+
   /// 迁移失败后恢复数据库服务。
   ///
   /// `DatabaseService.closeDatabase(forMigration: true)` 会保持已销毁状态
@@ -497,170 +511,109 @@ class DataDirectoryService {
     }
   }
 
-  /// isolate 入口：收集数据目录下所有待迁移的文件（避免阻塞 UI）。
+  /// 收集数据目录下所有待迁移的文件（[compute] 的 isolate 入口，避免阻塞 UI）。
   ///
   /// 数据目录已是应用专属文件夹，直接整目录递归收集，不再维护
   /// `databases / media / ai_analyses.db ...` 白名单，未来新增任何数据源
   /// 都会被自动迁移。
-  static Future<Map<String, dynamic>> _collectAppFiles(
-    (String, String) args,
-  ) async {
-    final (currentPath, excludePath) = args;
-    return collectFilesForMigration(currentPath, excludePath: excludePath);
-  }
-
-  /// 收集数据目录下所有待迁移的文件（纯逻辑，供测试直接调用）。
   ///
-  /// 返回 `(源路径, 目标相对路径)` 列表，目标相对路径在复制时保持目录
-  /// 结构。跳过系统文件（`desktop.ini`、`thumbs.db` 等）和 SQLite 共享
+  /// 返回的 `files` 是 `(源路径, 目标相对路径)` 列表，相对路径在复制时保持
+  /// 目录结构。跳过系统文件（`desktop.ini`、`thumbs.db` 等）和 SQLite 共享
   /// 内存临时文件（`-shm`）；WAL 日志保留。
   ///
   /// 数据目录内的 junction/symlink 子目录会被展开收集（文件落在链接名
-  /// 对应的相对路径下）；链接指向数据目录内部时跳过，因为真实位置的文件
-  /// 会被正常收集，避免重复或错误的目标路径。
+  /// 对应的相对路径下），否则链接指向的数据在新目录里会整块缺失；链接指向
+  /// 数据目录内部时跳过，因为真实位置的文件会被正常收集，避免重复。
   ///
-  /// 仅当 [excludePath] 位于 [currentPath] 内部（用户把新目录选在数据
-  /// 目录内）时才排除其中的文件，避免把目标目录复制进自身。若
-  /// [excludePath] 是 [currentPath] 的祖先或与其无关，不做排除。
-  @visibleForTesting
-  static Future<Map<String, dynamic>> collectFilesForMigration(
-    String currentPath, {
-    String? excludePath,
-  }) async {
-    final filesToCopy = <(String, String)>[];
+  /// 不需要排除迁移目标目录：目标位于数据目录内部的情况已由
+  /// [validateDataDirectoryPath] 在迁移开始前拒绝。
+  static Future<MigrationFileScan> collectFilesForMigration(
+    String dataDirPath,
+  ) async {
+    final files = <(String, String)>[];
     final errors = <String>[];
 
-    final dataDirReal = _resolveRealPathSync(currentPath);
-    final excludeReal =
-        excludePath == null ? null : _resolveRealPathSync(excludePath);
-    // 排除只在目标目录位于数据目录内部时生效。
-    final excludeApplied =
-        excludeReal != null && path.isWithin(dataDirReal, excludeReal);
-
-    await _collectMigrationEntries(
-      Directory(currentPath),
+    await _collectFrom(
+      Directory(dataDirPath),
       prefix: '',
-      dataDirReal: dataDirReal,
-      excludeReal: excludeApplied ? excludeReal : null,
-      visitedRealDirs: <String>{},
-      filesToCopy: filesToCopy,
+      rootReal: canonicalizePath(dataDirPath),
+      visitedDirs: <String>{},
+      files: files,
       errors: errors,
     );
 
-    return {'files': filesToCopy, 'errors': errors};
+    return (files: files, errors: errors);
   }
 
-  /// 递归收集目录下的迁移文件（含展开外部链接）。
+  /// 递归收集 [dir] 下的迁移文件。
   ///
-  /// [prefix] 是当前目录在数据目录内的相对前缀（数据目录根为 ''，外部
-  /// 链接展开后为链接相对路径）。[visitedRealDirs] 记录已展开过的真实目录，
-  /// 防止链接环导致无限递归。
-  static Future<void> _collectMigrationEntries(
+  /// [prefix] 是 [dir] 在数据目录内的相对前缀（数据目录根为 ''）。
+  /// [visitedDirs] 记录已展开过的真实目录，防止链接环导致无限递归。
+  static Future<void> _collectFrom(
     Directory dir, {
     required String prefix,
-    required String dataDirReal,
-    required String? excludeReal,
-    required Set<String> visitedRealDirs,
-    required List<(String, String)> filesToCopy,
+    required String rootReal,
+    required Set<String> visitedDirs,
+    required List<(String, String)> files,
     required List<String> errors,
   }) async {
-    final dirReal = _resolveRealPathSync(dir.path);
-    if (!visitedRealDirs.add(dirReal)) {
+    if (!visitedDirs.add(canonicalizePath(dir.path))) {
       return; // 已展开过，防止链接环
     }
 
     try {
       await for (final entity in dir.list(followLinks: false)) {
         try {
-          final relative = prefix.isEmpty
-              ? path.basename(entity.path)
-              : path.join(prefix, path.basename(entity.path));
+          final name = path.basename(entity.path);
+          final relative = prefix.isEmpty ? name : path.join(prefix, name);
 
-          if (entity is File) {
-            final fileName = path.basename(entity.path).toLowerCase();
-            if (_isWindowsSystemFile(fileName) || fileName.endsWith('-shm')) {
-              continue;
-            }
-            if (excludeReal != null &&
-                _isUnderOrEqual(
-                    excludeReal, _resolveRealPathSync(entity.path))) {
-              continue;
-            }
-            filesToCopy.add((entity.path, relative));
-          } else if (entity is Link) {
-            final targetReal = _resolveRealPathSync(entity.path);
-            if (path.equals(targetReal, dataDirReal) ||
-                path.isWithin(dataDirReal, targetReal)) {
+          if (entity is Link) {
+            final target = canonicalizePath(entity.path);
+            if (path.equals(target, rootReal) ||
+                path.isWithin(rootReal, target)) {
               // 指向数据目录内部：真实位置的文件会被正常收集，跳过链接。
               continue;
             }
-            if (excludeReal != null &&
-                _isUnderOrEqual(excludeReal, targetReal)) {
-              continue;
-            }
-            final targetType =
-                FileSystemEntity.typeSync(entity.path, followLinks: true);
-            if (targetType == FileSystemEntityType.file) {
-              final fileName = path.basename(entity.path).toLowerCase();
-              if (!_isWindowsSystemFile(fileName) &&
-                  !fileName.endsWith('-shm')) {
-                filesToCopy.add((entity.path, relative));
+          }
+
+          // 按真实类型处理，普通文件/目录与指向外部的 junction/symlink 一视同仁。
+          switch (FileSystemEntity.typeSync(entity.path, followLinks: true)) {
+            case FileSystemEntityType.file:
+              if (!_isSkippedFile(name)) {
+                files.add((entity.path, relative));
               }
-            } else if (targetType == FileSystemEntityType.directory) {
-              await _collectMigrationEntries(
+            case FileSystemEntityType.directory:
+              await _collectFrom(
                 Directory(entity.path), // 列出链接时 OS 会跟随到目标
                 prefix: relative,
-                dataDirReal: dataDirReal,
-                excludeReal: excludeReal,
-                visitedRealDirs: visitedRealDirs,
-                filesToCopy: filesToCopy,
+                rootReal: rootReal,
+                visitedDirs: visitedDirs,
+                files: files,
                 errors: errors,
               );
-            }
-            // 其余目标类型（悬空链接、特殊文件等）无法迁移，跳过。
-          } else if (entity is Directory) {
-            final dirRealPath = _resolveRealPathSync(entity.path);
-            if (excludeReal != null &&
-                _isUnderOrEqual(excludeReal, dirRealPath)) {
-              continue;
-            }
-            await _collectMigrationEntries(
-              entity,
-              prefix: relative,
-              dataDirReal: dataDirReal,
-              excludeReal: excludeReal,
-              visitedRealDirs: visitedRealDirs,
-              filesToCopy: filesToCopy,
-              errors: errors,
-            );
+            default:
+              break; // 悬空链接、管道等特殊类型无法迁移
           }
         } catch (e) {
-          errors.add('无法访问: ${entity.path}');
+          errors.add('无法访问 ${entity.path}: $e');
         }
       }
     } catch (e) {
-      errors.add('无法访问目录: ${dir.path}');
+      errors.add('无法访问目录 ${dir.path}: $e');
     }
   }
 
-  /// 判断 [target] 是否等于 [parent] 或位于其内部。
-  static bool _isUnderOrEqual(String parent, String target) =>
-      path.equals(parent, target) || path.isWithin(parent, target);
-
-  /// 解析路径的真实位置（跟随 junction/symlink）；目录不存在时逐级向上
-  /// 解析已存在的祖先，剩余部分原样拼接。
-  static String _resolveRealPathSync(String p) {
-    final normalized = path.normalize(p);
-    try {
-      return path.normalize(Directory(normalized).resolveSymbolicLinksSync());
-    } on FileSystemException {
-      final parent = path.dirname(normalized);
-      if (parent == normalized) return normalized; // 已到根目录
-      return path.join(
-        _resolveRealPathSync(parent),
-        path.basename(normalized),
-      );
-    }
+  /// 迁移时跳过的文件：系统文件与 SQLite 共享内存临时文件（`-shm`）。
+  /// `-wal` 必须保留，其中可能有尚未 checkpoint 的数据。
+  static bool _isSkippedFile(String fileName) {
+    const systemFiles = {
+      'desktop.ini',
+      'thumbs.db',
+      'ntuser.dat',
+      '.ds_store',
+    };
+    final lower = fileName.toLowerCase();
+    return systemFiles.contains(lower) || lower.endsWith('-shm');
   }
 
   /// 解析路径的真实位置（跟随 Windows junction/symlink）。
@@ -669,19 +622,14 @@ class DataDirectoryService {
   /// 拼接。这样指向当前数据目录自身的链接会被解析成同一真实路径，从而被
   /// 相同目录检查拦截，避免文件被复制进自身并截断。
   @visibleForTesting
-  static Future<String> canonicalizePath(String p) async {
+  static String canonicalizePath(String p) {
     final normalized = path.normalize(p);
     try {
-      return path.normalize(
-        await Directory(normalized).resolveSymbolicLinks(),
-      );
+      return path.normalize(Directory(normalized).resolveSymbolicLinksSync());
     } on FileSystemException {
       final parent = path.dirname(normalized);
       if (parent == normalized) return normalized; // 已到根目录
-      return path.join(
-        await canonicalizePath(parent),
-        path.basename(normalized),
-      );
+      return path.join(canonicalizePath(parent), path.basename(normalized));
     }
   }
 
@@ -710,16 +658,19 @@ class DataDirectoryService {
     String newPath,
   ) async {
     final currentPath = await getCurrentDataDirectory();
-    final resolvedCurrent = await canonicalizePath(currentPath);
-    final resolvedNew = await canonicalizePath(newPath);
-    return _rejectDataDirectoryTarget(resolvedCurrent, resolvedNew);
+    return _rejectDataDirectoryTarget(
+      canonicalizePath(currentPath),
+      canonicalizePath(newPath),
+    );
   }
 
   static DataDirectoryTargetRejection? _rejectDataDirectoryTarget(
     String currentPath,
     String newPath,
   ) {
-    if (currentPath == newPath) {
+    // 用 path.equals 而非 == ：Windows 路径大小写不敏感，同一目录可能有
+    // 大小写不同的两种写法（如盘符）。
+    if (path.equals(currentPath, newPath)) {
       return DataDirectoryTargetRejection.sameDirectory;
     }
     if (path.isWithin(newPath, currentPath)) {
@@ -729,17 +680,6 @@ class DataDirectoryService {
       return DataDirectoryTargetRejection.nestedDirectory;
     }
     return null;
-  }
-
-  /// 检查是否是 Windows 系统文件
-  static bool _isWindowsSystemFile(String fileName) {
-    final systemFiles = [
-      'desktop.ini',
-      'thumbs.db',
-      'ntuser.dat',
-      '.ds_store',
-    ];
-    return systemFiles.contains(fileName);
   }
 
   /// 重置到默认数据目录

--- a/test/unit/services/data_directory_service_test.dart
+++ b/test/unit/services/data_directory_service_test.dart
@@ -31,12 +31,8 @@ void main() {
     file.writeAsStringSync('content');
   }
 
-  Set<String> relativeFiles(Map<String, dynamic> result) {
-    return (result['files'] as List)
-        .cast<(String, String)>()
-        .map((e) => e.$2)
-        .toSet();
-  }
+  Set<String> relativeFiles(MigrationFileScan scan) =>
+      scan.files.map((e) => e.$2).toSet();
 
   group('DataDirectoryService.collectFilesForMigration', () {
     test('整目录收集应用数据，包括未来新增的数据源', () async {
@@ -47,12 +43,12 @@ void main() {
       createFile('backups/backup.zip');
       createFile('feature_cache/data.bin'); // 模拟未来新增数据源
 
-      final result = await DataDirectoryService.collectFilesForMigration(
+      final scan = await DataDirectoryService.collectFilesForMigration(
         tempDir.path,
       );
 
-      expect(result['errors'], isEmpty);
-      final files = relativeFiles(result);
+      expect(scan.errors, isEmpty);
+      final files = relativeFiles(scan);
       expect(
         files,
         containsAll([
@@ -75,11 +71,11 @@ void main() {
       createFile('ntuser.dat');
       createFile('.ds_store');
 
-      final result = await DataDirectoryService.collectFilesForMigration(
+      final scan = await DataDirectoryService.collectFilesForMigration(
         tempDir.path,
       );
 
-      final files = relativeFiles(result);
+      final files = relativeFiles(scan);
       expect(files, contains('databases/thoughtecho.db'));
       expect(files, contains('databases/thoughtecho.db-wal'));
       expect(files, isNot(contains('databases/thoughtecho.db-shm')));
@@ -89,63 +85,32 @@ void main() {
       expect(files, isNot(contains('.ds_store')));
     });
 
-    test('excludePath 位于数据目录内时，其中的文件不参与收集', () async {
-      createFile('databases/thoughtecho.db');
-      createFile('nested_target/data.bin');
-      createFile('nested_target/deep/inner.bin');
-
-      final result = await DataDirectoryService.collectFilesForMigration(
-        tempDir.path,
-        excludePath: abs('nested_target'),
-      );
-
-      final files = relativeFiles(result);
-      expect(files, contains('databases/thoughtecho.db'));
-      expect(files, isNot(contains('nested_target/data.bin')));
-      expect(files, isNot(contains('nested_target/deep/inner.bin')));
-    });
-
-    test('excludePath 是数据目录的祖先时，不排除任何文件', () async {
-      // 场景：Documents/ThoughtEcho -> Documents（新目录是当前目录的父级）。
-      // 祖先目录不是"目标复制进自身"，不应把所有文件误判为目标内文件。
+    test('相对路径以数据目录为基准，保持子目录结构', () async {
       final dataDir = Directory(abs('ThoughtEcho'))..createSync();
       createFile('ThoughtEcho/databases/thoughtecho.db');
-      createFile('ThoughtEcho/media/photo.jpg');
+      createFile('ThoughtEcho/media/sub/photo.jpg');
 
-      final result = await DataDirectoryService.collectFilesForMigration(
+      final scan = await DataDirectoryService.collectFilesForMigration(
         dataDir.path,
-        excludePath: tempDir.path,
       );
 
-      // 相对路径以数据目录为基准，文件不应被排除。
-      final files = relativeFiles(result);
-      expect(files, contains('databases/thoughtecho.db'));
-      expect(files, contains('media/photo.jpg'));
-    });
-
-    test('excludePath 与数据目录无关时，不排除任何文件', () async {
-      createFile('databases/thoughtecho.db');
-      createFile('media/photo.jpg');
-      final unrelated = Directory(abs('unrelated'))..createSync();
-
-      final result = await DataDirectoryService.collectFilesForMigration(
-        tempDir.path,
-        excludePath: unrelated.path,
+      expect(
+        relativeFiles(scan),
+        equals({'databases/thoughtecho.db', 'media/sub/photo.jpg'}),
       );
-
-      final files = relativeFiles(result);
-      expect(files, contains('databases/thoughtecho.db'));
-      expect(files, contains('media/photo.jpg'));
     });
 
-    test('数据目录不存在时返回空列表和错误', () async {
+    test('数据目录不存在时返回空列表和带原因的错误', () async {
       final missing = path.join(tempDir.path, 'does_not_exist');
-      final result = await DataDirectoryService.collectFilesForMigration(
+      final scan = await DataDirectoryService.collectFilesForMigration(
         missing,
       );
 
-      expect(result['files'], isEmpty);
-      expect(result['errors'], isNotEmpty);
+      expect(scan.files, isEmpty);
+      expect(scan.errors, hasLength(1));
+      // 错误里要带上失败原因，否则用户只看到路径无法排障。
+      expect(scan.errors.single, contains(missing));
+      expect(scan.errors.single.length, greaterThan(missing.length + 8));
     });
 
     test('指向外部的目录链接被展开，文件落在链接名相对路径下', () async {
@@ -165,14 +130,14 @@ void main() {
         return;
       }
 
-      final result = await DataDirectoryService.collectFilesForMigration(
+      final scan = await DataDirectoryService.collectFilesForMigration(
         tempDir.path,
       );
 
-      final files = relativeFiles(result);
+      final files = relativeFiles(scan);
       expect(files, contains('databases/thoughtecho.db'));
       expect(files, contains('media/a.jpg'));
-      expect(result['errors'], isEmpty);
+      expect(scan.errors, isEmpty);
     });
 
     test('指向数据目录内部的链接被跳过，不产生重复或错误路径', () async {
@@ -185,11 +150,11 @@ void main() {
         return;
       }
 
-      final result = await DataDirectoryService.collectFilesForMigration(
+      final scan = await DataDirectoryService.collectFilesForMigration(
         tempDir.path,
       );
 
-      final files = relativeFiles(result);
+      final files = relativeFiles(scan);
       expect(files, contains('databases/thoughtecho.db'));
       expect(files, isNot(contains('dup/thoughtecho.db')));
     });
@@ -211,13 +176,60 @@ void main() {
         return;
       }
 
-      final result = await DataDirectoryService.collectFilesForMigration(
+      final scan = await DataDirectoryService.collectFilesForMigration(
         tempDir.path,
       );
 
-      final files = relativeFiles(result);
+      final files = relativeFiles(scan);
       expect(files, contains('linked.dat'));
-      expect(result['errors'], isEmpty);
+      expect(scan.errors, isEmpty);
+    });
+  });
+
+  group('DataDirectoryService.copyFilesForMigration', () {
+    test('保持目录结构复制所有文件，并回报进度', () async {
+      createFile('databases/thoughtecho.db');
+      createFile('media/sub/photo.jpg');
+      final target = await TestHarness.createTempDirectory('copy_target');
+      addTearDown(() => TestHarness.deleteTempDirectory(target));
+
+      final scan = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+      );
+      final progressValues = <double>[];
+      await DataDirectoryService.copyFilesForMigration(
+        scan.files,
+        target.path,
+        onProgress: progressValues.add,
+      );
+
+      expect(
+        File(path.join(target.path, 'databases', 'thoughtecho.db'))
+            .existsSync(),
+        isTrue,
+      );
+      expect(
+        File(path.join(target.path, 'media', 'sub', 'photo.jpg')).existsSync(),
+        isTrue,
+      );
+      expect(progressValues.last, closeTo(1.0, 0.001));
+    });
+
+    test('任一文件复制失败即抛出，不静默跳过', () async {
+      // 收集之后源文件消失，模拟被占用/无权限等复制期失败。
+      createFile('databases/thoughtecho.db');
+      final target = await TestHarness.createTempDirectory('copy_fail_target');
+      addTearDown(() => TestHarness.deleteTempDirectory(target));
+
+      final scan = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+      );
+      File(abs('databases/thoughtecho.db')).deleteSync();
+
+      await expectLater(
+        DataDirectoryService.copyFilesForMigration(scan.files, target.path),
+        throwsA(isA<Exception>()),
+      );
     });
   });
 
@@ -261,6 +273,25 @@ void main() {
         isNull,
       );
     });
+
+    test('Windows 下大小写不同的同一目录被判为相同', () {
+      // 用 Windows 风格路径直接验证，不依赖宿主平台。
+      final windows = path.Context(style: path.Style.windows);
+      expect(
+        windows.equals(r'C:\Users\Me\Documents\ThoughtEcho',
+            r'c:\users\me\documents\thoughtecho'),
+        isTrue,
+      );
+    });
+
+    test('不同盘符的目标不会被误判为祖先或嵌套', () {
+      // package:path 的 Windows 风格把盘符作为第一段比较，跨盘迁移不应被拦。
+      final windows = path.Context(style: path.Style.windows);
+      const current = r'C:\Users\Me\Documents\ThoughtEcho';
+      const target = r'D:\ThoughtEcho';
+      expect(windows.isWithin(target, current), isFalse);
+      expect(windows.isWithin(current, target), isFalse);
+    });
   });
 
   group('DataDirectoryService.validateMigrationTarget', () {
@@ -293,13 +324,13 @@ void main() {
   });
 
   group('DataDirectoryService.canonicalizePath', () {
-    test('普通存在的目录原样返回', () async {
+    test('普通存在的目录原样返回', () {
       final real = Directory(abs('real'))..createSync();
-      final resolved = await DataDirectoryService.canonicalizePath(real.path);
+      final resolved = DataDirectoryService.canonicalizePath(real.path);
       expect(path.equals(resolved, real.path), isTrue);
     });
 
-    test('指向当前目录的符号链接被解析成同一真实路径', () async {
+    test('指向当前目录的符号链接被解析成同一真实路径', () {
       final real = Directory(abs('real'))..createSync();
       final link = Link(abs('link'));
       try {
@@ -309,15 +340,15 @@ void main() {
         return;
       }
 
-      final resolved = await DataDirectoryService.canonicalizePath(link.path);
+      final resolved = DataDirectoryService.canonicalizePath(link.path);
       expect(path.equals(resolved, real.path), isTrue);
     });
 
-    test('不存在的目标目录解析为规范化路径（逐级向上解析存在的祖先）', () async {
+    test('不存在的目标目录解析为规范化路径（逐级向上解析存在的祖先）', () {
       final parent = Directory(abs('parent'))..createSync();
       final target = path.join(parent.path, 'sub', 'new');
 
-      final resolved = await DataDirectoryService.canonicalizePath(target);
+      final resolved = DataDirectoryService.canonicalizePath(target);
       expect(path.equals(resolved, target), isTrue);
     });
   });

--- a/test/unit/services/data_directory_service_test.dart
+++ b/test/unit/services/data_directory_service_test.dart
@@ -4,11 +4,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as path;
 import 'package:thoughtecho/services/data_directory_service.dart';
 
+import '../../test_harness.dart';
+
 void main() {
   late Directory tempDir;
 
-  setUp(() {
-    tempDir = Directory.systemTemp.createTempSync('thoughtecho_migration_test');
+  setUpAll(() async {
+    await TestHarness.initialize();
+  });
+
+  setUp(() async {
+    tempDir = await TestHarness.createTempDirectory('migration_test');
   });
 
   tearDown(() {
@@ -138,6 +144,78 @@ void main() {
 
       expect(result['files'], isEmpty);
       expect(result['errors'], isNotEmpty);
+    });
+  });
+
+  group('DataDirectoryService.validateDataDirectoryPath', () {
+    test('相同目录返回错误', () {
+      expect(
+        DataDirectoryService.validateDataDirectoryPath(
+          path.join(tempDir.path, 'a'),
+          path.join(tempDir.path, 'a'),
+        ),
+        isNotNull,
+      );
+    });
+
+    test('目标是当前目录的祖先时返回错误', () {
+      expect(
+        DataDirectoryService.validateDataDirectoryPath(
+          path.join(tempDir.path, 'a', 'b'),
+          tempDir.path,
+        ),
+        isNotNull,
+      );
+    });
+
+    test('目标位于当前目录内部时返回错误', () {
+      expect(
+        DataDirectoryService.validateDataDirectoryPath(
+          tempDir.path,
+          path.join(tempDir.path, 'a', 'b'),
+        ),
+        isNotNull,
+      );
+    });
+
+    test('无关目录返回 null', () {
+      expect(
+        DataDirectoryService.validateDataDirectoryPath(
+          path.join(tempDir.path, 'a'),
+          path.join(tempDir.path, 'other'),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('DataDirectoryService.canonicalizePath', () {
+    test('普通存在的目录原样返回', () async {
+      final real = Directory(abs('real'))..createSync();
+      final resolved = await DataDirectoryService.canonicalizePath(real.path);
+      expect(path.equals(resolved, real.path), isTrue);
+    });
+
+    test('指向当前目录的符号链接被解析成同一真实路径', () async {
+      final real = Directory(abs('real'))..createSync();
+      final link = Link(abs('link'));
+      try {
+        link.createSync(real.path);
+      } on FileSystemException {
+        markTestSkipped('当前环境无法创建符号链接');
+        return;
+      }
+
+      final resolved = await DataDirectoryService.canonicalizePath(link.path);
+      expect(path.equals(resolved, real.path), isTrue);
+    });
+
+    test('不存在的目标目录解析为规范化路径（逐级向上解析存在的祖先）', () async {
+      final parent = Directory(abs('parent'))..createSync();
+      final target = path.join(parent.path, 'sub', 'new');
+
+      final resolved = await DataDirectoryService.canonicalizePath(target);
+      expect(path.equals(resolved, target), isTrue);
     });
   });
 }

--- a/test/unit/services/data_directory_service_test.dart
+++ b/test/unit/services/data_directory_service_test.dart
@@ -98,6 +98,38 @@ void main() {
       expect(files, isNot(contains('nested_target/deep/inner.bin')));
     });
 
+    test('excludePath 是数据目录的祖先时，不排除任何文件', () async {
+      // 场景：Documents/ThoughtEcho -> Documents（新目录是当前目录的父级）。
+      // 祖先目录不是"目标复制进自身"，不应把所有文件误判为目标内文件。
+      final dataDir = Directory(abs('ThoughtEcho'))..createSync();
+      createFile('ThoughtEcho/databases/thoughtecho.db');
+      createFile('ThoughtEcho/media/photo.jpg');
+
+      final result = await DataDirectoryService.collectFilesForMigration(
+        dataDir.path,
+        excludePath: tempDir.path,
+      );
+
+      final files = relativeFiles(result);
+      expect(files, contains('ThoughtEcho/databases/thoughtecho.db'));
+      expect(files, contains('ThoughtEcho/media/photo.jpg'));
+    });
+
+    test('excludePath 与数据目录无关时，不排除任何文件', () async {
+      createFile('databases/thoughtecho.db');
+      createFile('media/photo.jpg');
+      final unrelated = Directory(abs('unrelated'))..createSync();
+
+      final result = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+        excludePath: unrelated.path,
+      );
+
+      final files = relativeFiles(result);
+      expect(files, contains('databases/thoughtecho.db'));
+      expect(files, contains('media/photo.jpg'));
+    });
+
     test('数据目录不存在时返回空列表和错误', () async {
       final missing = path.join(tempDir.path, 'does_not_exist');
       final result = await DataDirectoryService.collectFilesForMigration(

--- a/test/unit/services/data_directory_service_test.dart
+++ b/test/unit/services/data_directory_service_test.dart
@@ -189,6 +189,35 @@ void main() {
     });
   });
 
+  group('DataDirectoryService.validateMigrationTarget', () {
+    test('与当前目录相同返回错误', () async {
+      final current = await DataDirectoryService.getCurrentDataDirectory();
+      expect(
+        await DataDirectoryService.validateMigrationTarget(current),
+        isNotNull,
+      );
+    });
+
+    test('目标是当前目录的祖先时返回错误', () async {
+      final current = await DataDirectoryService.getCurrentDataDirectory();
+      final ancestor = path.dirname(current);
+      expect(
+        await DataDirectoryService.validateMigrationTarget(ancestor),
+        isNotNull,
+      );
+    });
+
+    test('无关目录返回 null', () async {
+      final unrelated = await TestHarness.createTempDirectory('target_test');
+      addTearDown(() => TestHarness.deleteTempDirectory(unrelated));
+
+      expect(
+        await DataDirectoryService.validateMigrationTarget(unrelated.path),
+        isNull,
+      );
+    });
+  });
+
   group('DataDirectoryService.canonicalizePath', () {
     test('普通存在的目录原样返回', () async {
       final real = Directory(abs('real'))..createSync();

--- a/test/unit/services/data_directory_service_test.dart
+++ b/test/unit/services/data_directory_service_test.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+import 'package:thoughtecho/services/data_directory_service.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('thoughtecho_migration_test');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  String abs(String rel) => path.join(tempDir.path, rel);
+
+  void createFile(String rel) {
+    final file = File(abs(rel));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync('content');
+  }
+
+  Set<String> relativeFiles(Map<String, dynamic> result) {
+    return (result['files'] as List<String>)
+        .map((f) => path.relative(f, from: tempDir.path))
+        .toSet();
+  }
+
+  group('DataDirectoryService.collectFilesForMigration', () {
+    test('整目录收集应用数据，包括未来新增的数据源', () async {
+      createFile('databases/thoughtecho.db');
+      createFile('media/photo.jpg');
+      createFile('ai_analyses.db');
+      createFile('chat.db');
+      createFile('backups/backup.zip');
+      createFile('feature_cache/data.bin'); // 模拟未来新增数据源
+
+      final result = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+      );
+
+      expect(result['errors'], isEmpty);
+      final files = relativeFiles(result);
+      expect(
+        files,
+        containsAll([
+          'databases/thoughtecho.db',
+          'media/photo.jpg',
+          'ai_analyses.db',
+          'chat.db',
+          'backups/backup.zip',
+          'feature_cache/data.bin',
+        ]),
+      );
+    });
+
+    test('跳过系统文件和 SQLite -shm 临时文件，保留 -wal', () async {
+      createFile('databases/thoughtecho.db');
+      createFile('databases/thoughtecho.db-wal');
+      createFile('databases/thoughtecho.db-shm');
+      createFile('desktop.ini');
+      createFile('thumbs.db');
+      createFile('ntuser.dat');
+      createFile('.ds_store');
+
+      final result = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+      );
+
+      final files = relativeFiles(result);
+      expect(files, contains('databases/thoughtecho.db'));
+      expect(files, contains('databases/thoughtecho.db-wal'));
+      expect(files, isNot(contains('databases/thoughtecho.db-shm')));
+      expect(files, isNot(contains('desktop.ini')));
+      expect(files, isNot(contains('thumbs.db')));
+      expect(files, isNot(contains('ntuser.dat')));
+      expect(files, isNot(contains('.ds_store')));
+    });
+
+    test('excludePath 位于数据目录内时，其中的文件不参与收集', () async {
+      createFile('databases/thoughtecho.db');
+      createFile('nested_target/data.bin');
+      createFile('nested_target/deep/inner.bin');
+
+      final result = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+        excludePath: abs('nested_target'),
+      );
+
+      final files = relativeFiles(result);
+      expect(files, contains('databases/thoughtecho.db'));
+      expect(files, isNot(contains('nested_target/data.bin')));
+      expect(files, isNot(contains('nested_target/deep/inner.bin')));
+    });
+
+    test('数据目录不存在时返回空列表和错误', () async {
+      final missing = path.join(tempDir.path, 'does_not_exist');
+      final result = await DataDirectoryService.collectFilesForMigration(
+        missing,
+      );
+
+      expect(result['files'], isEmpty);
+      expect(result['errors'], isNotEmpty);
+    });
+  });
+}

--- a/test/unit/services/data_directory_service_test.dart
+++ b/test/unit/services/data_directory_service_test.dart
@@ -32,8 +32,9 @@ void main() {
   }
 
   Set<String> relativeFiles(Map<String, dynamic> result) {
-    return (result['files'] as List<String>)
-        .map((f) => path.relative(f, from: tempDir.path))
+    return (result['files'] as List)
+        .cast<(String, String)>()
+        .map((e) => e.$2)
         .toSet();
   }
 
@@ -116,9 +117,10 @@ void main() {
         excludePath: tempDir.path,
       );
 
+      // 相对路径以数据目录为基准，文件不应被排除。
       final files = relativeFiles(result);
-      expect(files, contains('ThoughtEcho/databases/thoughtecho.db'));
-      expect(files, contains('ThoughtEcho/media/photo.jpg'));
+      expect(files, contains('databases/thoughtecho.db'));
+      expect(files, contains('media/photo.jpg'));
     });
 
     test('excludePath 与数据目录无关时，不排除任何文件', () async {
@@ -144,6 +146,78 @@ void main() {
 
       expect(result['files'], isEmpty);
       expect(result['errors'], isNotEmpty);
+    });
+
+    test('指向外部的目录链接被展开，文件落在链接名相对路径下', () async {
+      // 外部目录必须是数据目录（tempDir）之外的兄弟目录，链接才属于"外部"。
+      final external = await TestHarness.createTempDirectory('external_media');
+      addTearDown(() => TestHarness.deleteTempDirectory(external));
+      final externalFile = File(path.join(external.path, 'a.jpg'));
+      externalFile.createSync();
+      externalFile.writeAsStringSync('content');
+
+      createFile('databases/thoughtecho.db');
+      final link = Link(abs('media'));
+      try {
+        link.createSync(external.path);
+      } on FileSystemException {
+        markTestSkipped('当前环境无法创建符号链接');
+        return;
+      }
+
+      final result = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+      );
+
+      final files = relativeFiles(result);
+      expect(files, contains('databases/thoughtecho.db'));
+      expect(files, contains('media/a.jpg'));
+      expect(result['errors'], isEmpty);
+    });
+
+    test('指向数据目录内部的链接被跳过，不产生重复或错误路径', () async {
+      createFile('databases/thoughtecho.db');
+      final link = Link(abs('dup'));
+      try {
+        link.createSync(abs('databases'));
+      } on FileSystemException {
+        markTestSkipped('当前环境无法创建符号链接');
+        return;
+      }
+
+      final result = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+      );
+
+      final files = relativeFiles(result);
+      expect(files, contains('databases/thoughtecho.db'));
+      expect(files, isNot(contains('dup/thoughtecho.db')));
+    });
+
+    test('指向外部的文件链接作为文件收集', () async {
+      // 外部文件放在数据目录之外的兄弟目录，链接才属于"外部"。
+      final externalDir =
+          await TestHarness.createTempDirectory('external_files');
+      addTearDown(() => TestHarness.deleteTempDirectory(externalDir));
+      final externalFile = File(path.join(externalDir.path, 'external.dat'));
+      externalFile.createSync();
+      externalFile.writeAsStringSync('content');
+
+      final link = Link(abs('linked.dat'));
+      try {
+        link.createSync(externalFile.path);
+      } on FileSystemException {
+        markTestSkipped('当前环境无法创建符号链接');
+        return;
+      }
+
+      final result = await DataDirectoryService.collectFilesForMigration(
+        tempDir.path,
+      );
+
+      final files = relativeFiles(result);
+      expect(files, contains('linked.dat'));
+      expect(result['errors'], isEmpty);
     });
   });
 

--- a/test/widget/pages/storage_management_page_test.dart
+++ b/test/widget/pages/storage_management_page_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:thoughtecho/gen_l10n/app_localizations.dart';
 import 'package:thoughtecho/pages/storage_management_page.dart';
+import 'package:thoughtecho/services/data_directory_service.dart';
 import 'package:thoughtecho/services/database_service.dart';
 import 'package:thoughtecho/services/unified_log_service.dart';
 
@@ -104,6 +105,70 @@ void main() {
 
       expect(find.textContaining('回收站中有'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '查看回收站'), findsNothing);
+
+      await _disposeApp(tester);
+      _disposeLogServiceOnce();
+    });
+
+    testWidgets('迁移目标被拒绝时显示对应的本地化提示', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: Builder(
+          builder: (context) {
+            final l10n = AppLocalizations.of(context);
+            return Scaffold(
+              body: Column(
+                children: [
+                  for (final rejection in DataDirectoryTargetRejection.values)
+                    TextButton(
+                      onPressed: () {
+                        final messenger = ScaffoldMessenger.of(context);
+                        messenger.clearSnackBars();
+                        messenger.showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              dataDirectoryRejectionMessage(l10n, rejection),
+                            ),
+                          ),
+                        );
+                      },
+                      child: Text(rejection.name),
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
+      ));
+
+      Future<void> expectRejectionMessage(
+        DataDirectoryTargetRejection rejection,
+        String expected,
+      ) async {
+        await tester.tap(find.text(rejection.name));
+        await tester.pump();
+        expect(find.text(expected), findsOneWidget);
+      }
+
+      await expectRejectionMessage(
+        DataDirectoryTargetRejection.sameDirectory,
+        '新目录与当前数据目录相同',
+      );
+      await expectRejectionMessage(
+        DataDirectoryTargetRejection.ancestorDirectory,
+        '新目录不能是当前数据目录的上级目录',
+      );
+      await expectRejectionMessage(
+        DataDirectoryTargetRejection.nestedDirectory,
+        '新目录不能位于当前数据目录内部',
+      );
 
       await _disposeApp(tester);
       _disposeLogServiceOnce();


### PR DESCRIPTION
## 背景

Windows 端「存储管理 → 更改数据目录」的数据迁移用硬编码白名单收集文件：

```dart
final appItems = [
  'databases',   // 数据库目录
  'media',       // 媒体文件目录
  'ai_analyses.db',
  'ai_analyses.db-wal',
  'chat.db',
  'chat.db-wal',
  'backups',     // 备份目录
];
```

这意味着以后每新增一种数据源（新数据库、新缓存目录等），都必须回来改这份清单，否则迁移时会漏文件。

## 改动

数据目录已经是应用专属文件夹（`Documents/ThoughtEcho` 或用户自定义目录），里面全是应用自己的数据，因此把「按白名单挑文件」改为**整目录递归收集**：

- `lib/services/data_directory_service.dart`
  - `_collectAppFiles` 改为递归整个数据目录，仅排除系统文件（`desktop.ini` / `thumbs.db` / `ntuser.dat` / `.ds_store`）和 SQLite `-shm` 临时文件；`-wal` 保留。
  - 把纯逻辑提取为 `collectFilesForMigration`（`@visibleForTesting`），便于直接测试。
  - 迁移时把目标目录一并传入收集逻辑，用 `path.isWithin` 排除嵌套在数据目录内的目标目录，防止把目标目录复制进自身（用户把新目录选在数据目录内部的场景）。
  - 复制、校验、配置写入流程不变。
- `test/unit/services/data_directory_service_test.dart`（新增）
  - 整目录收集覆盖未来新增数据源
  - 系统文件 / `-shm` 排除、`-wal` 保留
  - 目标目录嵌套排除
  - 数据目录不存在时返回错误

## 验证

- `flutter analyze --no-fatal-infos`：仅既有 4 条 info，无新增问题
- `flutter test test/unit/services/data_directory_service_test.dart`：4/4 通过
- `flutter test test/widget/pages/storage_management_page_test.dart`：2/2 通过

启动时 `checkAndMigrateLegacyData`（旧版 Documents 根目录 → 子目录的一次性迁移）未改动，与本次无关。

This PR was created by an AI agent (OpenHands) on behalf of the user.

@Shangjin-Xiao can click here to [continue refining the PR](https://app.all-hands.dev/conversations/75c314e1-f6e6-462b-abc5-ff10914de964)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 Windows「更改数据目录」改为整目录递归复制，展开外部 symlink/junction；收集或复制任一步失败即中止并恢复数据库服务。新增真实路径解析与严格目标预检（相同/祖先/嵌套），并优化进度对话框避免闪烁。

- **Refactors**
  - 整目录递归收集，移除白名单与收集阶段的 `excludePath`；仅排除系统文件和 SQLite `-shm`（保留 `-wal`）；返回 `(源路径, 相对路径)` 保持结构。
  - 手动递归并展开指向数据目录外部的链接，指向内部的链接跳过；按真实路径比较与校验（`canonicalizePath` / `validateDataDirectoryPath` / `validateMigrationTarget`，含 `path.equals`）。
  - 迁移时任一文件收集或复制失败即抛出并中止；失败后恢复 `DatabaseService`，旧目录原样保留可重试。
  - 目录选择页用 `DataDirectoryTargetRejection` 映射本地化提示；进度对话框改为单次 push + `ValueNotifier` 刷新，错误提示统一用 `AppSnackBar.error`。

<sup>Written for commit 49ee67c09d5f166ad90965c909bb2f1244c17518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 数据目录迁移支持递归收集应用数据，并自动适配未来新增的数据源。
  * 迁移前会校验目标目录，禁止选择当前目录、其上级目录或内部嵌套目录。
  * 支持处理符号链接和循环目录，避免重复迁移或异常。
  * 继续过滤系统文件和 SQLite 临时文件，同时保留必要的 WAL 文件。
  * 收集文件失败时会中止迁移，并在失败后提供更稳定的数据服务恢复处理。
  * 新增中文和英文迁移目标错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->