### PR TITLE
fix(editor): 修好添加笔记弹窗丢失的开合动画，「取消」补上未保存确认

### DIFF
--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -156,6 +156,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   Timer? _dbChangeDebounceTimer;
 
   bool _isSaving = false;
+  bool _closeRequestInFlight = false; // 未保存确认框只允许在飞一个
   bool _waitingForFetch = false; // 用户已触发保存，正在等待位置/天气获取完成
   bool _deferredControlsVisible = true;
   Timer? _deferredControlsTimer;
@@ -2083,25 +2084,31 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   /// 所以「取消」按钮以前是直接把路由弹掉的，未保存确认整个被绕过去。
   /// 两条路都改走这里。
   Future<void> _handleCloseRequest() async {
-    if (!mounted) return;
+    // 确认框弹出前「取消」还点得到，返回键也还进得来。没有这道闸，
+    // 连点两下就会叠两个未保存确认框，各自 await 各自的结果。
+    if (!mounted || _closeRequestInFlight) return;
+    _closeRequestInFlight = true;
+    try {
+      // 检查是否有未保存的更改
+      if (!_hasUnsavedChanges()) {
+        Navigator.pop(context);
+        return;
+      }
 
-    // 检查是否有未保存的更改
-    if (!_hasUnsavedChanges()) {
-      Navigator.pop(context);
-      return;
+      // 显示确认对话框
+      final dialogResult = await _showUnsavedChangesDialog();
+      if (!mounted) return;
+      if (dialogResult == true) {
+        // 用户选择放弃更改
+        Navigator.pop(context);
+      } else if (dialogResult == 'save') {
+        // 用户选择保存并退出
+        await _saveAndExit();
+      }
+      // dialogResult == null: 继续编辑，不做任何操作
+    } finally {
+      _closeRequestInFlight = false;
     }
-
-    // 显示确认对话框
-    final dialogResult = await _showUnsavedChangesDialog();
-    if (!mounted) return;
-    if (dialogResult == true) {
-      // 用户选择放弃更改
-      Navigator.pop(context);
-    } else if (dialogResult == 'save') {
-      // 用户选择保存并退出
-      await _saveAndExit();
-    }
-    // dialogResult == null: 继续编辑，不做任何操作
   }
 
   @override

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -2077,6 +2077,33 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     return result;
   }
 
