### PR TITLE
🌐 译者: [提取设置页硬编码多语言词条]

### DIFF
--- a/.jules/translator.md
+++ b/.jules/translator.md
@@ -54,3 +54,7 @@
 ## 2023-10-24 - [提取 '重试' 硬编码]
 **发现:** `NoteListView` 中 `SnackBarAction` 标签硬编码为中文 `'重试'`
 **规则:** 将 `'重试'` 统一替换为 `AppLocalizations.of(context)!.retry`
+
+## 2024-05-18 - [WebDAV 云同步状态]
+**发现:** '从未同步', '已启用', '(上次：$timeStr)' 等硬编码字符串。
+**规则:** 复用了已存在的 `webdavNeverSynced`, `webdavStatusEnabled`, `webdavLastSync` 等国际化键，确保多语言支持。

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -751,11 +751,11 @@ class SettingsPageState extends State<SettingsPage> {
 
                       final timeStr = webdavSync.lastSyncTime.isNotEmpty
                           ? LWWUtils.formatTimestamp(webdavSync.lastSyncTime)
-                          : '从未同步';
+                          : l10n.webdavNeverSynced;
 
                       return Text(statusStr.isNotEmpty
-                          ? '$statusStr (上次：$timeStr)'
-                          : '已启用 (上次：$timeStr)');
+                          ? '$statusStr (${l10n.webdavLastSync(timeStr)})'
+                          : '${l10n.webdavStatusEnabled} (${l10n.webdavLastSync(timeStr)})');
                     },
                   ),
                   leading: const Icon(Icons.cloud_sync_outlined),


### PR DESCRIPTION
提取了 `lib/pages/settings_page.dart` 中 WebDAV 同步状态显示的硬编码字符串，并替换为 `l10n` 变量。
- `'从未同步'` -> `l10n.webdavNeverSynced`
- `'已启用 (上次：$timeStr)'` -> `${l10n.webdavStatusEnabled} (${l10n.webdavLastSync(timeStr)})`

同时在 `.jules/translator.md` 中追加了对应的提取规则日志。

---
*PR created automatically by Jules for task [13518483714416708341](https://jules.google.com/task/13518483714416708341) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将设置页 WebDAV 同步状态的硬编码字符串提取为 `l10n`，统一本地化显示。无功能改动，仅提升多语言一致性。

- **Refactors**
  - 在 `lib/pages/settings_page.dart` 用 `l10n.webdavNeverSynced`、`l10n.webdavStatusEnabled`、`l10n.webdavLastSync(timeStr)` 替换原硬编码拼接。
  - 更新 `.jules/translator.md`，记录对应提取规则与示例。

<sup>Written for commit afbf763a7436c348f1024a461803954d3696504c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * WebDAV 云同步状态信息现已使用本地化文本显示。
  * “从未同步”“已启用”和“上次同步时间”等状态文案在不同语言环境下保持一致。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->