+  /// 关闭弹窗的统一入口。
+  ///
+  /// PopScope 只拦得住系统返回键：`Navigator.pop` 不走 popDisposition，
+  /// 所以「取消」按钮以前是直接把路由弹掉的，未保存确认整个被绕过去。
+  /// 两条路都改走这里。
+  Future<void> _handleCloseRequest() async {
+    if (!mounted) return;
+
+    // 检查是否有未保存的更改
+    if (!_hasUnsavedChanges()) {
+      Navigator.pop(context);
+      return;
+    }
+
+    // 显示确认对话框
+    final dialogResult = await _showUnsavedChangesDialog();
+    if (!mounted) return;
+    if (dialogResult == true) {
+      // 用户选择放弃更改
+      Navigator.pop(context);
+    } else if (dialogResult == 'save') {
+      // 用户选择保存并退出
+      await _saveAndExit();
+    }
+    // dialogResult == null: 继续编辑，不做任何操作
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_dialogPerfRecording) {
@@ -2088,27 +2115,9 @@ class _AddNoteDialogState extends State<AddNoteDialog>
 
     return PopScope(
       canPop: false,
-      onPopInvokedWithResult: (didPop, result) async {
+      onPopInvokedWithResult: (didPop, result) {
         if (didPop) return;
-
-        // 检查是否有未保存的更改
-        if (!_hasUnsavedChanges()) {
-          if (context.mounted) {
-            Navigator.pop(context);
-          }
-          return;
-        }
-
-        // 显示确认对话框
-        final dialogResult = await _showUnsavedChangesDialog();
-        if (dialogResult == true && context.mounted) {
-          // 用户选择放弃更改
-          Navigator.pop(context);
-        } else if (dialogResult == 'save') {
-          // 用户选择保存并退出
-          await _saveAndExit();
-        }
-        // dialogResult == null: 继续编辑，不做任何操作
+        unawaited(_handleCloseRequest());
       },
       child: KeyboardInsetPadding(
         onInsetBuild: _onKeyboardInsetBuild,
@@ -2722,7 +2731,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
                         ),
                       const Spacer(),
                       FilledButton.tonal(
-                        onPressed: () => Navigator.pop(context),
+                        onPressed: () => unawaited(_handleCloseRequest()),
                         child: Text(l10n.cancel),
                       ),
                       const SizedBox(width: 8),

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -104,7 +104,6 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   bool _dialogPerfFirstFrameLogged = false;
   bool _dialogPerfFocusLogged = false;
   bool _dialogPerfKeyboardStartLogged = false;
-  double _dialogPerfLastKeyboardInset = 0;
   double? _dialogPerfLastInsetBuildValue;
   int _dialogPerfBuildCount = 0;
   int _dialogPerfBodyReuseCount = 0;
@@ -137,12 +136,17 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   Timer? _dialogPerfKeyboardSettleTimer;
   Timer? _dialogPerfFinalizeTimer;
 
-  // 键盘弹出期间 showModalBottomSheet 会随 viewInsets 连续重建 builder。
-  // 临时复用主体 Widget，避免每一帧都重新构建完整表单内容。
-  bool _keyboardRebuildDeferralActive = false;
-  bool _keyboardRebuildWasDeferred = false;
+  // 键盘 inset 的依赖只挂在 KeyboardInsetPadding 上，本 State 不再订阅 MediaQuery，
+  // 否则键盘每动一帧都会把整个弹窗标脏。这个值由 KeyboardInsetPadding 回传。
+  double _lastKeyboardInset = 0;
+
+  // 键盘弹出期间 showModalBottomSheet 会随 viewInsets 连续重跑 builder，可那几帧里
+  // 弹窗自己的状态一点没变。按修订号复用上一次的 Widget 实例——Flutter 见到同一个
+  // 实例会整棵子树跳过 diff。状态真的变了（setState / 依赖变化 / 入参变化）修订号
+  // 就往前走，缓存立刻作废，不会像按定时器冻结那样把 setState 吞掉。
   Widget? _cachedDialogBody;
-  Timer? _keyboardRebuildResumeTimer;
+  int _dialogBodyRevision = 0;
+  int? _cachedDialogBodyRevision;
 
   // 性能优化：缓存Provider引用，避免重复查找
   LocationService? _cachedLocationService;
@@ -893,7 +897,6 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   }
 
   void _requestContentFocus(String reason) {
-    _beginKeyboardRebuildDeferral();
     _dialogOpenTimelineTask.instant(
       'ThoughtEcho.AddNoteDialog.focus.requested',
       arguments: <String, Object>{'reason': reason},
@@ -934,52 +937,50 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     });
   }
 
-  void _beginKeyboardRebuildDeferral() {
-    if (_keyboardRebuildDeferralActive) {
-      return;
-    }
-
-    _keyboardRebuildDeferralActive = true;
-    _keyboardRebuildWasDeferred = false;
-    _keyboardRebuildResumeTimer?.cancel();
-    _keyboardRebuildResumeTimer = Timer(
-      const Duration(milliseconds: 1800),
-      _endKeyboardRebuildDeferral,
-    );
+  @override
+  void setState(VoidCallback fn) {
+    _dialogBodyRevision++;
+    super.setState(fn);
   }
 
-  void _endKeyboardRebuildDeferral() {
-    if (!_keyboardRebuildDeferralActive) {
-      return;
-    }
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // 主题/语言等继承数据变了，缓存里那棵树是拿旧值构造的，必须重建。
+    _dialogBodyRevision++;
+  }
 
-    _keyboardRebuildResumeTimer?.cancel();
-    _keyboardRebuildResumeTimer = null;
-    _keyboardRebuildDeferralActive = false;
-    _cachedDialogBody = null;
-
-    if (mounted && _keyboardRebuildWasDeferred) {
-      setState(() {
-        _keyboardRebuildWasDeferred = false;
-      });
-    } else {
-      _keyboardRebuildWasDeferred = false;
+  @override
+  void didUpdateWidget(AddNoteDialog oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // onSave 每次都是新闭包，不能拿它判断；只看主体真正渲染的入参。
+    if (!identical(oldWidget.tags, widget.tags) ||
+        oldWidget.initialQuote != widget.initialQuote ||
+        oldWidget.prefilledContent != widget.prefilledContent ||
+        oldWidget.prefilledAuthor != widget.prefilledAuthor ||
+        oldWidget.prefilledWork != widget.prefilledWork) {
+      _dialogBodyRevision++;
     }
   }
 
-  Widget _buildKeyboardDeferredDialogBody(Widget Function() buildBody) {
-    if (_keyboardRebuildDeferralActive && _cachedDialogBody != null) {
+  Widget _buildCachedDialogBody(Widget Function() buildBody) {
+    final cached = _cachedDialogBody;
+    if (cached != null && _cachedDialogBodyRevision == _dialogBodyRevision) {
       if (_dialogPerfRecording) {
         _dialogPerfBodyReuseCount++;
       }
-      _keyboardRebuildWasDeferred = true;
-      return _cachedDialogBody!;
+      return cached;
     }
 
+    final body = _buildMeasuredDialogBody(buildBody);
+    _cachedDialogBody = body;
+    _cachedDialogBodyRevision = _dialogBodyRevision;
+    return body;
+  }
+
+  Widget _buildMeasuredDialogBody(Widget Function() buildBody) {
     if (!_dialogPerfRecording) {
-      final body = buildBody();
-      _cachedDialogBody = body;
-      return body;
+      return buildBody();
     }
 
     // 只测 Widget 树的构造，不含 element 挂载、布局和光栅化——
@@ -992,7 +993,6 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     if (elapsedMs > _dialogPerfBodyBuildWorstMs) {
       _dialogPerfBodyBuildWorstMs = elapsedMs;
     }
-    _cachedDialogBody = body;
     return body;
   }
 
@@ -1022,7 +1022,10 @@ class _AddNoteDialogState extends State<AddNoteDialog>
         (_dialogPerfStateChanges[source] ?? 0) + 1;
   }
 
-  void _recordDialogPerfInsetBuild(double keyboardInset) {
+  /// KeyboardInsetPadding 每次按 inset 重排都回调这里。
+  /// 弹窗自己不订阅 MediaQuery，键盘的实时值只能从这条路进来。
+  void _onKeyboardInsetBuild(double keyboardInset) {
+    _lastKeyboardInset = keyboardInset;
     if (!_dialogPerfEnabled || !_dialogPerfRecording) {
       return;
     }
@@ -1038,24 +1041,15 @@ class _AddNoteDialogState extends State<AddNoteDialog>
   void didChangeMetrics() {
     super.didChangeMetrics();
 
-    // 键盘弹出和收起都会连续改变 viewInsets；两种方向都暂停主体重建。
-    _beginKeyboardRebuildDeferral();
-
-    if (_keyboardRebuildDeferralActive) {
-      _keyboardRebuildResumeTimer?.cancel();
-      _keyboardRebuildResumeTimer = Timer(
-        const Duration(milliseconds: 220),
-        _endKeyboardRebuildDeferral,
-      );
-    }
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) {
         return;
       }
 
-      final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
-      _dialogPerfLastKeyboardInset = keyboardInset;
+      // 注意：这里不能读 MediaQuery.viewInsetsOf(context)。即使在帧回调里读，
+      // 也会给本 State 挂上 viewInsets 依赖，键盘每动一帧都把整个弹窗标脏。
+      // 值改由 KeyboardInsetPadding 在自己的 build 里回传。
+      final keyboardInset = _lastKeyboardInset;
       if (keyboardInset <= 0) {
         return;
       }
@@ -1091,7 +1085,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
           _dialogOpenTimelineTask.instant(
             'ThoughtEcho.AddNoteDialog.keyboardInset.settled',
             arguments: <String, Object>{
-              'inset': _dialogPerfLastKeyboardInset.round(),
+              'inset': _lastKeyboardInset.round(),
             },
           );
           _finishDialogOpenTimeline('keyboardSettled');
@@ -1099,7 +1093,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
             return;
           }
           logDebug(
-            '键盘 inset 稳定: inset=${_dialogPerfLastKeyboardInset.round()}, '
+            '键盘 inset 稳定: inset=${_lastKeyboardInset.round()}, '
             'elapsed=${_dialogPerfKeyboardSettledMs}ms',
             source: 'AddNoteDialog.Perf',
           );
@@ -1207,7 +1201,7 @@ class _AddNoteDialogState extends State<AddNoteDialog>
       'avg=${avgFrameMs.toStringAsFixed(1)}ms, '
       'worst=${worstFrameMs.toStringAsFixed(1)}ms, '
       'focus=$_dialogPerfFocusLogged, '
-      'keyboardInset=${_dialogPerfLastKeyboardInset.round()}',
+      'keyboardInset=${_lastKeyboardInset.round()}',
       source: 'AddNoteDialog.Perf',
     );
 
@@ -1738,7 +1732,6 @@ class _AddNoteDialogState extends State<AddNoteDialog>
     _dialogOpenTimelineTimeout?.cancel();
     _dialogPerfFinalizeTimer?.cancel();
     _dialogPerfKeyboardSettleTimer?.cancel();
-    _keyboardRebuildResumeTimer?.cancel();
     _deferredControlsTimer?.cancel();
     _autoFocusTimer?.cancel();
     _autoMetadataFallbackTimer?.cancel();
@@ -2118,8 +2111,8 @@ class _AddNoteDialogState extends State<AddNoteDialog>
         // dialogResult == null: 继续编辑，不做任何操作
       },
       child: KeyboardInsetPadding(
-        onInsetBuild: _recordDialogPerfInsetBuild,
-        child: _buildKeyboardDeferredDialogBody(() => SingleChildScrollView(
+        onInsetBuild: _onKeyboardInsetBuild,
+        child: _buildCachedDialogBody(() => SingleChildScrollView(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/lib/widgets/add_note_dialog_parts.dart
+++ b/lib/widgets/add_note_dialog_parts.dart
@@ -8,7 +8,11 @@ import '../theme/theme_style.dart';
 import '../utils/icon_utils.dart';
 
 /// 只让外层边距响应键盘 inset，避免键盘动画驱动整个弹窗内容重建。
-class KeyboardInsetPadding extends StatelessWidget {
+///
+/// 退场期间（路由动画走 reverse）改用最后一次的 inset：弹窗下滑和键盘收起是两段
+/// 各自独立的动画，而键盘在不少机型上是一帧收完的。底部内边距跟着塌掉的话，
+/// 弹窗会先瞬间掉下去一个键盘的高度，剩下那点位移根本看不出是动画。
+class KeyboardInsetPadding extends StatefulWidget {
   final Widget child;
   final ValueChanged<double>? onInsetBuild;
 
@@ -16,9 +20,29 @@ class KeyboardInsetPadding extends StatelessWidget {
       {super.key, required this.child, this.onInsetBuild});
 
   @override
+  State<KeyboardInsetPadding> createState() => _KeyboardInsetPaddingState();
+}
+
+class _KeyboardInsetPaddingState extends State<KeyboardInsetPadding> {
+  double _lastInset = 0;
+  bool _wasPresented = false;
+
+  @override
   Widget build(BuildContext context) {
-    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
-    onInsetBuild?.call(keyboardInset);
+    final liveInset = MediaQuery.viewInsetsOf(context).bottom;
+    final status = ModalRoute.of(context)?.animation?.status;
+    if (status != null && status != AnimationStatus.dismissed) {
+      _wasPresented = true;
+    }
+    // dismissed 也要冻结，但只在弹过一次之后：首帧的 dismissed 是入场前的状态，
+    // 那时候冻结会把编辑已有笔记（进来时键盘还开着）的初始内边距顶掉。
+    final isLeaving = status == AnimationStatus.reverse ||
+        (status == AnimationStatus.dismissed && _wasPresented);
+    final keyboardInset = isLeaving ? _lastInset : liveInset;
+    if (!isLeaving) {
+      _lastInset = liveInset;
+    }
+    widget.onInsetBuild?.call(keyboardInset);
     return Padding(
       padding: EdgeInsets.only(
         bottom: keyboardInset,
@@ -26,7 +50,7 @@ class KeyboardInsetPadding extends StatelessWidget {
         right: 16,
         top: 16,
       ),
-      child: child,
+      child: widget.child,
     );
   }
 }

--- a/test/widget/add_note_dialog_focus_timing_test.dart
+++ b/test/widget/add_note_dialog_focus_timing_test.dart
@@ -390,6 +390,58 @@ void main() {
     expect(find.byType(AddNoteDialog), findsNothing);
   });
 
+  testWidgets('cancel then save-and-exit saves once and closes',
+      (tester) async {
+    final savedQuotes = <Quote>[];
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<FeatureGuideService>(
+            create: (_) => _MockFeatureGuideService(),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('zh'),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () {
+                  showModalBottomSheet<void>(
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (_) => AddNoteDialog(
+                      tags: const [],
+                      onSave: savedQuotes.add,
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, '保存并退出的内容');
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, '取消'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, '保存并退出'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AddNoteDialog), findsNothing);
+    expect(savedQuotes, hasLength(1));
+    expect(savedQuotes.single.content, '保存并退出的内容');
+  });
+
   testWidgets('does not warn about unsaved changes when editing unchanged note',
       (tester) async {
     final initialQuote = Quote(

--- a/test/widget/add_note_dialog_focus_timing_test.dart
+++ b/test/widget/add_note_dialog_focus_timing_test.dart
@@ -329,6 +329,67 @@ void main() {
     await tester.pump(const Duration(seconds: 2));
   });
 
+  testWidgets('cancel button warns about unsaved changes', (tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<FeatureGuideService>(
+            create: (_) => _MockFeatureGuideService(),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('zh'),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () {
+                  showModalBottomSheet<void>(
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (_) => AddNoteDialog(
+                      tags: const [],
+                      onSave: (_) {},
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, '还没保存的内容');
+    await tester.pump();
+
+    // 「取消」以前直接 Navigator.pop，绕过 PopScope 的未保存确认，内容当场丢掉。
+    await tester.tap(find.widgetWithText(FilledButton, '取消'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('未保存的内容'), findsOneWidget);
+    expect(find.byType(AddNoteDialog), findsOneWidget);
+
+    // 选「继续编辑」应该留在弹窗里，内容还在。
+    await tester.tap(find.widgetWithText(TextButton, '继续编辑'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AddNoteDialog), findsOneWidget);
+    expect(find.text('还没保存的内容'), findsOneWidget);
+
+    // 再点一次取消并放弃，弹窗才关闭。
+    await tester.tap(find.widgetWithText(FilledButton, '取消'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, '放弃更改'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AddNoteDialog), findsNothing);
+  });
+
   testWidgets('does not warn about unsaved changes when editing unchanged note',
       (tester) async {
     final initialQuote = Quote(

--- a/test/widget/add_note_dialog_focus_timing_test.dart
+++ b/test/widget/add_note_dialog_focus_timing_test.dart
@@ -270,6 +270,65 @@ void main() {
     databaseService.completeSave();
   });
 
+  testWidgets('applies state changes right after the entrance settles',
+      (tester) async {
+    final initialQuote = Quote(
+      id: 'quote-color',
+      content: '已有内容',
+      date: DateTime(2026).toIso8601String(),
+      colorHex: '#336699',
+    );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<FeatureGuideService>(
+            create: (_) => _MockFeatureGuideService(),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('zh'),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () {
+                  showModalBottomSheet<void>(
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (_) => AddNoteDialog(
+                      initialQuote: initialQuote,
+                      tags: const [],
+                      onSave: (_) {},
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    const colorChipKey = ValueKey('add_note_color_chip');
+    expect(
+        tester.widget<FilterChip>(find.byKey(colorChipKey)).selected, isTrue);
+
+    // 焦点请求之后主体一度被按定时器冻住，这一下 setState 会被吞掉直到冻结到期。
+    await tester.tap(find.byKey(colorChipKey));
+    await tester.pump();
+
+    expect(
+        tester.widget<FilterChip>(find.byKey(colorChipKey)).selected, isFalse);
+
+    await tester.pump(const Duration(seconds: 2));
+  });
+
   testWidgets('does not warn about unsaved changes when editing unchanged note',
       (tester) async {
     final initialQuote = Quote(

--- a/test/widget/add_note_dialog_focus_timing_test.dart
+++ b/test/widget/add_note_dialog_focus_timing_test.dart
@@ -390,6 +390,64 @@ void main() {
     expect(find.byType(AddNoteDialog), findsNothing);
   });
 
+  testWidgets('repeated cancel taps stack only one confirmation',
+      (tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<FeatureGuideService>(
+            create: (_) => _MockFeatureGuideService(),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('zh'),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () {
+                  showModalBottomSheet<void>(
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (_) => AddNoteDialog(
+                      tags: const [],
+                      onSave: (_) {},
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, '连点取消的内容');
+    await tester.pump();
+
+    // 确认框还没盖上来之前「取消」仍可点，连点两下不能叠出两个确认框。
+    final cancelButton =
+        tester.widget<FilledButton>(find.widgetWithText(FilledButton, '取消'));
+    cancelButton.onPressed!();
+    cancelButton.onPressed!();
+    await tester.pumpAndSettle();
+
+    expect(find.text('未保存的内容'), findsOneWidget);
+
+    // 关掉唯一那个确认框后就该回到弹窗，而不是露出第二个确认框。
+    await tester.tap(find.widgetWithText(TextButton, '继续编辑'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('未保存的内容'), findsNothing);
+    expect(find.byType(AddNoteDialog), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 2));
+  });
+
   testWidgets('cancel then save-and-exit saves once and closes',
       (tester) async {
     final savedQuotes = <Quote>[];

--- a/test/widget/keyboard_inset_padding_test.dart
+++ b/test/widget/keyboard_inset_padding_test.dart
@@ -26,4 +26,58 @@ void main() {
 
     expect(reportedInsets, containsAllInOrder(<double>[0, 240]));
   });
+
+  testWidgets('holds the last inset while the route is leaving',
+      (tester) async {
+    final reportedInsets = <double>[];
+    double bottomInset = 240;
+    late StateSetter setInset;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () {
+              showModalBottomSheet<void>(
+                context: context,
+                isScrollControlled: true,
+                builder: (_) => StatefulBuilder(
+                  builder: (context, setState) {
+                    setInset = setState;
+                    return MediaQuery(
+                      data: MediaQuery.of(context).copyWith(
+                        viewInsets: EdgeInsets.only(bottom: bottomInset),
+                      ),
+                      child: KeyboardInsetPadding(
+                        onInsetBuild: reportedInsets.add,
+                        child: const SizedBox(width: 100, height: 100),
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(reportedInsets.last, 240);
+
+    // 退场和键盘收起同时发生：inset 塌到 0，但内边距必须停在 240，
+    // 否则弹窗会先瞬移一个键盘的高度，下滑动画就没了。
+    final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+    navigator.pop();
+    bottomInset = 0;
+    setInset(() {});
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(reportedInsets.last, 240);
+
+    await tester.pumpAndSettle();
+  });
 }

--- a/test/widget/keyboard_inset_padding_test.dart
+++ b/test/widget/keyboard_inset_padding_test.dart
@@ -80,4 +80,63 @@ void main() {
 
     await tester.pumpAndSettle();
   });
+
+  testWidgets('does not resurrect a keyboard dismissed before the pop',
+      (tester) async {
+    final reportedInsets = <double>[];
+    double bottomInset = 240;
+    late StateSetter setInset;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () {
+              showModalBottomSheet<void>(
+                context: context,
+                isScrollControlled: true,
+                builder: (_) => StatefulBuilder(
+                  builder: (context, setState) {
+                    setInset = setState;
+                    return MediaQuery(
+                      data: MediaQuery.of(context).copyWith(
+                        viewInsets: EdgeInsets.only(bottom: bottomInset),
+                      ),
+                      child: KeyboardInsetPadding(
+                        onInsetBuild: reportedInsets.add,
+                        child: const SizedBox(width: 100, height: 100),
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(reportedInsets.last, 240);
+
+    // 用户先自己收了键盘：弹窗早就按 inset=0 重排完了。
+    bottomInset = 0;
+    setInset(() {});
+    await tester.pumpAndSettle();
+    expect(reportedInsets.last, 0);
+
+    // 此时再关闭，冻结的必须是 0。若改成「冻结最后一次非零 inset」，
+    // 退场一开始弹窗会凭空长高一个键盘，反而是更糟的跳变。
+    final navigator = tester.state<NavigatorState>(find.byType(Navigator));
+    navigator.pop();
+    setInset(() {});
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(reportedInsets.last, 0);
+
+    await tester.pumpAndSettle();
+  });
 }


### PR DESCRIPTION
## 背景

上一次给 AddNoteDialog 做的「性能优化」实际收益很小，还带来了动画丢失：弹窗有时候直接没有开合动画，取消/关闭时概率更高。

从实机日志能直接看出优化没打中要害：

```
打开性能明细: firstFrame=109ms, ... widgetBuilds=30, bodyBuilds=2,
bodyBuildFirst=0.0ms, bodyBuildWorst=0.2ms, bodyReuses=28, insetBuilds=30
打开帧耗时明细: jank16=8, jank32=5, jank50=5, buildAvg=12.1ms, buildWorst=163.1ms
```

被缓存下来的那次主体构建只花 **0.2ms**，而最差一帧的 build 是 **163ms**。省的和卡的完全不是一回事。

## 改了什么

### 1. 关闭/取消时动画整段消失

弹窗下滑和键盘收起是两段互不相干的动画，而键盘在不少机型上是一帧收完的。`KeyboardInsetPadding` 的底部内边距跟着 `viewInsets` 塌到 0，弹窗高度瞬间少掉一个键盘的高度、直接掉到屏幕底部，剩下那点位移根本看不出是在放动画。键盘收得快慢因机型/输入法而异，所以表现为概率性丢失。

退场期间（路由动画走 `reverse`）内边距冻结在最后一次的 inset 上，下滑动画完整跑完。首帧那次 `dismissed` 不冻结，否则编辑已有笔记（进来时键盘还开着）的初始内边距会被顶掉。

### 2. 主体缓存会把 setState 吞掉

原来在 `didChangeMetrics` 的帧回调里读 `MediaQuery.viewInsetsOf(context)`。哪怕是在帧回调里读，也会给弹窗 State 挂上 viewInsets 依赖，键盘每动一帧都把整棵树标脏——回头又用一个 220ms/1800ms 的定时器把主体冻住来遮掩。

代价是这段窗口里所有 `setState` 都被吞掉：请求焦点之后的 1.8 秒内改颜色、删标签、完整笔记加载完，界面全都不动，等冻结到期才一次性跳出来。

现在：inset 实时值由 `KeyboardInsetPadding` 回传，State 不再订阅 MediaQuery；主体缓存改按修订号失效（`setState` / 依赖变化 / 入参变化都会作废）。键盘动画那几十帧里状态确实没变，照样复用同一个 Widget 实例跳过整棵子树的 diff，省下的重建一点没少，但不会再压住真实的状态变化。

### 3. 「取消」绕过未保存确认

`PopScope` 只拦得住系统返回键：`Navigator.pop` 不走 `popDisposition`，所以「取消」按钮是直接把路由弹掉的，未保存确认整个被绕过去——系统返回键会弹「未保存的内容」，点取消按钮不会，写了一半的内容当场没了。

关闭弹窗收敛到 `_handleCloseRequest` 一个入口，返回键和「取消」都走它，并补上确认对话框返回后的 mounted 检查。

## 验证

Flutter 3.44.1（对齐 CI 里 firebase 性能工作流的版本）实跑：

- `flutter analyze` 干净，改动文件无新增问题
- 三条新回归测试**在旧代码上失败、新代码上通过**：
  - `holds the last inset while the route is leaving`
  - `applies state changes right after the entrance settles`
  - `cancel button warns about unsaved changes`
- `flutter test test/widget/` 全绿（246 passed）
- `test/performance/add_note_dialog_optimized_test.dart` 有 2 条挂了，但那是墙钟阈值测试，**在本 PR 之前的代码上同样挂**（748ms vs 阈值 300ms），是测试环境太慢，与本次改动无关

## 已知遗留

打开时那 163ms 的首帧还在，本 PR 没动。根因是 `_deferredControlsVisible` 初始值是 `true`，「次要控件延后挂载」这个优化实际上是死代码——`_showDeferredControls()` 每次都提前 return，作者/作品输入框、标签区、颜色选择、AI 菜单全都在第一帧就建出来。250ms 的入场动画被一帧 170ms 吃掉，看着就是没动画。

但 `add_note_dialog_focus_timing_test.dart` 里有条 `renders secondary controls with the initial dialog frame` 明确要求这些控件首帧就在，看起来是刻意的产品取舍（延后会导致内容 350ms 后突然跳出来），所以没擅自改。真要解决得往下拆：定位 163ms 具体花在哪个子树（TextField / ExpansionTile / MarkdownBody / 颜色网格），单独优化那一块。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkvUb7Ta4SGHbmRoqKZwJc)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复添加笔记弹窗在关闭/取消时丢失的开合动画，并统一「取消」与系统返回键的未保存确认。旧行为：键盘一帧收起致退场动画消失、「取消」直接 pop 丢内容、定时器冻结吞掉 setState。新行为：退场冻结最后一次键盘 inset（若已收起则冻结为 0），所有关闭路径走统一入口并防重入，主体用“修订号+实例缓存”复用且状态即时生效。

**变更要点**
- 将 KeyboardInsetPadding 改为 Stateful：路由退场或弹过一次后的 dismissed 冻结最后一次 inset；首帧 dismissed 不冻结；若用户在关闭前已收起键盘，则冻结为 0，避免退场时“复活”键盘高度。
- 弹窗 State 不再订阅 MediaQuery.viewInsets；实时键盘 inset 由 KeyboardInsetPadding 通过 onInsetBuild 回传，避免键盘每帧标脏整棵树。
- 主体构建改为“修订号+实例缓存”：setState、继承依赖或入参变化即递增修订号使缓存失效；移除定时器式冻结，避免吞掉真实的状态更新。
- 关闭入口收敛至 _handleCloseRequest：PopScope 返回键与「取消」共用；增加 mounted 检查与防重入闸（避免连点叠出多个确认框）；「取消→保存并退出」仅保存一次并关闭。
- 新增回归测试覆盖：inset 冻结与“先收起键盘”语义、入场后状态即时生效、「取消」触发未保存确认与防重入、以及取消→保存并退出仅保存一次。 

**评审建议**
- 关注 add_note_dialog_parts.dart 中退场冻结与首帧豁免逻辑，确认“已收起键盘时冻结为 0”的分支。
- 查看 add_note_dialog.dart 的修订号缓存实现及 setState/didChangeDependencies/didUpdateWidget 的修订点。
- 验证 _handleCloseRequest 的三条出口与防重入是否覆盖所有关闭路径。

<sup>Written for commit 08f32694b99dac9818f388d17688063816e04c09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化添加笔记弹窗的显示性能，减少键盘输入期间的卡顿和不必要刷新。
  - 优化键盘弹出与收起时的布局表现，确保弹窗退场动画更加稳定。

- **错误修复**
  - 统一取消按钮与系统返回键的关闭行为，存在未保存内容时会显示确认提示。
  - 修复编辑已有笔记时颜色状态无法及时切换的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->