### PR TITLE
perf(note-list): 折叠正文排版量封顶，plan 加缓存，热路径去掉全量字符串扫描

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,8 +342,7 @@ MultiAISettings → AIProviderSettings → AINetworkManager / OpenAIStreamServic
 
 ## 文档维护
 
-- 开发者文档：`AGENTS.md`（本文件即旧 `CLAUDE.md` 的替代，不要另建 `CLAUDE.md`）、
-  各子目录 `AGENTS.md`、`README.md`
+- 开发者文档：`AGENTS.md`、各子目录 `AGENTS.md`、`README.md`
 - 双语用户手册：`docs/USER_MANUAL.md`
 - 应用内手册：`assets/docs/user_manual_zh.md`、`assets/docs/user_manual_en.md`
 - 网站：`res/index.html`、`res/user-guide.html`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,8 +364,10 @@ MultiAISettings → AIProviderSettings → AINetworkManager / OpenAIStreamServic
   - `.squad/agents/<name>/history.md`：各角色的工作历史；
   - `.squad/log/`、`.squad/casting/`：会话日志与角色分派记录。
 
-  这些是**过程档案**，不是规范：与本文件冲突时以本文件为准，但「为什么当初这么做」
-  基本只在 `.squad/` 里写着。
+  这些是**过程档案**，不是规范，也不能直接当实现依据——里面有大量后来被推翻的中间
+  判断。只用来追溯「为什么当初这么做」，那个信息基本只在 `.squad/` 里写着。
+  与当前代码、本文件或 `docs/` 下的最终交接文档冲突时，一律以当前实现和最终交接
+  文档为准（`.squad/decisions.md` 说的「权威」是指它在 `.squad/` 内部权威）。
 
 ## Git、隐私与提交
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,13 +342,31 @@ MultiAISettings → AIProviderSettings → AINetworkManager / OpenAIStreamServic
 
 ## 文档维护
 
-- 开发者文档：`AGENTS.md`、各子目录 `AGENTS.md`、`README.md`
+- 开发者文档：`AGENTS.md`（本文件即旧 `CLAUDE.md` 的替代，不要另建 `CLAUDE.md`）、
+  各子目录 `AGENTS.md`、`README.md`
 - 双语用户手册：`docs/USER_MANUAL.md`
 - 应用内手册：`assets/docs/user_manual_zh.md`、`assets/docs/user_manual_en.md`
 - 网站：`res/index.html`、`res/user-guide.html`
 
 只有用户可见行为变化时才同步用户文档，并同时维护中英文内容；纯内部重构只更新确实受影响
 的开发者文档。禁止描述尚未实现的功能，除非明确标为路线图。
+
+### 历史记录去哪里找
+
+动手改一块**已经被优化过或返工过**的代码之前，先翻这两处，别从零推一遍别人踩过的坑：
+
+- `docs/` —— 按主题的交接与审计文档，文件名带日期。性能、主题、同步、Thoughter
+  各有一串，例如 `docs/note-list-perf-handoff-2026-08-12.md` →
+  `docs/note-list-perf-analysis-2026-08-13.md` 是同一条线的连续两份。
+- `.squad/` —— **AI 团队的过程记录**，比 `docs/` 更细也更早：
+  - `.squad/decisions.md`：所有重要决策的权威记录，带日期和决策人；
+  - `.squad/*_handoff.md`：单轮任务的交接（字体重构、记录页冷启动、
+    新增笔记弹窗性能等）；
+  - `.squad/agents/<name>/history.md`：各角色的工作历史；
+  - `.squad/log/`、`.squad/casting/`：会话日志与角色分派记录。
+
+  这些是**过程档案**，不是规范：与本文件冲突时以本文件为准，但「为什么当初这么做」
+  基本只在 `.squad/` 里写着。
 
 ## Git、隐私与提交
 

--- a/docs/note-list-perf-analysis-2026-08-13.md
+++ b/docs/note-list-perf-analysis-2026-08-13.md
@@ -1,0 +1,210 @@
+# 记录页仍然卡顿 —— 日志诊断（2026-08-13）
+
+接着 `docs/note-list-perf-handoff-2026-08-12.md`（阶段 D，折叠卡片彻底不跑 Quill）。
+这份只做一件事：**用 2026-08-13 那轮 `NoteListView.Perf` 日志回答「Quill 都拿掉了，
+为什么还卡」**。结论先行，证据在后，最后是按性价比排序的下一步。
+
+---
+
+## 一句话结论
+
+阶段 D 优化的是**稳态**成本，而稳态从来就不是卡顿的来源。日志里所有掉帧都集中在
+两类帧上，这两类阶段 D 一个都没碰：
+
+1. **某张卡第一次被建出来 / 第一次布局**（`h=none→…`）；
+2. **整个列表被 `setState` 重建一遍**（分页数据到达、`_isLoading` 翻转……）。
+
+滑过**已经建好**的卡片时，帧时间是 `avgFrame=3.1ms / frameJank=0`——完美。
+所以主观上「没减轻很多」是准确的：均值确实降了（`avgBuild` 从上一份基线的
+15.6ms 降到 1.2~6.1ms），但用户感知的是那几个 **117.8ms / 123.9ms 的建帧**，
+而它们和上一份基线的 157.6ms 是同一个量级。
+
+---
+
+## 证据：把 14 个 session 按「有没有新卡片」分两堆
+
+| session | 场景 | frames | frameJank | avgFrame | worstFrame | worstBuild | built |
+|---|---|---|---|---|---|---|---|
+| scroll-10 | 往回滑，全是老卡片 | 100 | **0** | **3.1ms** | 6.2ms | 3.5ms | **0** |
+| scroll-13 | 往回滑，全是老卡片 | 102 | **0** | **3.8ms** | 14.6ms | 7.9ms | **0** |
+| scroll-11 | 往回滑，全是老卡片 | 8 | 0 | 3.8ms | 6.9ms | 1.9ms | 0 |
+| scroll-9 | 下滑，11 张新卡 | 99 | 1 | 4.5ms | 16.8ms | 13.5ms | 11 |
+| scroll-8 | 下滑，16 张新卡 | 80 | 4 | 6.8ms | 31.7ms | 28.9ms | 16 |
+| scroll-5 | 下滑，23 张新卡 | 65 | 6 | 7.4ms | 25.3ms | 21.7ms | 23 |
+| scroll-3 | 下滑 + loadMore | 55 | **11** | 9.7ms | 22.7ms | 21.2ms | **104** |
+| scroll-4 | 几乎没动 + 分页落地 | 31 | **10** | **18.5ms** | **122.9ms** | **117.8ms** | 30 |
+| scroll-14 | 往回滑 + loadMore | 231 | 4 | 5.0ms | **143.5ms** | **123.9ms** | **297** |
+
+分界线干净得不像话：**`built=0` 的 session 一帧都不掉；`built` 大的 session 出现
+三位数毫秒的建帧。** 卡顿 100% 是「第一次」的成本，稳态成本已经不是矛盾了。
+
+顺带两个读日志时容易被骗的地方：
+
+- **scroll-1 / scroll-2 的 `frames=0` 是仪表盲区，不是「没掉帧」。** `FrameTiming`
+  是批量回调，短 session 被下一个 session 的 `_startScrollSessionPerfCapture`
+  强制收尾（`note_list_scroll.dart:118`），回调还没送到。**首屏那两段——恰恰是最贵的
+  两段——完全没有帧数据。** 它俩的 `eventJank=12/16` 和 `eventAvg=22.4ms` 才是真相。
+- **`quoteContent={…}` 里贵的那两项没被统计。** `height=` 统计的是
+  `_QuoteHeightEstimateCache`（廉价估算），真正做 `TextPainter` 实测的
+  `_QuotePlainTextLayoutExpansionCache` 和 `CollapsedRichTextMetrics.plan()`
+  **一个计数器都没有**。日志显示 `docWorstUs=0`、`irWorstUs=415`，看着一片绿，
+  是因为它只盯着已经被优化掉的那条路。
+
+---
+
+## 根因一：纯文本卡片仍然排版**整篇**正文
+
+阶段 D 给富文本上了行数预算，**纯文本一行没改**：
+
+```dart
+// lib/widgets/quote_content_widget.dart:769
+Widget _buildPlainTextContent({required bool needsExpansion}) {
+  Widget plainText = Text(
+    quote.content,          // ← 没有 maxLines
+    style: style,
+    softWrap: true,
+    overflow: TextOverflow.visible,
+  );
+  if (!showFullContent && needsExpansion) {
+    plainText = _CollapsedContentWrapper(maxHeight: 160, child: plainText);
+  }
+  return plainText;
+}
+```
+
+`_CollapsedContentWrapper` 是 `ClipRect(SizedBox(height: 160, …))`。
+`RenderParagraph` **不看高度约束**——它按 `maxWidth` 把整篇正文断行、整形完，
+算出自然高度，然后才被裁掉只剩 160px。一条 3000 字的笔记，折叠卡片只显示 5 行，
+却付了 3000 字的排版钱。
+
+折叠判定那一路是同一个毛病（`quote_content_widget.dart:472`）：
+
+```dart
+final painter = TextPainter(text: TextSpan(text: quote.content, style: style), …)
+  ..layout(maxWidth: maxWidth);          // ← 也没有 maxLines
+return painter.height > collapsedContentMaxHeight + 0.5;
+```
+
+这一路有缓存兜着（`_QuotePlainTextLayoutExpansionCache`），渲染那一路没有。
+
+**日志对得上**：`slowLayouts` 里最慢的清一色是 `plain`——
+`11.1ms / 11.6ms / 10.6ms / 9.5ms / 9.3ms`，全部 `h=none→…`（首次布局）。
+而 119 条笔记里 `rich=40`，剩下 **79 条是纯文本**，`builtKind=p143/r26/m128`
+也说明构建量的大头是 plain。**阶段 D 优化的是少数派。**
+
+> 修法：判定侧用 `TextPainter(maxLines: n)` + `didExceedMaxLines`；渲染侧给
+> `Text` 传 `maxLines` + `TextOverflow.clip`，`n` 由 `160 / 行高` 推出。
+> 保真度不变（本来就要裁掉），成本从 O(全文) 降到 O(可见行)。
+
+---
+
+## 根因二：富文本卡片**每次重建**都重新量一遍，而且量两遍
+
+`CollapsedRichTextMetrics.plan()` 在 `QuoteContent.build` 的 `LayoutBuilder` 里
+直接调用（`quote_content_widget.dart:676`），**没有任何缓存**。每次重建：
+
+- 每个可见块跑一次 `buildCollapsedBlockLayout()` + 一次 `TextPainter.layout()`（测量）；
+- 然后 `_CollapsedRichTextBlock.build` 里**又**跑一次 `buildCollapsedBlockLayout()`（渲染）；
+- 再由 `RenderParagraph` 做真正的排版。
+
+也就是说同一段文字的 span 构造做了两遍，排版做了两遍。IR 解析确实很便宜
+（`irWorstUs=415`，阶段 D 的功劳），但**贵的是 IR 之后的排版，那部分完全没缓存**。
+
+---
+
+## 根因三：37 张最贵的卡片被永久钉在树上，每次 `setState` 全部重建
+
+```dart
+// lib/widgets/note_list_view.dart:111
+static bool shouldKeepAliveQuoteItem(Quote quote) {
+  …
+  if (deltaContent.contains('"image"') || …) return true;   // 有媒体 → 永久 keepAlive
+  return QuoteItemWidget.needsExpansionFor(quote);
+}
+```
+
+日志里 `pinnedKeepAlive=37`、`keepAlive=53~66`。这些 element 永远不脱离树；
+而 `ListView.builder` 每次 build 都换一个新的 `SliverChildBuilderDelegate`
+（`shouldRebuild` 恒为 true），所以 **`NoteListViewState` 每 `setState` 一次，
+就有 55~100 张卡片重建一次**——其中 37 张正是根因二里最贵的那类。
+
+`built=297@10-118`（scroll-14，`stateΔ=4`）、`built=104@0-46`（scroll-3）就是这么来的。
+`worstBuild=123.9ms` 也是。
+
+触发 `setState` 的源头至少有：
+
+- **分页数据事件**：`_quotes..clear()..addAll(list)`
+  （`note_list_data_stream.dart:112`、`:396`）。注意 `watchQuotes` 每次都重发
+  **整个累积列表**，第 3 页到达 = 119 个**全新** `Quote` 对象替换 119 个旧对象。
+  `AppConstants.scrollPreloadThreshold = 0.35` 意味着只要滑过全长的 1/3 就会触发，
+  几乎每次下滑都要吃一次。
+- `_scheduleExpandableQuoteCheck` 的回填（`note_list_data_stream.dart:28`）；
+- `_isLoading` 收尾、`_hasMore` 同步、锚点修正……
+
+`_scheduleIdlePrefetch` 的注释（`note_list_scroll.dart:823`）其实已经点破了这件事，
+但它只是把**预取**挪到静止期；用户滑到 35% 触发的那次 `_loadMore` 仍然落在滚动帧内。
+
+---
+
+## 根因四：热路径上有几个 O(正文长度) 的字符串扫描（release 也在跑）
+
+`_shouldKeepAliveNoteListItem` → `shouldKeepAliveQuoteItem` 会对**每一次 itemBuilder
+调用**做 3 次 `deltaContent.contains(…)`，全量扫描整个 delta JSON，无缓存。
+`delta_media_extractor.dart` 明确说明 source 可能是整段 base64 `data:` URL，
+那种笔记上这一步就是每次构建扫几 MB。
+
+`DeltaMediaCache` / `DeltaRichTextCache` 已经把这类判断缓存好了
+（`readDeltaMediaEmbed` 是唯一真源），`shouldKeepAliveQuoteItem` 应该走缓存，
+而不是自己再 `contains` 一遍。
+
+另外几个每卡每帧的固定开销：`QuoteItemWidget.build` 里 7 个
+`context.select<SettingsService, …>` + `QuoteContent.build` 里 2 个、
+`DateTime.parse(quote.date)` + `DateFormat` 格式化、两层嵌套 `LayoutBuilder`、
+每张卡一个带 `BouncingScrollPhysics` 的 `SingleChildScrollView`（=每张卡一个
+独立 `ScrollPosition`）、`PopupMenuButton` + `Tooltip` + `Material/InkWell`。
+单看都不贵，乘以 100 张卡的重建就是几十毫秒。
+
+---
+
+## 还有一个测量本身的问题
+
+开发者模式的「首屏滚动性能监控」打开时，`_recordNoteListItemBuild` 和
+`_wrapNoteListItemPerfProbe` 各调一次 `_noteListPerfKindFor(quote)`，
+里面又是 3 次全量 `contains`；`_quoteMixStatsText()` 每次收尾再对 119 条各扫 3 次。
+**开着监控测出来的绝对值是偏高的**，而如果你是开着它在体感流畅度，那你摸到的
+有一部分就是探针自己。
+
+判断改动效果只看**相对值**，而且必须 release 模式——上一份交接的「下一步第 1 条」
+到现在还是没做。
+
+---
+
+## 下一步（按性价比排序）
+
+1. **纯文本折叠走 `maxLines`**（判定侧 + 渲染侧各一处）。改动最小、收益最大，
+   直接打掉 `slowLayouts` 里排前几名的那批。
+2. **缓存 `CollapsedRichTextMetrics.plan()`**，键 = 内容指纹 + `maxWidth` + 样式哈希
+   （和 `_QuotePlainTextLayoutExpansionCache` 同一套键即可），顺便让测量和渲染
+   共用同一份 `buildCollapsedBlockLayout` 结果，省掉重复的 span 构造。
+3. **`shouldKeepAliveQuoteItem` 改走 `DeltaMediaCache`**，去掉热路径上的 `contains`。
+4. **切断「数据事件 → 全列表重建」**。两个方向，选一个：
+   - `watchQuotes` 分页事件改成**追加**而不是整表替换，并给 `Quote` 加值相等，
+     让没变的卡片 `didUpdateWidget` 直接短路；
+   - 或者把 `keepAlive` 收窄——媒体卡片永久钉住是为了防图片闪烁，但
+     `imageCache` 本来就兜得住（`CollapsedMediaImage` 的注释里已经论证过一次了），
+     值得重新验证「永久 keepAlive」这个前提还成不成立。
+5. **`scrollPreloadThreshold` 0.35 太早**。整表替换的代价这么大，应该等到接近底部
+   （0.8 左右）再触发，把它推进静止期。
+
+第 1、2、3 条互不相干，可以并行做；第 4 条是结构性的，建议单独一轮并配基准。
+
+---
+
+## 复测口径（别再换了）
+
+release 模式，115~119 条笔记 / `media≈32`，下滑约 28000px 后原路滑回。
+只看这三个数，别看均值：
+
+- `worstBuild` —— 目前 117.8ms / 123.9ms，这是用户唯一能感觉到的东西；
+- `built=` 的峰值 —— 目前单 session 297，衡量根因三；
+- `slowLayouts` 里 `plain` 的占比和耗时 —— 目前包揽前几名，衡量根因一。

--- a/docs/note-list-perf-analysis-2026-08-13.md
+++ b/docs/note-list-perf-analysis-2026-08-13.md
@@ -157,6 +157,13 @@ static bool shouldKeepAliveQuoteItem(Quote quote) {
 （`readDeltaMediaEmbed` 是唯一真源），`shouldKeepAliveQuoteItem` 应该走缓存，
 而不是自己再 `contains` 一遍。
 
+**这里只是慢，不是错。** 一度以为「正文里写了 `"image"` 的笔记会被误判成有媒体」，
+实测不成立：`jsonEncode` 会把正文里的引号转义成 `\"image\"`，子串扫描本来就匹配不上
+（`test/unit/utils/delta_media_extractor_test.dart` 里留了这条断言）。真正的分歧只出现在
+`"image"` 作为某个 op 的**属性名**时，那在本项目里不会发生。所以换成缓存纯粹是省时间：
+`contains` 每次调用都要重扫一遍全文且结果不复用，而按内容指纹查表的主要成本
+（`String.hashCode`）被 Dart VM 缓存在字符串对象头里，同一个 `Quote` 反复问是廉价的。
+
 另外几个每卡每帧的固定开销：`QuoteItemWidget.build` 里 7 个
 `context.select<SettingsService, …>` + `QuoteContent.build` 里 2 个、
 `DateTime.parse(quote.date)` + `DateFormat` 格式化、两层嵌套 `LayoutBuilder`、
@@ -188,7 +195,7 @@ static bool shouldKeepAliveQuoteItem(Quote quote) {
 |---|---|---|
 | 纯文本排版整篇正文 | 判定与渲染各加一处 `maxLines`，行数由 `QuoteContent.collapsedPlainTextMaxLines` 按「折叠盒高 ÷ 行高下界 + 1」算 | `quote_content_widget.dart` |
 | `plan()` 每次重建重量 | 加 `CollapsedRichTextPlanCache`（LRU 300，键只存内容指纹），两个调用点都带上键 | `collapsed_rich_text.dart` |
-| 热路径全量 `contains` | `shouldKeepAliveQuoteItem` 改走新的 `DeltaMediaCache.hasMediaOf`（只存 bool，`data:` 笔记也能缓存） | `note_list_view.dart` / `delta_media_extractor.dart` |
+| 热路径全量 `contains` | `shouldKeepAliveQuoteItem` 改走新的 `DeltaMediaCache.hasMediaOf`（只存 bool，`data:` 笔记也能缓存）。**这条是省时间，不是修 bug**，见根因四 | `note_list_view.dart` / `delta_media_extractor.dart` |
 | 探针自己也在扫 | `_noteListPerfKindFor`、`_quoteMixStatsText` 一并改走缓存 | `note_list/*.dart` |
 
 行数预算**只能偏大**：多排的行落在 160px 盒子外面被 `ClipRect` 裁掉，看不见；
@@ -226,7 +233,7 @@ static bool shouldKeepAliveQuoteItem(Quote quote) {
 ## 复测口径（别再换了）
 
 release 模式，115~119 条笔记 / `media≈32`，下滑约 28000px 后原路滑回。
-只看这三个数，别看均值：
+只看这四个数，别看均值：
 
 - `worstBuild` —— 改前 117.8ms / 123.9ms，这是用户唯一能感觉到的东西；
 - `built=` 的峰值 —— 改前单 session 297，衡量根因三（**本轮没动，应该基本不变**）；

--- a/docs/note-list-perf-analysis-2026-08-13.md
+++ b/docs/note-list-perf-analysis-2026-08-13.md
@@ -174,29 +174,52 @@ static bool shouldKeepAliveQuoteItem(Quote quote) {
 **开着监控测出来的绝对值是偏高的**，而如果你是开着它在体感流畅度，那你摸到的
 有一部分就是探针自己。
 
-判断改动效果只看**相对值**，而且必须 release 模式——上一份交接的「下一步第 1 条」
-到现在还是没做。
+这轮日志本身**已经是 release 的**（上一份交接的「下一步第 1 条」做了），
+所以上面那些绝对值就是用户真实感受到的量级，只是还含着探针自己的开销。
+本轮已经把探针改走缓存，下一轮的绝对值会更干净一些。
 
 ---
 
+## 已修（本轮）
+
+根因一、二、四**已经改掉**，都不改视觉、不改用户可见行为：
+
+| | 改法 | 落点 |
+|---|---|---|
+| 纯文本排版整篇正文 | 判定与渲染各加一处 `maxLines`，行数由 `QuoteContent.collapsedPlainTextMaxLines` 按「折叠盒高 ÷ 行高下界 + 1」算 | `quote_content_widget.dart` |
+| `plan()` 每次重建重量 | 加 `CollapsedRichTextPlanCache`（LRU 300，键只存内容指纹），两个调用点都带上键 | `collapsed_rich_text.dart` |
+| 热路径全量 `contains` | `shouldKeepAliveQuoteItem` 改走新的 `DeltaMediaCache.hasMediaOf`（只存 bool，`data:` 笔记也能缓存） | `note_list_view.dart` / `delta_media_extractor.dart` |
+| 探针自己也在扫 | `_noteListPerfKindFor`、`_quoteMixStatsText` 一并改走缓存 | `note_list/*.dart` |
+
+行数预算**只能偏大**：多排的行落在 160px 盒子外面被 `ClipRect` 裁掉，看不见；
+少排的内容是静悄悄消失的。所以行高取 `fontSize * (height ?? 1.0)` 这个下界，再 +1 行。
+渲染侧还要按 `DefaultTextStyle.merge` 之后的**实际**样式算——`Text` 的字号可能整个
+来自环境，照着一个 `fontSize` 为 null 的样式估就会低估行数。
+`test/unit/widgets/collapsed_plain_text_budget_test.dart` 用真的 `TextPainter`
+钉住了这条不变量。
+
+顺带把测量盲区补上了：性能日志新增 `plan=`、`planMiss+`、`planWorkUs+`、`planWorstUs=`。
+折叠富文本真正的排版成本一直在 `plan()` 里，而日志此前只统计便宜的 IR 解析
+（`irWorstUs=415`），看着一片绿。
+
+**根因三（37 张媒体卡永久 keepAlive + 数据事件整表替换）没动**，它是结构性的，
+需要单独一轮并配基准，见下。
+
 ## 下一步（按性价比排序）
 
-1. **纯文本折叠走 `maxLines`**（判定侧 + 渲染侧各一处）。改动最小、收益最大，
-   直接打掉 `slowLayouts` 里排前几名的那批。
-2. **缓存 `CollapsedRichTextMetrics.plan()`**，键 = 内容指纹 + `maxWidth` + 样式哈希
-   （和 `_QuotePlainTextLayoutExpansionCache` 同一套键即可），顺便让测量和渲染
-   共用同一份 `buildCollapsedBlockLayout` 结果，省掉重复的 span 构造。
-3. **`shouldKeepAliveQuoteItem` 改走 `DeltaMediaCache`**，去掉热路径上的 `contains`。
-4. **切断「数据事件 → 全列表重建」**。两个方向，选一个：
+1. **切断「数据事件 → 全列表重建」**（根因三）。两个方向，选一个：
    - `watchQuotes` 分页事件改成**追加**而不是整表替换，并给 `Quote` 加值相等，
      让没变的卡片 `didUpdateWidget` 直接短路；
    - 或者把 `keepAlive` 收窄——媒体卡片永久钉住是为了防图片闪烁，但
      `imageCache` 本来就兜得住（`CollapsedMediaImage` 的注释里已经论证过一次了），
      值得重新验证「永久 keepAlive」这个前提还成不成立。
-5. **`scrollPreloadThreshold` 0.35 太早**。整表替换的代价这么大，应该等到接近底部
-   （0.8 左右）再触发，把它推进静止期。
-
-第 1、2、3 条互不相干，可以并行做；第 4 条是结构性的，建议单独一轮并配基准。
+2. **`scrollPreloadThreshold` 0.35 太早**。整表替换的代价这么大，应该等到接近底部
+   （0.8 左右）再触发，把它推进静止期。**会改变分页时机**，要先确认。
+3. **让测量和渲染共用一份 `buildCollapsedBlockLayout`**。现在同一段文字的 span
+   构造做两遍（测量一遍用 `measurement` palette、渲染一遍用主题 palette）。
+   `plan()` 有缓存之后测量那遍已经不在热路径上了，收益变小，但仍然是浪费。
+4. **冷启动首次滑过仍然要重解全部图片**（上一份就记着的第 3 条，与本轮正交）。
+   `imageCache` 是纯内存的，重启即失。要消除首次等待需要保存时生成缩略图文件存盘。
 
 ---
 
@@ -205,6 +228,9 @@ static bool shouldKeepAliveQuoteItem(Quote quote) {
 release 模式，115~119 条笔记 / `media≈32`，下滑约 28000px 后原路滑回。
 只看这三个数，别看均值：
 
-- `worstBuild` —— 目前 117.8ms / 123.9ms，这是用户唯一能感觉到的东西；
-- `built=` 的峰值 —— 目前单 session 297，衡量根因三；
-- `slowLayouts` 里 `plain` 的占比和耗时 —— 目前包揽前几名，衡量根因一。
+- `worstBuild` —— 改前 117.8ms / 123.9ms，这是用户唯一能感觉到的东西；
+- `built=` 的峰值 —— 改前单 session 297，衡量根因三（**本轮没动，应该基本不变**）；
+- `slowLayouts` 里 `plain` 的占比和耗时 —— 改前包揽前几名（11.1 / 11.6 / 10.6ms），
+  衡量根因一，**本轮主要看这一项**；
+- 新增的 `planMiss+` / `planWorkUs+` —— 稳态滑动里 `planMiss` 应该接近 0，
+  不是 0 就说明缓存键漏了什么维度，每帧都在重量。

--- a/lib/utils/delta_media_extractor.dart
+++ b/lib/utils/delta_media_extractor.dart
@@ -242,11 +242,15 @@ class DeltaMediaCache {
   static int _hitCount = 0;
   static int _missCount = 0;
 
-  /// 只回答「这条笔记里有没有媒体」，不解析也不返回任何 source。
+  /// 只回答「这条笔记里有没有媒体」，不返回任何 source。
   ///
   /// 给热路径用：列表的 keepAlive 判定原来是三次 `deltaContent.contains(...)`，
-  /// 每次条目构建都要全量扫一遍整份 delta JSON，正文越长越贵，而且和真正的解析
-  /// 口径也不一致（正文里出现 `"image"` 这串字就会误判）。
+  /// **每次**条目构建都要重新全量扫一遍整份 delta JSON，正文越长越贵，而且结果
+  /// 一次都不复用。这里换成按内容指纹查表：指纹的主要成本是 `String.hashCode`，
+  /// 而 Dart VM 把它缓存在字符串对象头里，所以同一个 `Quote` 反复问是廉价的。
+  ///
+  /// 口径也从「子串碰运气」变成 `readDeltaMediaEmbed` 那一份唯一真源——
+  /// 结果与 [parseDeltaMedia] 恒等，媒体序列化改形状时不会有第二处需要同步。
   static bool hasMediaOf(String? deltaContent) {
     if (deltaContent == null || deltaContent.isEmpty) {
       return false;
@@ -260,11 +264,11 @@ class DeltaMediaCache {
       return cached;
     }
 
-    // 摘要缓存已经有就直接借用，省掉一次解析。这里不做 LRU touch：
-    // 命中与否由 [of] 自己的访问顺序决定，不该被布尔查询顺手改写。
-    final existing = _cache[key];
-    final hasMedia =
-        existing?.hasMedia ?? parseDeltaMedia(deltaContent).hasMedia;
+    // 走 [_summaryFor] 而不是直接 `parseDeltaMedia`：它顺手把摘要也放进 [_cache]，
+    // 于是紧接着调 [of] 的调用方（比如性能日志的条目分类）不会把同一份 delta
+    // 再解析一遍。`data:` 笔记仍然按 [_summaryFor] 的规则跳过摘要缓存，但布尔
+    // 结果照样常驻——热路径要的就是这一个 bool。
+    final hasMedia = _summaryFor(key, deltaContent).hasMedia;
 
     if (_hasMediaCache.length >= _maxHasMediaCacheSize) {
       final victims =
@@ -291,6 +295,14 @@ class DeltaMediaCache {
       return existing;
     }
 
+    return _summaryFor(key, deltaContent);
+  }
+
+  /// 解析一次并按规则写入摘要缓存。调用方必须先查过 [_cache] 没命中。
+  static DeltaMediaSummary _summaryFor(
+    DeltaContentFingerprint key,
+    String deltaContent,
+  ) {
     _missCount++;
     final summary = parseDeltaMedia(deltaContent);
 
@@ -330,6 +342,9 @@ class DeltaMediaCache {
       'hitCount': _hitCount,
       'missCount': _missCount,
       'hitRate': total == 0 ? 0.0 : _hitCount / total,
+      // 布尔缓存单独报一个尺寸：`data:` 笔记的摘要不进 [_cache]，只有这一项
+      // 能证明它们的 keepAlive 判定确实没在每次构建时重解。
+      'hasMediaCacheSize': _hasMediaCache.length,
     };
   }
 }

--- a/lib/utils/delta_media_extractor.dart
+++ b/lib/utils/delta_media_extractor.dart
@@ -264,11 +264,23 @@ class DeltaMediaCache {
       return cached;
     }
 
-    // 走 [_summaryFor] 而不是直接 `parseDeltaMedia`：它顺手把摘要也放进 [_cache]，
-    // 于是紧接着调 [of] 的调用方（比如性能日志的条目分类）不会把同一份 delta
-    // 再解析一遍。`data:` 笔记仍然按 [_summaryFor] 的规则跳过摘要缓存，但布尔
-    // 结果照样常驻——热路径要的就是这一个 bool。
-    final hasMedia = _summaryFor(key, deltaContent).hasMedia;
+    // 摘要缓存已经有就直接借用。列表里 [of] 和 [hasMediaOf] 都会被每次条目构建
+    // 调到，谁先谁后不定；不先查一遍 [_cache] 的话，后手那一个必然把同一份
+    // delta 再解析一遍。借用时照常 touch：这条目正在被使用，不该因为提问的入口
+    // 不同就被当成冷数据淘汰掉。
+    //
+    // 没有就走 [_summaryFor]，它顺手把摘要也放进 [_cache]，于是反过来也成立。
+    // `data:` 笔记按 [_summaryFor] 的规则跳过摘要缓存，但布尔结果照样常驻——
+    // 热路径要的就是这一个 bool。
+    final existing = _cache.remove(key);
+    final bool hasMedia;
+    if (existing != null) {
+      _hitCount++;
+      _cache[key] = existing;
+      hasMedia = existing.hasMedia;
+    } else {
+      hasMedia = _summaryFor(key, deltaContent).hasMedia;
+    }
 
     if (_hasMediaCache.length >= _maxHasMediaCacheSize) {
       final victims =

--- a/lib/utils/delta_media_extractor.dart
+++ b/lib/utils/delta_media_extractor.dart
@@ -225,11 +225,57 @@ class DeltaMediaCache {
   static final LinkedHashMap<DeltaContentFingerprint, DeltaMediaSummary>
       _cache = LinkedHashMap<DeltaContentFingerprint, DeltaMediaSummary>();
 
+  /// 「这条笔记有没有媒体」的布尔缓存，和 [_cache] 分开。
+  ///
+  /// 分开的理由是 `data:` 内嵌媒体：那种笔记的摘要**不进** [_cache]（见 [of]），
+  /// 于是每次问都要重解一遍整份 base64。而列表的 keepAlive 判定每次构建条目都要
+  /// 问一次，正是最不能重解的地方。这张表只存一个 bool，既不持有 source 也不持有
+  /// delta，data: 笔记也可以安全常驻。
+  static final LinkedHashMap<DeltaContentFingerprint, bool> _hasMediaCache =
+      LinkedHashMap<DeltaContentFingerprint, bool>();
+
   static const int _maxCacheSize = 300;
   static const int _pruneBatchSize = 50;
+  static const int _maxHasMediaCacheSize = 600;
+  static const int _hasMediaPruneBatchSize = 100;
 
   static int _hitCount = 0;
   static int _missCount = 0;
+
+  /// 只回答「这条笔记里有没有媒体」，不解析也不返回任何 source。
+  ///
+  /// 给热路径用：列表的 keepAlive 判定原来是三次 `deltaContent.contains(...)`，
+  /// 每次条目构建都要全量扫一遍整份 delta JSON，正文越长越贵，而且和真正的解析
+  /// 口径也不一致（正文里出现 `"image"` 这串字就会误判）。
+  static bool hasMediaOf(String? deltaContent) {
+    if (deltaContent == null || deltaContent.isEmpty) {
+      return false;
+    }
+
+    final key = DeltaContentFingerprint.of(deltaContent);
+
+    final cached = _hasMediaCache.remove(key);
+    if (cached != null) {
+      _hasMediaCache[key] = cached;
+      return cached;
+    }
+
+    // 摘要缓存已经有就直接借用，省掉一次解析。这里不做 LRU touch：
+    // 命中与否由 [of] 自己的访问顺序决定，不该被布尔查询顺手改写。
+    final existing = _cache[key];
+    final hasMedia =
+        existing?.hasMedia ?? parseDeltaMedia(deltaContent).hasMedia;
+
+    if (_hasMediaCache.length >= _maxHasMediaCacheSize) {
+      final victims =
+          _hasMediaCache.keys.take(_hasMediaPruneBatchSize).toList();
+      for (final victim in victims) {
+        _hasMediaCache.remove(victim);
+      }
+    }
+    _hasMediaCache[key] = hasMedia;
+    return hasMedia;
+  }
 
   static DeltaMediaSummary of(String? deltaContent) {
     if (deltaContent == null || deltaContent.isEmpty) {
@@ -271,6 +317,7 @@ class DeltaMediaCache {
 
   static void clear() {
     _cache.clear();
+    _hasMediaCache.clear();
     _hitCount = 0;
     _missCount = 0;
   }

--- a/lib/widgets/note_list/collapsed_rich_text.dart
+++ b/lib/widgets/note_list/collapsed_rich_text.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:flutter/material.dart';
 
 import '../../gen_l10n/app_localizations.dart';
@@ -404,6 +406,14 @@ class CollapsedRichTextMetrics {
   /// 量出折叠盒该画哪些块、每块几行、一共多高。
   ///
   /// 这是**唯一**一次测量：盒子的高度和要画的内容都从这一次的结果来，两者不会漂。
+  ///
+  /// 传 [cacheContent]（笔记的 `deltaContent`）即启用结果缓存。**强烈建议传**：
+  /// 这个方法是在 `LayoutBuilder` 里调的，卡片每重建一次就要把每个可见块重新
+  /// `TextPainter.layout` 一遍，而列表里有几十张卡片是永久 keepAlive 的——一次
+  /// `setState` 就是几十次全量重量。结果只取决于参数，缓存不会让测量和渲染漂开。
+  ///
+  /// [cacheBoldPrioritized] 必须如实反映 [blocks] 是否已被 [prioritizeBoldBlocks]
+  /// 重排过：同一份 delta 在开关两种状态下的计划不同，不进键就会串味。
   static CollapsedRichTextPlan plan({
     required List<RichTextBlock> blocks,
     required TextStyle baseStyle,
@@ -414,6 +424,78 @@ class CollapsedRichTextMetrics {
     TextDirection textDirection = TextDirection.ltr,
     TextScaler textScaler = TextScaler.noScaling,
     Locale? locale,
+    String? cacheContent,
+    bool cacheBoldPrioritized = false,
+  }) {
+    _CollapsedRichTextPlanCacheKey? cacheKey;
+    if (cacheContent != null && cacheContent.isNotEmpty) {
+      cacheKey = _CollapsedRichTextPlanCacheKey(
+        fingerprint: DeltaContentFingerprint.of(cacheContent),
+        boldPrioritized: cacheBoldPrioritized,
+        showMedia: showMedia,
+        // 宽度是连续量，直接进键几乎不会命中；量化到 0.01px 之后同一次布局里
+        // 的重复调用才落在同一个桶里。
+        maxWidthKey: (maxWidth * 100).round(),
+        limitKey: (limit * 100).round(),
+        styleHash: baseStyle.hashCode,
+        boldWeightValue: boldWeight.value,
+        textDirection: textDirection,
+        textScalerHash: textScaler.hashCode,
+        localeTag: locale?.toLanguageTag(),
+      );
+      final cached = CollapsedRichTextPlanCache._get(cacheKey);
+      if (cached != null) {
+        return cached;
+      }
+    }
+
+    final stopwatch = cacheKey == null ? null : (Stopwatch()..start());
+    final computed = _computePlan(
+      blocks: blocks,
+      baseStyle: baseStyle,
+      maxWidth: maxWidth,
+      limit: limit,
+      showMedia: showMedia,
+      boldWeight: boldWeight,
+      textDirection: textDirection,
+      textScaler: textScaler,
+      locale: locale,
+    );
+
+    // 计划里排到了 `data:` 内嵌媒体就不进缓存：那个 source 是整段 base64，
+    // 缓存住等于把若干 MB 长期钉在堆上。`DeltaMediaCache` 和 `DeltaRichTextCache`
+    // 跳过这类笔记是同一个理由。
+    //
+    // 判据是**计划自己排到的块**，不是整篇 blocks：折叠盒只有 160px，正文长的
+    // 笔记根本排不到后面那张内嵌图，那种计划不持有 base64，可以照常缓存。
+    if (cacheKey != null && !_holdsInlineDataMedia(computed)) {
+      stopwatch!.stop();
+      CollapsedRichTextPlanCache._put(
+        cacheKey,
+        computed,
+        stopwatch.elapsedMicroseconds,
+      );
+    }
+    return computed;
+  }
+
+  static bool _holdsInlineDataMedia(CollapsedRichTextPlan plan) {
+    for (final entry in plan.entries) {
+      if (isInlineDataUri(entry.block.media?.source)) return true;
+    }
+    return false;
+  }
+
+  static CollapsedRichTextPlan _computePlan({
+    required List<RichTextBlock> blocks,
+    required TextStyle baseStyle,
+    required double maxWidth,
+    required double limit,
+    required bool showMedia,
+    required FontWeight boldWeight,
+    required TextDirection textDirection,
+    required TextScaler textScaler,
+    required Locale? locale,
   }) {
     final visible = CollapsedRichText.visibleBlocks(
       blocks,
@@ -487,6 +569,134 @@ class CollapsedRichTextMetrics {
   /// 折叠盒 160px 配最小的 `small`（10px × 1.2 ≈ 12px）也就十几行，这个值只是
   /// 防止畸形样式（比如 `size: "0.1"`）把预算算成天文数字。
   static const int _maxLinesPerBlock = 32;
+}
+
+/// [CollapsedRichTextMetrics.plan] 的 LRU 缓存。
+///
+/// 键**不持有 delta 字符串本身**，只存指纹——和 [DeltaMediaCache]、
+/// [DeltaRichTextCache] 同一套理由：带 `data:` 内嵌媒体的笔记，一个 source 就是
+/// 整段 base64。计划本身只有块引用和行数，不含像素数据，可以放心常驻。
+class CollapsedRichTextPlanCache {
+  CollapsedRichTextPlanCache._();
+
+  static final LinkedHashMap<_CollapsedRichTextPlanCacheKey,
+          CollapsedRichTextPlan> _cache =
+      LinkedHashMap<_CollapsedRichTextPlanCacheKey, CollapsedRichTextPlan>();
+
+  static const int _maxCacheSize = 300;
+  static const int _pruneBatchSize = 50;
+
+  static int _hitCount = 0;
+  static int _missCount = 0;
+  static int _workMicros = 0;
+  static int _worstWorkMicros = 0;
+
+  static CollapsedRichTextPlan? _get(_CollapsedRichTextPlanCacheKey key) {
+    final existing = _cache.remove(key);
+    if (existing == null) {
+      return null;
+    }
+    _hitCount++;
+    _cache[key] = existing;
+    return existing;
+  }
+
+  static void _put(
+    _CollapsedRichTextPlanCacheKey key,
+    CollapsedRichTextPlan plan,
+    int workMicros,
+  ) {
+    _missCount++;
+    _workMicros += workMicros;
+    if (workMicros > _worstWorkMicros) {
+      _worstWorkMicros = workMicros;
+    }
+    if (_cache.length >= _maxCacheSize) {
+      final victims = _cache.keys.take(_pruneBatchSize).toList();
+      for (final victim in victims) {
+        _cache.remove(victim);
+      }
+    }
+    _cache[key] = plan;
+  }
+
+  static void clear() {
+    _cache.clear();
+    _hitCount = 0;
+    _missCount = 0;
+    _workMicros = 0;
+    _worstWorkMicros = 0;
+  }
+
+  static Map<String, dynamic> get stats {
+    final total = _hitCount + _missCount;
+    return {
+      'cacheSize': _cache.length,
+      'maxSize': _maxCacheSize,
+      'hitCount': _hitCount,
+      'missCount': _missCount,
+      'hitRate': total == 0 ? 0.0 : _hitCount / total,
+      'workMicros': _workMicros,
+      'worstWorkMicros': _worstWorkMicros,
+    };
+  }
+}
+
+@immutable
+class _CollapsedRichTextPlanCacheKey {
+  const _CollapsedRichTextPlanCacheKey({
+    required this.fingerprint,
+    required this.boldPrioritized,
+    required this.showMedia,
+    required this.maxWidthKey,
+    required this.limitKey,
+    required this.styleHash,
+    required this.boldWeightValue,
+    required this.textDirection,
+    required this.textScalerHash,
+    required this.localeTag,
+  });
+
+  final DeltaContentFingerprint fingerprint;
+  final bool boldPrioritized;
+  final bool showMedia;
+  final int maxWidthKey;
+  final int limitKey;
+  final int styleHash;
+  final int boldWeightValue;
+  final TextDirection textDirection;
+  final int textScalerHash;
+  final String? localeTag;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is _CollapsedRichTextPlanCacheKey &&
+        other.fingerprint == fingerprint &&
+        other.boldPrioritized == boldPrioritized &&
+        other.showMedia == showMedia &&
+        other.maxWidthKey == maxWidthKey &&
+        other.limitKey == limitKey &&
+        other.styleHash == styleHash &&
+        other.boldWeightValue == boldWeightValue &&
+        other.textDirection == textDirection &&
+        other.textScalerHash == textScalerHash &&
+        other.localeTag == localeTag;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        fingerprint,
+        boldPrioritized,
+        showMedia,
+        maxWidthKey,
+        limitKey,
+        styleHash,
+        boldWeightValue,
+        textDirection,
+        textScalerHash,
+        localeTag,
+      );
 }
 
 class _CollapsedRichTextBlock extends StatelessWidget {

--- a/lib/widgets/note_list/collapsed_rich_text.dart
+++ b/lib/widgets/note_list/collapsed_rich_text.dart
@@ -428,15 +428,23 @@ class CollapsedRichTextMetrics {
     bool cacheBoldPrioritized = false,
   }) {
     _CollapsedRichTextPlanCacheKey? cacheKey;
-    if (cacheContent != null && cacheContent.isNotEmpty) {
+    // 宽度必须是有限的才建键：`double.infinity.round()` 会直接抛
+    // `UnsupportedError`，那会赶在 [_computePlan] 自己的非有限宽度兜底之前炸掉。
+    // 无界横向约束下直接走计算分支，由那条兜底返回空计划。
+    if (cacheContent != null &&
+        cacheContent.isNotEmpty &&
+        maxWidth.isFinite &&
+        limit.isFinite) {
       cacheKey = _CollapsedRichTextPlanCacheKey(
         fingerprint: DeltaContentFingerprint.of(cacheContent),
         boldPrioritized: cacheBoldPrioritized,
         showMedia: showMedia,
-        // 宽度是连续量，直接进键几乎不会命中；量化到 0.01px 之后同一次布局里
-        // 的重复调用才落在同一个桶里。
-        maxWidthKey: (maxWidth * 100).round(),
-        limitKey: (limit * 100).round(),
+        // 宽度**按原值进键，不做量化**。同一张卡片在同一次布局里拿到的约束逐位
+        // 相同，精确相等本来就命中；而量化成 0.01px 的桶会让两个相差不到 0.01px、
+        // 却恰好跨过 `TextPainter` 换行阈值的宽度共用一份计划——那是按另一个宽度
+        // 算出来的行数和盒高，内容会被多裁一行。省那点命中率不值得。
+        maxWidth: maxWidth,
+        limit: limit,
         styleHash: baseStyle.hashCode,
         boldWeightValue: boldWeight.value,
         textDirection: textDirection,
@@ -468,13 +476,15 @@ class CollapsedRichTextMetrics {
     //
     // 判据是**计划自己排到的块**，不是整篇 blocks：折叠盒只有 160px，正文长的
     // 笔记根本排不到后面那张内嵌图，那种计划不持有 base64，可以照常缓存。
-    if (cacheKey != null && !_holdsInlineDataMedia(computed)) {
+    if (cacheKey != null) {
       stopwatch!.stop();
-      CollapsedRichTextPlanCache._put(
-        cacheKey,
-        computed,
-        stopwatch.elapsedMicroseconds,
-      );
+      // miss 和耗时**先记**，再决定要不要存。跳过存储的那些计划照样是真金白银
+      // 算出来的；不记的话性能日志会漏掉它们，`planWorstUs` 恰好把最贵的一类
+      // （带内嵌媒体的）系统性地漏没。
+      CollapsedRichTextPlanCache._recordMiss(stopwatch.elapsedMicroseconds);
+      if (!_holdsInlineDataMedia(computed)) {
+        CollapsedRichTextPlanCache._put(cacheKey, computed);
+      }
     }
     return computed;
   }
@@ -601,16 +611,18 @@ class CollapsedRichTextPlanCache {
     return existing;
   }
 
-  static void _put(
-    _CollapsedRichTextPlanCacheKey key,
-    CollapsedRichTextPlan plan,
-    int workMicros,
-  ) {
+  static void _recordMiss(int workMicros) {
     _missCount++;
     _workMicros += workMicros;
     if (workMicros > _worstWorkMicros) {
       _worstWorkMicros = workMicros;
     }
+  }
+
+  static void _put(
+    _CollapsedRichTextPlanCacheKey key,
+    CollapsedRichTextPlan plan,
+  ) {
     if (_cache.length >= _maxCacheSize) {
       final victims = _cache.keys.take(_pruneBatchSize).toList();
       for (final victim in victims) {
@@ -648,8 +660,8 @@ class _CollapsedRichTextPlanCacheKey {
     required this.fingerprint,
     required this.boldPrioritized,
     required this.showMedia,
-    required this.maxWidthKey,
-    required this.limitKey,
+    required this.maxWidth,
+    required this.limit,
     required this.styleHash,
     required this.boldWeightValue,
     required this.textDirection,
@@ -660,8 +672,8 @@ class _CollapsedRichTextPlanCacheKey {
   final DeltaContentFingerprint fingerprint;
   final bool boldPrioritized;
   final bool showMedia;
-  final int maxWidthKey;
-  final int limitKey;
+  final double maxWidth;
+  final double limit;
   final int styleHash;
   final int boldWeightValue;
   final TextDirection textDirection;
@@ -675,8 +687,8 @@ class _CollapsedRichTextPlanCacheKey {
         other.fingerprint == fingerprint &&
         other.boldPrioritized == boldPrioritized &&
         other.showMedia == showMedia &&
-        other.maxWidthKey == maxWidthKey &&
-        other.limitKey == limitKey &&
+        other.maxWidth == maxWidth &&
+        other.limit == limit &&
         other.styleHash == styleHash &&
         other.boldWeightValue == boldWeightValue &&
         other.textDirection == textDirection &&
@@ -689,8 +701,8 @@ class _CollapsedRichTextPlanCacheKey {
         fingerprint,
         boldPrioritized,
         showMedia,
-        maxWidthKey,
-        limitKey,
+        maxWidth,
+        limit,
         styleHash,
         boldWeightValue,
         textDirection,

--- a/lib/widgets/note_list/collapsed_rich_text.dart
+++ b/lib/widgets/note_list/collapsed_rich_text.dart
@@ -548,10 +548,7 @@ class CollapsedRichTextMetrics {
 
       // 用本块**最矮**的一行换算行数上限：宁可多排一两行（`ClipRect` 会裁掉），
       // 也不能少排——少排的内容是静悄悄消失的，没有任何提示。
-      final maxLines = (remainingHeight <= 0
-              ? 1
-              : (remainingHeight / layout.minLineHeight).ceil() + 1)
-          .clamp(1, _maxLinesPerBlock);
+      final maxLines = _lineBudgetFor(remainingHeight, layout.minLineHeight);
 
       final painter = TextPainter(
         text: layout.span,
@@ -572,6 +569,32 @@ class CollapsedRichTextMetrics {
       height: height,
       showMedia: showMedia,
     );
+  }
+
+  /// 把「还剩多少像素」换算成「这个块最多排几行」。
+  ///
+  /// **不能直接 `(remainingHeight / minLineHeight).ceil()`**：`double` 的 `ceil()`
+  /// 对非有限值抛 `UnsupportedError`，而这里有两条路会算出非有限值——
+  /// 调用方传了非有限的 `limit`（`remainingHeight` 跟着非有限），或者畸形样式
+  /// 让 `minLineHeight` 变成 0（除出来是 infinity）。两种都会把布局炸掉，
+  /// 而不是退化成一个难看的折叠盒。
+  ///
+  /// 算不出可信预算时给 [_maxLinesPerBlock]，方向和 [CollapsedRichTextMetrics]
+  /// 其余地方一致：宁可多排（会被裁掉），不能少排（内容静悄悄消失）。
+  static int _lineBudgetFor(double remainingHeight, double minLineHeight) {
+    if (remainingHeight <= 0) {
+      return 1;
+    }
+    if (!remainingHeight.isFinite ||
+        !minLineHeight.isFinite ||
+        minLineHeight <= 0) {
+      return _maxLinesPerBlock;
+    }
+    final budget = remainingHeight / minLineHeight;
+    if (!budget.isFinite) {
+      return _maxLinesPerBlock;
+    }
+    return (budget.ceil() + 1).clamp(1, _maxLinesPerBlock);
   }
 
   /// 单个块的排版行数硬上限。

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -865,15 +865,13 @@ extension _NoteListItemsExtension on NoteListViewState {
   /// 走 [DeltaMediaCache]，不再自己 `contains`：这个方法每次条目构建要被调两次
   /// （记账一次、探针一次），全量扫描整份 delta 的话**监控本身**就会把它想测的
   /// 帧撑大，测出来的绝对值全部偏高。
+  ///
+  /// 只问一次 `of`：`hasMediaOf` 会顺手填好摘要缓存，但在这里先问 bool 再问摘要
+  /// 是白跑一趟——分类本来就要用到三个计数。
   String _noteListPerfKindFor(Quote quote) {
     final deltaContent = quote.deltaContent;
     if (deltaContent == null || quote.editSource != 'fullscreen') {
       return 'plain';
-    }
-    // 先用只存 bool 的那张表挡一道：绝大多数富文本笔记没有媒体，走到这里就结束了。
-    // `of` 对带 `data:` 内嵌媒体的笔记是不缓存的，能少问一次就少问一次。
-    if (!DeltaMediaCache.hasMediaOf(deltaContent)) {
-      return 'rich';
     }
     final media = DeltaMediaCache.of(deltaContent);
     if (media.imageCount > 0) {

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -860,18 +860,29 @@ extension _NoteListItemsExtension on NoteListViewState {
     );
   }
 
+  /// 性能日志里给条目分类用的标签。
+  ///
+  /// 走 [DeltaMediaCache]，不再自己 `contains`：这个方法每次条目构建要被调两次
+  /// （记账一次、探针一次），全量扫描整份 delta 的话**监控本身**就会把它想测的
+  /// 帧撑大，测出来的绝对值全部偏高。
   String _noteListPerfKindFor(Quote quote) {
     final deltaContent = quote.deltaContent;
     if (deltaContent == null || quote.editSource != 'fullscreen') {
       return 'plain';
     }
-    if (deltaContent.contains('"image"')) {
+    // 先用只存 bool 的那张表挡一道：绝大多数富文本笔记没有媒体，走到这里就结束了。
+    // `of` 对带 `data:` 内嵌媒体的笔记是不缓存的，能少问一次就少问一次。
+    if (!DeltaMediaCache.hasMediaOf(deltaContent)) {
+      return 'rich';
+    }
+    final media = DeltaMediaCache.of(deltaContent);
+    if (media.imageCount > 0) {
       return 'rich-image';
     }
-    if (deltaContent.contains('"video"')) {
+    if (media.videoCount > 0) {
       return 'rich-video';
     }
-    if (deltaContent.contains('"audio"')) {
+    if (media.audioCount > 0) {
       return 'rich-audio';
     }
     return 'rich';

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -71,9 +71,7 @@ extension _NoteListScrollExtension on NoteListViewState {
       final deltaContent = quote.deltaContent;
       if (deltaContent != null && quote.editSource == 'fullscreen') {
         rich++;
-        if (deltaContent.contains('"image"') ||
-            deltaContent.contains('"video"') ||
-            deltaContent.contains('"audio"')) {
+        if (DeltaMediaCache.hasMediaOf(deltaContent)) {
           media++;
         }
       }

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -14,6 +14,7 @@ import '../gen_l10n/app_localizations.dart';
 import '../models/quote_model.dart';
 import '../models/note_tag.dart';
 import '../services/database_service.dart';
+import '../utils/delta_media_extractor.dart';
 import '../utils/icon_utils.dart';
 import '../utils/jank_detector.dart';
 import '../utils/lottie_animation_manager.dart';
@@ -114,9 +115,11 @@ class NoteListView extends StatefulWidget {
       return false;
     }
 
-    if (deltaContent.contains('"image"') ||
-        deltaContent.contains('"video"') ||
-        deltaContent.contains('"audio"')) {
+    // 走缓存，**不要**退回 `deltaContent.contains('"image"')` 那一套。
+    // 这个方法在 `_shouldKeepAliveNoteListItem` 里被每次条目构建各调一次，
+    // 三次 `contains` 就是三次全量扫描整份 delta JSON，正文越长越贵；
+    // 而且口径也不对——正文里正好写了 `"image"` 这串字的笔记会被误判成有媒体。
+    if (DeltaMediaCache.hasMediaOf(deltaContent)) {
       return true;
     }
 

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -116,9 +116,9 @@ class NoteListView extends StatefulWidget {
     }
 
     // 走缓存，**不要**退回 `deltaContent.contains('"image"')` 那一套。
-    // 这个方法在 `_shouldKeepAliveNoteListItem` 里被每次条目构建各调一次，
-    // 三次 `contains` 就是三次全量扫描整份 delta JSON，正文越长越贵；
-    // 而且口径也不对——正文里正好写了 `"image"` 这串字的笔记会被误判成有媒体。
+    // 这个方法在 `_shouldKeepAliveNoteListItem` 里被每次条目构建调一次，
+    // 三次 `contains` 就是三次全量扫描整份 delta JSON，正文越长越贵，
+    // 而且每次构建都要重扫一遍——结果一次都不复用。
     if (DeltaMediaCache.hasMediaOf(deltaContent)) {
       return true;
     }

--- a/lib/widgets/quote_content_widget.dart
+++ b/lib/widgets/quote_content_widget.dart
@@ -166,6 +166,39 @@ class QuoteContent extends StatelessWidget {
   static const double _lineSpacing = 4.0;
   static const int _averageCharsPerLine = 28;
 
+  /// 纯文本折叠预览的行数硬上限，防畸形字号（`fontSize: 0.1`）把预算算成天文数字。
+  static const int _maxCollapsedPlainTextLines = 64;
+
+  /// 拿不到字号时的兜底，取 Material `bodyLarge` 的默认值。
+  static const double _fallbackFontSize = 16.0;
+
+  /// 折叠盒（[collapsedContentMaxHeight] 高）最多能显示多少行纯文本。
+  ///
+  /// **只用来给 `Text` / `TextPainter` 设 `maxLines`，所以必须偏大。** 宁可多排一
+  /// 两行——`ClipRect` 会裁掉，看不见；少排的内容却是静悄悄消失的，没有任何提示。
+  ///
+  /// 偏大由行高取**下界**来保证：`fontSize * (height ?? 1.0)`。`height` 为 null 时
+  /// 真实行高由字体的 ascent/descent 决定，普遍是字号的 1.2~1.4 倍，恒不小于这里
+  /// 算的值；于是 `ceil(limit / 下界) + 1` 行的真实高度恒 > limit。
+  ///
+  /// 存在的理由是性能：`RenderParagraph` **不看高度约束**，不设 `maxLines` 的话
+  /// 一条几千字的笔记会把整篇断行整形完，再被 `ClipRect` 裁到只剩五六行——折叠卡片
+  /// 为看不见的像素付了全文排版的钱。富文本那条路阶段 D 已经按剩余像素算好了行数
+  /// 预算（见 [CollapsedRichTextMetrics.plan]），纯文本这条一直漏着。
+  static int collapsedPlainTextMaxLines({
+    required TextStyle? style,
+    required TextScaler textScaler,
+    double limit = collapsedContentMaxHeight,
+  }) {
+    final fontSize = style?.fontSize ?? _fallbackFontSize;
+    final lineHeight = textScaler.scale(fontSize) * (style?.height ?? 1.0);
+    if (!lineHeight.isFinite || lineHeight <= 0) {
+      return _maxCollapsedPlainTextLines;
+    }
+    return ((limit / lineHeight).ceil() + 1)
+        .clamp(1, _maxCollapsedPlainTextLines);
+  }
+
   /// 折叠卡片挂缩略图所需的最小容器宽度：缩略图连间距占 84px，再给正文留
   /// 至少 96px，低于这个宽度就不画缩略图，避免 Row 溢出（见 build 中的说明）。
   static const double _minWidthForCollapsedThumbnail = 180.0;
@@ -179,6 +212,7 @@ class QuoteContent extends StatelessWidget {
     _QuoteContentControllerCache.clear();
     DeltaMediaCache.clear();
     DeltaRichTextCache.clear();
+    CollapsedRichTextPlanCache.clear();
   }
 
   /// 修复问题1：清理特定笔记的缓存（用于笔记删除/更新）
@@ -204,6 +238,9 @@ class QuoteContent extends StatelessWidget {
         // 性能日志要一行拿全就得带上它们。
         'richText': DeltaRichTextCache.stats,
         'media': DeltaMediaCache.stats,
+        // 折叠富文本真正的排版成本在这里。IR 解析（richText）便宜得多，
+        // 只盯着它会以为折叠态已经没有成本了。
+        'plan': CollapsedRichTextPlanCache.stats,
       };
 
   /// Returns a compact one-line summary suitable for copy/paste performance logs.
@@ -224,6 +261,9 @@ class QuoteContent extends StatelessWidget {
     final media = Map<String, dynamic>.from(
       stats['media'] as Map<String, dynamic>,
     );
+    final plan = Map<String, dynamic>.from(
+      stats['plan'] as Map<String, dynamic>,
+    );
 
     final buffer = StringBuffer()
       ..write('doc=${document['cacheSize']}')
@@ -239,7 +279,10 @@ class QuoteContent extends StatelessWidget {
       ..write(',irWorstUs=${richText['worstWorkMicros']}')
       ..write(',media=${media['cacheSize']}')
       ..write('/${media['maxSize']}')
-      ..write(',mediaMiss=${media['missCount']}');
+      ..write(',mediaMiss=${media['missCount']}')
+      ..write(',plan=${plan['cacheSize']}')
+      ..write('/${plan['maxSize']}')
+      ..write(',planWorstUs=${plan['worstWorkMicros']}');
 
     if (baseline != null) {
       final baselineDocument = Map<String, dynamic>.from(
@@ -250,6 +293,9 @@ class QuoteContent extends StatelessWidget {
       );
       final baselineController = Map<String, dynamic>.from(
         baseline['controller'] as Map<String, dynamic>? ?? const {},
+      );
+      final baselinePlan = Map<String, dynamic>.from(
+        baseline['plan'] as Map<String, dynamic>? ?? const {},
       );
 
       buffer
@@ -274,7 +320,13 @@ class QuoteContent extends StatelessWidget {
         ..write(',ctrlWorstUs=')
         ..write(_debugNewWorst(controller, baselineController))
         ..write(',ctrlDispose+')
-        ..write(_debugIntDelta(controller, baselineController, 'disposeCount'));
+        ..write(_debugIntDelta(controller, baselineController, 'disposeCount'))
+        ..write(',planMiss+')
+        ..write(_debugIntDelta(plan, baselinePlan, 'missCount'))
+        ..write(',planWorkUs+')
+        ..write(_debugIntDelta(plan, baselinePlan, 'workMicros'))
+        ..write(',planWorstUs=')
+        ..write(_debugNewWorst(plan, baselinePlan));
     }
 
     return buffer.toString();
@@ -465,15 +517,24 @@ class QuoteContent extends StatelessWidget {
             textDirection: textDirection,
             textScaler: textScaler,
             locale: locale,
+            // 这里的 blocks 是 DeltaRichTextCache 的原序列，没有按加粗重排。
+            cacheContent: quote.deltaContent,
           );
           return plan.height > collapsedContentMaxHeight + 0.5;
         }
 
+        // `maxLines` 不改变这个判断的答案，只砍掉多余的排版量：
+        // n 行的真实高度恒 > 160.5（见 [collapsedPlainTextMaxLines]），所以正文
+        // 超过 n 行时被夹住的 height 仍然 > 阈值，不超过 n 行时 height 就是精确值。
         final painter = TextPainter(
           text: TextSpan(text: quote.content, style: style),
           textDirection: textDirection,
           textScaler: textScaler,
           locale: locale,
+          maxLines: collapsedPlainTextMaxLines(
+            style: style,
+            textScaler: textScaler,
+          ),
         )..layout(maxWidth: maxWidth);
         final exceeds = painter.height > collapsedContentMaxHeight + 0.5;
         painter.dispose();
@@ -633,7 +694,7 @@ class QuoteContent extends StatelessWidget {
           // 文本**。旧实现在 `_documentFromDelta` 里也有这条兜底；直接画空的话，
           // 卡片正文整个消失，而且因为量出来是 0 高，连双击展开都进不去——用户会
           // 以为笔记内容丢了。
-          return _buildPlainTextContent(needsExpansion: needsExpansion);
+          return _buildPlainTextContent(context, needsExpansion: needsExpansion);
         }
         if (prioritizeBoldContent) {
           blocks = prioritizeBoldBlocks(blocks);
@@ -683,6 +744,8 @@ class QuoteContent extends StatelessWidget {
               textDirection: textDirection,
               textScaler: textScaler,
               locale: locale,
+              cacheContent: quote.deltaContent,
+              cacheBoldPrioritized: prioritizeBoldContent,
             );
             final double boxHeight =
                 plan.height.clamp(0.0, collapsedContentMaxHeight);
@@ -762,19 +825,45 @@ class QuoteContent extends StatelessWidget {
       return _buildRichTextContent(context);
     }
 
-    return _buildPlainTextContent(needsExpansion: needsExpansion);
+    return _buildPlainTextContent(context, needsExpansion: needsExpansion);
   }
 
   /// 纯文本正文。富文本的 delta 解不出来时也走这里兜底。
-  Widget _buildPlainTextContent({required bool needsExpansion}) {
+  Widget _buildPlainTextContent(
+    BuildContext context, {
+    required bool needsExpansion,
+  }) {
+    // 折叠态给 `maxLines` 封顶。盒子是 `ClipRect(SizedBox(height: 160))`，而
+    // `RenderParagraph` 不看高度约束——不封顶的话整篇正文都会被断行整形一遍，
+    // 然后裁到只剩五六行。行数取的是偏大的上界，裁出来的像素和以前逐位相同。
+    final bool clampToCollapsedBox = !showFullContent && needsExpansion;
+
+    int? collapsedMaxLines;
+    if (clampToCollapsedBox) {
+      // 行数预算必须按 `Text` **实际用的**样式算，不能按传进来的 [style] 算。
+      // `Text` 会把 [style] 往 `DefaultTextStyle` 上 merge（`inherit` 为 true 时），
+      // 字号可能整个来自环境；照着一个 fontSize 为 null 的样式去估，行高就会被
+      // 高估，行数被低估，正文尾巴静悄悄少一截。这里复刻 `Text` 自己的合并规则。
+      final TextStyle? rawStyle = style;
+      final defaultStyle = DefaultTextStyle.of(context).style;
+      final effectiveStyle = rawStyle == null || rawStyle.inherit
+          ? defaultStyle.merge(rawStyle)
+          : rawStyle;
+      collapsedMaxLines = collapsedPlainTextMaxLines(
+        style: effectiveStyle,
+        textScaler: MediaQuery.textScalerOf(context),
+      );
+    }
+
     Widget plainText = Text(
       quote.content,
       style: style,
       softWrap: true,
-      overflow: TextOverflow.visible,
+      maxLines: clampToCollapsedBox ? collapsedMaxLines : maxLines,
+      overflow: clampToCollapsedBox ? TextOverflow.clip : TextOverflow.visible,
     );
 
-    if (!showFullContent && needsExpansion) {
+    if (clampToCollapsedBox) {
       plainText = _CollapsedContentWrapper(
         key: collapsedWrapperKey,
         maxHeight: collapsedContentMaxHeight,

--- a/lib/widgets/quote_content_widget.dart
+++ b/lib/widgets/quote_content_widget.dart
@@ -166,7 +166,10 @@ class QuoteContent extends StatelessWidget {
   static const double _lineSpacing = 4.0;
   static const int _averageCharsPerLine = 28;
 
-  /// 纯文本折叠预览的行数硬上限，防畸形字号（`fontSize: 0.1`）把预算算成天文数字。
+  /// 纯文本折叠预览的行数上限。
+  ///
+  /// 折叠盒 160px 配一个正常字号也就十几行，这个值只防畸形样式（`fontSize: 0.1`）
+  /// 把预算算成天文数字。**超过它不是夹到它**——见 [collapsedPlainTextMaxLines]。
   static const int _maxCollapsedPlainTextLines = 64;
 
   /// 拿不到字号时的兜底，取 Material `bodyLarge` 的默认值。
@@ -181,11 +184,19 @@ class QuoteContent extends StatelessWidget {
   /// 真实行高由字体的 ascent/descent 决定，普遍是字号的 1.2~1.4 倍，恒不小于这里
   /// 算的值；于是 `ceil(limit / 下界) + 1` 行的真实高度恒 > limit。
   ///
+  /// 返回 null 表示**不要设 `maxLines`**。算不出可信预算时只能退回「整篇都排」：
+  /// 那只是慢，而夹一个盖不住盒子的行数会真的截断正文。两种情况会退回 null：
+  ///
+  /// - 行高非有限或 ≤ 0（畸形样式）；
+  /// - 预算超过 [_maxCollapsedPlainTextLines]。字号和行高同时极小时，
+  ///   **夹到上限的那 64 行仍然填不满 160px 的盒子**，照样会截断——所以上限是
+  ///   「超过就放弃截断」，不是「超过就取上限」。
+  ///
   /// 存在的理由是性能：`RenderParagraph` **不看高度约束**，不设 `maxLines` 的话
   /// 一条几千字的笔记会把整篇断行整形完，再被 `ClipRect` 裁到只剩五六行——折叠卡片
   /// 为看不见的像素付了全文排版的钱。富文本那条路阶段 D 已经按剩余像素算好了行数
   /// 预算（见 [CollapsedRichTextMetrics.plan]），纯文本这条一直漏着。
-  static int collapsedPlainTextMaxLines({
+  static int? collapsedPlainTextMaxLines({
     required TextStyle? style,
     required TextScaler textScaler,
     double limit = collapsedContentMaxHeight,
@@ -193,10 +204,13 @@ class QuoteContent extends StatelessWidget {
     final fontSize = style?.fontSize ?? _fallbackFontSize;
     final lineHeight = textScaler.scale(fontSize) * (style?.height ?? 1.0);
     if (!lineHeight.isFinite || lineHeight <= 0) {
-      return _maxCollapsedPlainTextLines;
+      return null;
     }
-    return ((limit / lineHeight).ceil() + 1)
-        .clamp(1, _maxCollapsedPlainTextLines);
+    final budget = (limit / lineHeight).ceil() + 1;
+    if (budget > _maxCollapsedPlainTextLines) {
+      return null;
+    }
+    return budget < 1 ? 1 : budget;
   }
 
   /// 折叠卡片挂缩略图所需的最小容器宽度：缩略图连间距占 84px，再给正文留
@@ -694,7 +708,8 @@ class QuoteContent extends StatelessWidget {
           // 文本**。旧实现在 `_documentFromDelta` 里也有这条兜底；直接画空的话，
           // 卡片正文整个消失，而且因为量出来是 0 高，连双击展开都进不去——用户会
           // 以为笔记内容丢了。
-          return _buildPlainTextContent(context, needsExpansion: needsExpansion);
+          return _buildPlainTextContent(context,
+              needsExpansion: needsExpansion);
         }
         if (prioritizeBoldContent) {
           blocks = prioritizeBoldBlocks(blocks);

--- a/test/unit/utils/delta_media_extractor_test.dart
+++ b/test/unit/utils/delta_media_extractor_test.dart
@@ -287,71 +287,98 @@ void main() {
   group('DeltaMediaCache.hasMediaOf', () {
     setUp(DeltaMediaCache.clear);
 
-    test('三种媒体都认，纯文本不认', () {
-      String wrap(Object embed) => jsonEncode([
-            {'insert': embed},
-            {'insert': '\n'},
-          ]);
+    String wrap(Object embed) => jsonEncode([
+          {'insert': embed},
+          {'insert': '\n'},
+        ]);
 
+    test('认图片', () {
       expect(DeltaMediaCache.hasMediaOf(wrap({'image': 'a.png'})), isTrue);
+    });
+
+    test('认视频', () {
       expect(DeltaMediaCache.hasMediaOf(wrap({'video': 'a.mp4'})), isTrue);
-      expect(
-        DeltaMediaCache.hasMediaOf(
-          wrap({
-            'custom': jsonEncode({'audio': 'a.m4a'}),
-          }),
-        ),
-        isTrue,
-      );
-      expect(
-        DeltaMediaCache.hasMediaOf(
-          jsonEncode([
-            {'insert': '只有文字\n'},
-          ]),
-        ),
-        isFalse,
-      );
     });
 
-    test('正文里出现 "image" 这串字不算有媒体', () {
-      // 旧的 `deltaContent.contains('"image"')` 会在这里误判成有媒体，
-      // 于是这条笔记被永久 keepAlive，白白钉在树上每次 setState 重建一遍。
-      final delta = jsonEncode([
-        {'insert': '讨论一下 {"image": ...} 这个字段该怎么存\n'},
-      ]);
-      expect(delta.contains('"image"'), isTrue);
-      expect(DeltaMediaCache.hasMediaOf(delta), isFalse);
-    });
-
-    test('null / 空串安全', () {
-      expect(DeltaMediaCache.hasMediaOf(null), isFalse);
-      expect(DeltaMediaCache.hasMediaOf(''), isFalse);
-    });
-
-    test('答案与 parseDeltaMedia 一致，且第二次走缓存', () {
-      final delta = jsonEncode([
-        {
-          'insert': {'image': 'a.png'},
-        },
-        {'insert': '\n'},
-      ]);
-      expect(DeltaMediaCache.hasMediaOf(delta), parseDeltaMedia(delta).hasMedia);
+    test('认 custom 里的音频（本项目音频的真实形状）', () {
+      final delta = wrap({
+        'custom': jsonEncode({'audio': 'a.m4a'}),
+      });
       expect(DeltaMediaCache.hasMediaOf(delta), isTrue);
     });
 
-    test('data: 内嵌媒体也缓存布尔结果（摘要缓存跳过它们）', () {
+    test('纯文字不算有媒体', () {
+      final delta = jsonEncode([
+        {'insert': '只有文字\n'},
+      ]);
+      expect(DeltaMediaCache.hasMediaOf(delta), isFalse);
+    });
+
+    test('null 安全', () {
+      expect(DeltaMediaCache.hasMediaOf(null), isFalse);
+    });
+
+    test('空串安全', () {
+      expect(DeltaMediaCache.hasMediaOf(''), isFalse);
+    });
+
+    test('口径由解析决定，不由子串决定', () {
+      // 判定从三次 `deltaContent.contains(...)` 换成了 `readDeltaMediaEmbed`
+      // 那一份唯一真源。这里钉住「子串出现 ≠ 有媒体」：`image` 只是某个 op 的
+      // 属性名时，子串扫描会当成有媒体，解析不会。
+      //
+      // （用户在正文里打出 `"image"` **不会**触发这种分歧：jsonEncode 会把正文
+      // 里的引号转义成 `\"image\"`，子串扫描本来就匹配不上。）
       final delta = jsonEncode([
         {
-          'insert': {'image': 'data:image/png;base64,AAAA'},
+          'insert': '一段文字\n',
+          'attributes': {'image': 'not-an-embed'},
         },
-        {'insert': '\n'},
       ]);
+      expect(delta.contains('"image"'), isTrue);
+      expect(DeltaMediaCache.hasMediaOf(delta), isFalse);
+      expect(
+          DeltaMediaCache.hasMediaOf(delta), parseDeltaMedia(delta).hasMedia);
+    });
+
+    test('答案与 parseDeltaMedia 一致', () {
+      final delta = wrap({'image': 'a.png'});
+      expect(
+          DeltaMediaCache.hasMediaOf(delta), parseDeltaMedia(delta).hasMedia);
+    });
+
+    test('第二次走缓存，不再解析', () {
+      final delta = wrap({'image': 'a.png'});
+      DeltaMediaCache.hasMediaOf(delta);
+      final missesAfterFirst = DeltaMediaCache.stats['missCount'];
+
+      DeltaMediaCache.hasMediaOf(delta);
+      expect(DeltaMediaCache.stats['missCount'], missesAfterFirst);
+    });
+
+    test('顺手填好摘要缓存，紧接着的 of 不会再解析一遍', () {
+      final delta = wrap({'image': 'a.png'});
+      DeltaMediaCache.hasMediaOf(delta);
+      final missesAfterBool = DeltaMediaCache.stats['missCount'];
+
+      expect(DeltaMediaCache.of(delta).firstImageSource, 'a.png');
+      expect(DeltaMediaCache.stats['missCount'], missesAfterBool);
+    });
+
+    test('data: 内嵌媒体也缓存布尔结果（摘要缓存跳过它们）', () {
+      final delta = wrap({'image': 'data:image/png;base64,AAAA'});
 
       expect(DeltaMediaCache.hasMediaOf(delta), isTrue);
       // 摘要缓存故意不收 data: 笔记，布尔缓存必须自己扛住，
       // 否则 keepAlive 判定每次条目构建都要重解一遍整段 base64。
       expect(DeltaMediaCache.stats['cacheSize'], 0);
+      expect(DeltaMediaCache.stats['hasMediaCacheSize'], 1);
+
+      // 第二次不能再解析：`missCount` 只在真的解析时才涨，所以它不涨就证明
+      // 布尔缓存生效了。只断言返回值仍是 true 是抓不住回归的——去掉缓存也成立。
+      final missesAfterFirst = DeltaMediaCache.stats['missCount'];
       expect(DeltaMediaCache.hasMediaOf(delta), isTrue);
+      expect(DeltaMediaCache.stats['missCount'], missesAfterFirst);
     });
   });
 }

--- a/test/unit/utils/delta_media_extractor_test.dart
+++ b/test/unit/utils/delta_media_extractor_test.dart
@@ -283,4 +283,75 @@ void main() {
       expect(DeltaMediaCache.of(b).firstImageSource, 'bbb.png');
     });
   });
+
+  group('DeltaMediaCache.hasMediaOf', () {
+    setUp(DeltaMediaCache.clear);
+
+    test('三种媒体都认，纯文本不认', () {
+      String wrap(Object embed) => jsonEncode([
+            {'insert': embed},
+            {'insert': '\n'},
+          ]);
+
+      expect(DeltaMediaCache.hasMediaOf(wrap({'image': 'a.png'})), isTrue);
+      expect(DeltaMediaCache.hasMediaOf(wrap({'video': 'a.mp4'})), isTrue);
+      expect(
+        DeltaMediaCache.hasMediaOf(
+          wrap({
+            'custom': jsonEncode({'audio': 'a.m4a'}),
+          }),
+        ),
+        isTrue,
+      );
+      expect(
+        DeltaMediaCache.hasMediaOf(
+          jsonEncode([
+            {'insert': '只有文字\n'},
+          ]),
+        ),
+        isFalse,
+      );
+    });
+
+    test('正文里出现 "image" 这串字不算有媒体', () {
+      // 旧的 `deltaContent.contains('"image"')` 会在这里误判成有媒体，
+      // 于是这条笔记被永久 keepAlive，白白钉在树上每次 setState 重建一遍。
+      final delta = jsonEncode([
+        {'insert': '讨论一下 {"image": ...} 这个字段该怎么存\n'},
+      ]);
+      expect(delta.contains('"image"'), isTrue);
+      expect(DeltaMediaCache.hasMediaOf(delta), isFalse);
+    });
+
+    test('null / 空串安全', () {
+      expect(DeltaMediaCache.hasMediaOf(null), isFalse);
+      expect(DeltaMediaCache.hasMediaOf(''), isFalse);
+    });
+
+    test('答案与 parseDeltaMedia 一致，且第二次走缓存', () {
+      final delta = jsonEncode([
+        {
+          'insert': {'image': 'a.png'},
+        },
+        {'insert': '\n'},
+      ]);
+      expect(DeltaMediaCache.hasMediaOf(delta), parseDeltaMedia(delta).hasMedia);
+      expect(DeltaMediaCache.hasMediaOf(delta), isTrue);
+    });
+
+    test('data: 内嵌媒体也缓存布尔结果（摘要缓存跳过它们）', () {
+      final delta = jsonEncode([
+        {
+          'insert': {'image': 'data:image/png;base64,AAAA'},
+        },
+        {'insert': '\n'},
+      ]);
+
+      expect(DeltaMediaCache.hasMediaOf(delta), isTrue);
+      // 摘要缓存故意不收 data: 笔记，布尔缓存必须自己扛住，
+      // 否则 keepAlive 判定每次条目构建都要重解一遍整段 base64。
+      expect(DeltaMediaCache.stats['cacheSize'], 0);
+      expect(DeltaMediaCache.hasMediaOf(delta), isTrue);
+    });
+  });
 }

--- a/test/unit/utils/delta_media_extractor_test.dart
+++ b/test/unit/utils/delta_media_extractor_test.dart
@@ -356,6 +356,17 @@ void main() {
       expect(DeltaMediaCache.stats['missCount'], missesAfterFirst);
     });
 
+    test('摘要缓存已经热了的话，hasMediaOf 不会重新解析', () {
+      // 列表里 of 和 hasMediaOf 都会被每次条目构建调到，谁先谁后不定。
+      // 只保证一个方向的话，后手那个必然把同一份 delta 再解析一遍。
+      final delta = wrap({'image': 'a.png'});
+      DeltaMediaCache.of(delta);
+      final missesAfterSummary = DeltaMediaCache.stats['missCount'];
+
+      expect(DeltaMediaCache.hasMediaOf(delta), isTrue);
+      expect(DeltaMediaCache.stats['missCount'], missesAfterSummary);
+    });
+
     test('顺手填好摘要缓存，紧接着的 of 不会再解析一遍', () {
       final delta = wrap({'image': 'a.png'});
       DeltaMediaCache.hasMediaOf(delta);

--- a/test/unit/widgets/collapsed_plain_text_budget_test.dart
+++ b/test/unit/widgets/collapsed_plain_text_budget_test.dart
@@ -31,8 +31,10 @@ void main() {
       style: style,
       textScaler: textScaler,
     );
-    final lineHeight = realLineHeight(style, textScaler);
+    // null 表示放弃截断（整篇都排），永远不会少排内容。
+    if (maxLines == null) return;
 
+    final lineHeight = realLineHeight(style, textScaler);
     expect(
       maxLines * lineHeight,
       greaterThanOrEqualTo(boxHeight),
@@ -72,25 +74,51 @@ void main() {
         textScaler: TextScaler.noScaling,
       );
       // 兜底字号 16、行高按 1.0 估，真实行高只会更大，所以 11 行足够盖住 160px。
-      expect(maxLines * 16.0, greaterThanOrEqualTo(boxHeight));
+      expect(maxLines, isNotNull);
+      expect(maxLines! * 16.0, greaterThanOrEqualTo(boxHeight));
     });
+  });
 
-    test('畸形字号不会把行数算成天文数字', () {
-      final maxLines = QuoteContent.collapsedPlainTextMaxLines(
-        style: const TextStyle(fontSize: 0.01, height: 0.01),
-        textScaler: TextScaler.noScaling,
+  group('算不出可信预算时放弃截断，而不是夹一个盖不住盒子的行数', () {
+    test('字号和行高同时极小 → 不设 maxLines', () {
+      // 预算会超过 64 行的硬上限。夹到 64 的话，64 × 0.0001px 远远盖不住 160px，
+      // 正文会被真的截断——放弃截断只是慢，截断是丢内容。
+      expect(
+        QuoteContent.collapsedPlainTextMaxLines(
+          style: const TextStyle(fontSize: 0.01, height: 0.01),
+          textScaler: TextScaler.noScaling,
+        ),
+        isNull,
       );
-      expect(maxLines, lessThanOrEqualTo(64));
-      expect(maxLines, greaterThan(0));
     });
 
-    test('字号为 0 / 非法时退到硬上限而不是 0 行', () {
+    test('字号为 0 → 不设 maxLines', () {
       expect(
         QuoteContent.collapsedPlainTextMaxLines(
           style: const TextStyle(fontSize: 0),
           textScaler: TextScaler.noScaling,
         ),
-        64,
+        isNull,
+      );
+    });
+
+    test('行高非有限 → 不设 maxLines', () {
+      expect(
+        QuoteContent.collapsedPlainTextMaxLines(
+          style: const TextStyle(fontSize: 16, height: double.infinity),
+          textScaler: TextScaler.noScaling,
+        ),
+        isNull,
+      );
+    });
+
+    test('正常样式仍然给出预算，没有被兜底吞掉', () {
+      expect(
+        QuoteContent.collapsedPlainTextMaxLines(
+          style: const TextStyle(fontSize: 16, height: 1.5),
+          textScaler: TextScaler.noScaling,
+        ),
+        isNotNull,
       );
     });
   });
@@ -102,6 +130,7 @@ void main() {
         style: style,
         textScaler: TextScaler.noScaling,
       );
+      expect(maxLines, isNotNull);
 
       // 这是整个改动的目的：`RenderParagraph` 不看高度约束，不封顶的话
       // 一条几千字的笔记会把整篇断行整形完，再被 ClipRect 裁到只剩五六行。

--- a/test/unit/widgets/collapsed_plain_text_budget_test.dart
+++ b/test/unit/widgets/collapsed_plain_text_budget_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/widgets/quote_content_widget.dart';
+
+/// 折叠态的纯文本正文带 `maxLines`，行数由
+/// [QuoteContent.collapsedPlainTextMaxLines] 算。它的唯一硬性要求是**只能偏大**：
+///
+/// - 偏大 → 多排的行落在 160px 折叠盒外面，`ClipRect` 裁掉，用户看不见；
+/// - 偏小 → 正文尾巴静悄悄少一截，没有任何提示，而且和「双击展开」的判定对不上。
+///
+/// 所以这里不断言具体行数（那会随字体和主题漂），只断言
+/// `maxLines × 真实行高 ≥ 折叠盒高度`——用真的 `TextPainter` 量出来的真实行高。
+void main() {
+  const double boxHeight = QuoteContent.collapsedContentMaxHeight;
+
+  /// 用 `TextPainter` 量出这套样式下一行到底多高。
+  double realLineHeight(TextStyle style, TextScaler textScaler) {
+    final painter = TextPainter(
+      text: TextSpan(text: '单行', style: style),
+      textDirection: TextDirection.ltr,
+      textScaler: textScaler,
+      maxLines: 1,
+    )..layout(maxWidth: 1000);
+    final height = painter.height;
+    painter.dispose();
+    return height;
+  }
+
+  void expectCoversBox(TextStyle style, TextScaler textScaler) {
+    final maxLines = QuoteContent.collapsedPlainTextMaxLines(
+      style: style,
+      textScaler: textScaler,
+    );
+    final lineHeight = realLineHeight(style, textScaler);
+
+    expect(
+      maxLines * lineHeight,
+      greaterThanOrEqualTo(boxHeight),
+      reason: 'maxLines=$maxLines × 行高=$lineHeight 必须盖满 ${boxHeight}px 的折叠盒，'
+          '否则折叠预览会少排内容',
+    );
+  }
+
+  group('collapsedPlainTextMaxLines 恒偏大', () {
+    test('显式行高', () {
+      for (final height in [1.0, 1.2, 1.5, 1.8, 2.4]) {
+        expectCoversBox(
+          TextStyle(fontSize: 16, height: height),
+          TextScaler.noScaling,
+        );
+      }
+    });
+
+    test('行高交给字体（height 为 null）', () {
+      for (final fontSize in [10.0, 12.0, 14.0, 16.0, 20.0, 28.0]) {
+        expectCoversBox(TextStyle(fontSize: fontSize), TextScaler.noScaling);
+      }
+    });
+
+    test('跟随系统字号缩放', () {
+      for (final scale in [0.8, 1.0, 1.3, 2.0, 3.0]) {
+        expectCoversBox(
+          const TextStyle(fontSize: 16, height: 1.5),
+          TextScaler.linear(scale),
+        );
+      }
+    });
+
+    test('样式为 null 时也不能少排', () {
+      final maxLines = QuoteContent.collapsedPlainTextMaxLines(
+        style: null,
+        textScaler: TextScaler.noScaling,
+      );
+      // 兜底字号 16、行高按 1.0 估，真实行高只会更大，所以 11 行足够盖住 160px。
+      expect(maxLines * 16.0, greaterThanOrEqualTo(boxHeight));
+    });
+
+    test('畸形字号不会把行数算成天文数字', () {
+      final maxLines = QuoteContent.collapsedPlainTextMaxLines(
+        style: const TextStyle(fontSize: 0.01, height: 0.01),
+        textScaler: TextScaler.noScaling,
+      );
+      expect(maxLines, lessThanOrEqualTo(64));
+      expect(maxLines, greaterThan(0));
+    });
+
+    test('字号为 0 / 非法时退到硬上限而不是 0 行', () {
+      expect(
+        QuoteContent.collapsedPlainTextMaxLines(
+          style: const TextStyle(fontSize: 0),
+          textScaler: TextScaler.noScaling,
+        ),
+        64,
+      );
+    });
+  });
+
+  group('工作量确实有上界', () {
+    test('正文再长，行数预算也不跟着涨', () {
+      const style = TextStyle(fontSize: 16, height: 1.5);
+      final maxLines = QuoteContent.collapsedPlainTextMaxLines(
+        style: style,
+        textScaler: TextScaler.noScaling,
+      );
+
+      // 这是整个改动的目的：`RenderParagraph` 不看高度约束，不封顶的话
+      // 一条几千字的笔记会把整篇断行整形完，再被 ClipRect 裁到只剩五六行。
+      final painter = TextPainter(
+        text: TextSpan(text: '很长的正文内容。' * 2000, style: style),
+        textDirection: TextDirection.ltr,
+        maxLines: maxLines,
+      )..layout(maxWidth: 320);
+
+      expect(painter.didExceedMaxLines, isTrue);
+      expect(painter.computeLineMetrics(), hasLength(maxLines));
+      // 排出来的高度盖得住折叠盒，裁剪之后的像素和不封顶时一模一样。
+      expect(painter.height, greaterThanOrEqualTo(boxHeight));
+      painter.dispose();
+    });
+  });
+}

--- a/test/unit/widgets/collapsed_rich_text_plan_cache_test.dart
+++ b/test/unit/widgets/collapsed_rich_text_plan_cache_test.dart
@@ -181,6 +181,73 @@ void main() {
     });
   });
 
+  group('畸形输入不能把布局炸掉', () {
+    // `double.ceil()` 对非有限值抛 UnsupportedError，所以这些路径一旦漏掉
+    // 就不是「折叠盒难看」，是整个列表崩。
+    test('无界横向约束：不建缓存键，也不抛异常', () {
+      final delta = longDelta();
+      final plan = CollapsedRichTextMetrics.plan(
+        blocks: DeltaRichTextCache.of(delta),
+        baseStyle: baseStyle,
+        maxWidth: double.infinity,
+        limit: 160,
+        showMedia: false,
+        cacheContent: delta,
+      );
+
+      expect(plan.isEmpty, isTrue);
+      // 非有限宽度不该进缓存：键里放 infinity 只是把崩溃点往后挪。
+      expect(CollapsedRichTextPlanCache.stats['cacheSize'], 0);
+    });
+
+    test('非有限 limit 不抛异常', () {
+      final delta = longDelta();
+      expect(
+        () => CollapsedRichTextMetrics.plan(
+          blocks: DeltaRichTextCache.of(delta),
+          baseStyle: baseStyle,
+          maxWidth: width,
+          limit: double.infinity,
+          showMedia: false,
+          cacheContent: delta,
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('NaN limit 不抛异常', () {
+      final delta = longDelta();
+      expect(
+        () => CollapsedRichTextMetrics.plan(
+          blocks: DeltaRichTextCache.of(delta),
+          baseStyle: baseStyle,
+          maxWidth: width,
+          limit: double.nan,
+          showMedia: false,
+          cacheContent: delta,
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('行高为 0 的畸形样式不抛异常', () {
+      // minLineHeight 为 0 时 remainingHeight / minLineHeight 是 infinity，
+      // 和非有限 limit 同一个崩法。
+      final delta = longDelta();
+      expect(
+        () => CollapsedRichTextMetrics.plan(
+          blocks: DeltaRichTextCache.of(delta),
+          baseStyle: const TextStyle(fontSize: 0, height: 0),
+          maxWidth: width,
+          limit: 160,
+          showMedia: false,
+          cacheContent: delta,
+        ),
+        returnsNormally,
+      );
+    });
+  });
+
   test('clear 把计数一起清掉', () {
     planFor(longDelta());
     expect(CollapsedRichTextPlanCache.stats['cacheSize'], 1);

--- a/test/unit/widgets/collapsed_rich_text_plan_cache_test.dart
+++ b/test/unit/widgets/collapsed_rich_text_plan_cache_test.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/delta_rich_text_parser.dart';
+import 'package:thoughtecho/widgets/note_list/collapsed_rich_text.dart';
+
+/// `CollapsedRichTextMetrics.plan` 的结果缓存。
+///
+/// 它是在 `LayoutBuilder` 里被调用的：卡片每重建一次，每个可见块就要重新
+/// `TextPainter.layout` 一遍。而记录页里有几十张卡片是永久 keepAlive 的，
+/// 一次 `setState` 就是几十次全量重量——这是 08-13 日志里 117.8ms / 123.9ms
+/// 建帧的主要来源之一。
+///
+/// 缓存的正确性只有两条：**相同输入必须给出相同计划**（否则测量和渲染会漂开，
+/// 折叠盒高度和实际画出来的内容对不上），**任何进键的参数变了都必须重新算**。
+void main() {
+  const TextStyle baseStyle = TextStyle(fontSize: 16, height: 1.5);
+  const double width = 320;
+
+  setUp(() {
+    CollapsedRichTextPlanCache.clear();
+    DeltaRichTextCache.clear();
+  });
+
+  String longDelta() => jsonEncode([
+        {'insert': '${'折叠盒只有 160px，正文可以很长。' * 40}\n'},
+      ]);
+
+  CollapsedRichTextPlan planFor(
+    String delta, {
+    double maxWidth = width,
+    bool showMedia = false,
+    bool boldPrioritized = false,
+    TextStyle style = baseStyle,
+    String? cacheContent,
+  }) {
+    return CollapsedRichTextMetrics.plan(
+      blocks: DeltaRichTextCache.of(delta),
+      baseStyle: style,
+      maxWidth: maxWidth,
+      limit: 160,
+      showMedia: showMedia,
+      cacheContent: cacheContent ?? delta,
+      cacheBoldPrioritized: boldPrioritized,
+    );
+  }
+
+  group('命中', () {
+    test('同样的输入第二次命中，且计划逐字段相同', () {
+      final delta = longDelta();
+
+      final first = planFor(delta);
+      expect(CollapsedRichTextPlanCache.stats['missCount'], 1);
+      expect(CollapsedRichTextPlanCache.stats['hitCount'], 0);
+
+      final second = planFor(delta);
+      expect(CollapsedRichTextPlanCache.stats['hitCount'], 1);
+      expect(CollapsedRichTextPlanCache.stats['missCount'], 1);
+
+      expect(identical(first, second), isTrue);
+      expect(second.height, first.height);
+      expect(second.entries.length, first.entries.length);
+      expect(second.showMedia, first.showMedia);
+    });
+
+    test('缓存的计划和不带缓存算出来的一致', () {
+      final delta = longDelta();
+
+      final cached = planFor(delta);
+      final uncached = CollapsedRichTextMetrics.plan(
+        blocks: DeltaRichTextCache.of(delta),
+        baseStyle: baseStyle,
+        maxWidth: width,
+        limit: 160,
+        showMedia: false,
+      );
+
+      expect(cached.height, uncached.height);
+      expect(cached.entries.length, uncached.entries.length);
+      for (var i = 0; i < cached.entries.length; i++) {
+        expect(cached.entries[i].maxLines, uncached.entries[i].maxLines);
+      }
+    });
+
+    test('不传 cacheContent 就完全不走缓存', () {
+      final delta = longDelta();
+      CollapsedRichTextMetrics.plan(
+        blocks: DeltaRichTextCache.of(delta),
+        baseStyle: baseStyle,
+        maxWidth: width,
+        limit: 160,
+        showMedia: false,
+      );
+      expect(CollapsedRichTextPlanCache.stats['cacheSize'], 0);
+      expect(CollapsedRichTextPlanCache.stats['missCount'], 0);
+    });
+  });
+
+  group('进键的参数变了就必须重算', () {
+    test('宽度', () {
+      final delta = longDelta();
+      planFor(delta);
+      planFor(delta, maxWidth: width - 84); // 挂了缩略图之后的正文宽度
+      expect(CollapsedRichTextPlanCache.stats['missCount'], 2);
+    });
+
+    test('showMedia', () {
+      final delta = jsonEncode([
+        {'insert': '带图的笔记\n'},
+        {
+          'insert': {'image': 'a.png'},
+        },
+        {'insert': '\n'},
+      ]);
+      planFor(delta, showMedia: false);
+      planFor(delta, showMedia: true);
+      expect(CollapsedRichTextPlanCache.stats['missCount'], 2);
+    });
+
+    test('加粗优先（blocks 被重排过）', () {
+      final delta = longDelta();
+      planFor(delta, boldPrioritized: false);
+      planFor(delta, boldPrioritized: true);
+      expect(CollapsedRichTextPlanCache.stats['missCount'], 2);
+    });
+
+    test('基准样式（换主题 / 换字号）', () {
+      final delta = longDelta();
+      planFor(delta);
+      planFor(delta, style: const TextStyle(fontSize: 20, height: 1.5));
+      expect(CollapsedRichTextPlanCache.stats['missCount'], 2);
+    });
+
+    test('不同笔记不会串味', () {
+      final short = jsonEncode([
+        {'insert': '短\n'},
+      ]);
+      final long = longDelta();
+
+      final shortPlan = planFor(short);
+      final longPlan = planFor(long);
+
+      expect(longPlan.height, greaterThan(shortPlan.height));
+      expect(CollapsedRichTextPlanCache.stats['missCount'], 2);
+    });
+  });
+
+  group('不把 base64 钉在堆上', () {
+    test('计划排到了 data: 内嵌媒体就不进缓存', () {
+      // DeltaMediaCache / DeltaRichTextCache 跳过这类笔记是同一个理由：
+      // 那个 source 就是整段 base64，缓存住等于常驻若干 MB。
+      final delta = jsonEncode([
+        {
+          'insert': {'image': 'data:image/png;base64,AAAABBBBCCCC'},
+        },
+        {'insert': '\n'},
+      ]);
+
+      planFor(delta, showMedia: true);
+      planFor(delta, showMedia: true);
+
+      expect(CollapsedRichTextPlanCache.stats['cacheSize'], 0);
+    });
+
+    test('正文长到排不着那张 data: 图时照常缓存', () {
+      // 折叠盒只有 160px，前面的正文就把预算吃光了，计划里根本没有那个媒体块，
+      // 也就不持有 base64——这种照常缓存，否则长笔记白白失去缓存。
+      final delta = jsonEncode([
+        {'insert': '${'折叠盒只有 160px，正文可以很长。' * 40}\n'},
+        {
+          'insert': {'image': 'data:image/png;base64,AAAABBBBCCCC'},
+        },
+        {'insert': '\n'},
+      ]);
+
+      final plan = planFor(delta, showMedia: true);
+
+      expect(plan.entries.any((e) => e.block.isMedia), isFalse);
+      expect(CollapsedRichTextPlanCache.stats['cacheSize'], 1);
+    });
+  });
+
+  test('clear 把计数一起清掉', () {
+    planFor(longDelta());
+    expect(CollapsedRichTextPlanCache.stats['cacheSize'], 1);
+
+    CollapsedRichTextPlanCache.clear();
+    expect(CollapsedRichTextPlanCache.stats['cacheSize'], 0);
+    expect(CollapsedRichTextPlanCache.stats['missCount'], 0);
+    expect(CollapsedRichTextPlanCache.stats['hitCount'], 0);
+  });
+}

--- a/test/unit/widgets/note_list_keep_alive_test.dart
+++ b/test/unit/widgets/note_list_keep_alive_test.dart
@@ -76,5 +76,24 @@ void main() {
 
       expect(NoteListView.shouldKeepAliveQuoteItem(quote), isTrue);
     });
+
+    test('正文里写了 "image" 这串字的短笔记不保活', () {
+      // 判定改走 DeltaMediaCache 之前，这里是 `deltaContent.contains('"image"')`，
+      // 于是一条只是在讨论 JSON 字段名的短笔记会被误判成「有媒体」而永久保活——
+      // 白白钉在 element 树上，每次 setState 陪着重建一遍。
+      final delta = jsonEncode([
+        {'insert': '这个 {"image": "..."} 字段该怎么存\n'},
+      ]);
+      expect(delta.contains('"image"'), isTrue);
+
+      final quote = _quote(
+        id: 'talks-about-image',
+        content: '这个 {"image": "..."} 字段该怎么存',
+        deltaContent: delta,
+        editSource: 'fullscreen',
+      );
+
+      expect(NoteListView.shouldKeepAliveQuoteItem(quote), isFalse);
+    });
   });
 }

--- a/test/unit/widgets/note_list_keep_alive_test.dart
+++ b/test/unit/widgets/note_list_keep_alive_test.dart
@@ -77,18 +77,21 @@ void main() {
       expect(NoteListView.shouldKeepAliveQuoteItem(quote), isTrue);
     });
 
-    test('正文里写了 "image" 这串字的短笔记不保活', () {
-      // 判定改走 DeltaMediaCache 之前，这里是 `deltaContent.contains('"image"')`，
-      // 于是一条只是在讨论 JSON 字段名的短笔记会被误判成「有媒体」而永久保活——
-      // 白白钉在 element 树上，每次 setState 陪着重建一遍。
+    test('保活口径由媒体解析决定，不由子串扫描决定', () {
+      // 判定原本是三次 `deltaContent.contains(...)`，现在走 DeltaMediaCache。
+      // 这里钉住「子串出现 ≠ 有媒体」：`image` 只是某个 op 的属性名时，
+      // 子串扫描会当成有媒体而永久保活，解析不会。
       final delta = jsonEncode([
-        {'insert': '这个 {"image": "..."} 字段该怎么存\n'},
+        {
+          'insert': '短笔记\n',
+          'attributes': {'image': 'not-an-embed'},
+        },
       ]);
       expect(delta.contains('"image"'), isTrue);
 
       final quote = _quote(
-        id: 'talks-about-image',
-        content: '这个 {"image": "..."} 字段该怎么存',
+        id: 'image-attribute-only',
+        content: '短笔记',
         deltaContent: delta,
         editSource: 'fullscreen',
       );


### PR DESCRIPTION
> ⚠️ **本页任何自动生成的摘要（cubic / CodeRabbit 的正文追加段与评论）里，「修复正文含 "image" 被误判为媒体」是一处已被撤回的说法。** 那是我最初写错、后来自己证伪的结论，机器人抄的是旧版描述。正确说法见下面第 3 节。

## 为什么

阶段 D（#469）把折叠卡片的 Quill 拿掉之后仍然卡。用 08-13 那轮 **release** 的 `NoteListView.Perf` 日志把 14 个 scroll session 按「这段滑动里有没有新卡片被建出来」分两堆，分界线干净得不像话：

| session | 场景 | frameJank | avgFrame | worstBuild | built |
|---|---|---|---|---|---|
| scroll-10 / 13 / 11 | 往回滑，全是老卡片 | **0** | **3.1–3.8ms** | 1.9–7.9ms | **0** |
| scroll-8 / 5 | 下滑，16–23 张新卡 | 4–6 | 6.8–7.4ms | 21–29ms | 16–23 |
| scroll-3 | 下滑 + loadMore | **11** | 9.7ms | 21ms | **104** |
| scroll-4 | 几乎没动 + 分页落地 | **10** | **18.5ms** | **117.8ms** | 30 |
| scroll-14 | 往回滑 + loadMore | 4 | 5.0ms | **123.9ms** | **297** |

`built=0` 的 session 一帧都不掉。**阶段 D 优化的是稳态成本，而稳态从来就不是卡顿来源**——掉帧全部集中在「第一次构建/布局」和「整列表重建」两类帧上。均值确实降了（`avgBuild` 15.6ms → 1.2~6.1ms），但用户感知的是那两个 117.8ms / 123.9ms 的建帧。

完整诊断见 `docs/note-list-perf-analysis-2026-08-13.md`。本 PR 修掉其中**不改视觉、不改用户可见行为**的三条。

## 改了什么

### 1. 纯文本折叠正文的排版量封顶

折叠盒是 `ClipRect(SizedBox(height: 160))`，而 `RenderParagraph` **不看高度约束**——一条几千字的笔记会把整篇断行整形完，再被裁到只剩五六行。阶段 D 给富文本上了行数预算（`CollapsedRichTextMetrics.plan`），纯文本一直漏着，而 119 条笔记里 **79 条是纯文本**，`slowLayouts` 的前几名清一色是 `plain`（11.1 / 11.6 / 10.6ms，全部首次布局）。

判定侧和渲染侧各加一处 `maxLines`，行数由新增的 `QuoteContent.collapsedPlainTextMaxLines` 按「折叠盒高 ÷ 行高下界 + 1」算。

预算**只能偏大**：多排的行落在 160px 盒子外面被 `ClipRect` 裁掉，看不见；少排的内容是静悄悄消失的，没有任何提示。所以行高取 `fontSize * (height ?? 1.0)` 这个下界再 +1 行。算不出可信预算时（行高非有限，或预算超过 64 行的硬上限）返回 `null`，即**放弃截断**而不是夹到上限——字号和行高同时极小时那 64 行盖不住 160px，夹上去会真的截断正文。

渲染侧还要按 `DefaultTextStyle.merge` 之后的**实际**样式算——`Text` 的字号可能整个来自环境，照着一个 `fontSize` 为 null 的样式估就会低估行数。

判定侧的答案不变：n 行的真实高度恒 > 160.5，所以正文超过 n 行时被夹住的 `height` 仍然 > 阈值，不超过 n 行时 `height` 就是精确值。

### 2. `CollapsedRichTextMetrics.plan()` 加缓存

它在 `LayoutBuilder` 里被直接调用且没有任何缓存，卡片每重建一次就要把每个可见块重新 `TextPainter.layout` 一遍。列表里有 37 张卡片是永久 keepAlive 的，一次 `setState` 就是几十次全量重量。

加 LRU（300 条），键只存内容指纹，不持有 delta 字符串本身。宽度**按原值进键不做量化**：两个相差不到 0.01px 却恰好跨过 `TextPainter` 换行阈值的宽度共用一份计划的话，会按另一个宽度的行数多裁一行；同一次布局的约束逐位相同，精确相等本来就命中。宽度非有限时不建键（`double.infinity.round()` 会抛 `UnsupportedError`）。

计划里**排到了** `data:` 内嵌媒体则不进缓存（那个 source 是整段 base64），理由与 `DeltaMediaCache` / `DeltaRichTextCache` 一致；判据是计划自己排到的块而不是整篇 blocks，所以正文长到排不着那张图的笔记照常享受缓存。miss 和耗时**先记账再决定是否入缓存**，跳过存储的那些不会从统计里凭空消失。

顺带修了 `_computePlan` 里两条会抛 `UnsupportedError` 的路：非有限的 `limit`，以及畸形样式让 `minLineHeight` 变成 0（`160 / 0 = Infinity`）。两条都走 `_lineBudgetFor` 兜住。

### 3. 热路径去掉全量字符串扫描

`shouldKeepAliveQuoteItem` 原本对**每次条目构建**做三次 `deltaContent.contains(...)`，全量扫描整份 delta JSON，release 也在跑，而且每次构建都要重扫、结果一次都不复用。改走新增的 `DeltaMediaCache.hasMediaOf`（只存 bool，所以 `data:` 笔记也能安全缓存，不像摘要缓存要跳过它们；与 `of` 双向共用同一次解析）。

> **自我更正**：初版描述说这同时修掉了「正文里写了 `"image"` 的笔记被误判成有媒体」。**这个说法是错的**，我自己写的回归测试当场证伪了它——`jsonEncode` 会把正文里的引号转义成 `\"image\"`，子串扫描本来就匹配不上。真正的分歧只在 `"image"` 作为某个 op 的**属性名**时出现，本项目里不会发生。
>
> 所以这条纯粹是省时间，**不是修正确性**，旧代码在这件事上没有 bug：`contains` 每次调用重扫全文且结果不复用，而按内容指纹查表的主要成本（`String.hashCode`）被 Dart VM 缓存在字符串对象头里。

性能探针自己的两处扫描（`_noteListPerfKindFor`、`_quoteMixStatsText`）一并改掉——开着监控测出来的绝对值此前是偏高的。

### 4. 顺带补上测量盲区

日志新增 `plan=` / `planMiss+` / `planWorkUs+` / `planWorstUs=`。折叠富文本真正的排版成本一直在 `plan()` 里，而日志此前只统计便宜的 IR 解析（`irWorstUs=415`），看着一片绿。

## 视觉与行为

**没有视觉变化，也没有用户可见的行为变化。** 折叠盒尺寸、裁剪位置、展开入口的出现条件都不变；`maxLines` 只是不再为已经被裁掉的像素付排版钱。keepAlive 的判定口径在实际数据上与改动前一致（见第 3 节的自我更正）。

## 测试

新增：

- `test/unit/widgets/collapsed_plain_text_budget_test.dart` —— 用真的 `TextPainter` 钉住「`maxLines` × 真实行高 ≥ 折叠盒高度」这条不变量，覆盖显式行高 / 行高交给字体 / 系统字号缩放 0.8~3.0 / 样式为 null / 各种退回不截断的畸形样式。不断言具体行数（那会随字体和主题漂）。
- `test/unit/widgets/collapsed_rich_text_plan_cache_test.dart` —— 命中后计划逐字段相同、与不带缓存算出来的一致、宽度 / showMedia / 加粗优先 / 基准样式任一变化都重算、不同笔记不串味、`data:` 计划不进缓存，以及四条畸形输入不抛异常。**这四条验证过确实抓得住**：把 `_lineBudgetFor` 换回原表达式，其中三条以 `UnsupportedError` 失败。

补充：`delta_media_extractor_test.dart`（`hasMediaOf` 的各媒体形状、口径由解析而非子串决定、与 `of` 双向共用解析、`data:` 笔记的布尔缓存可被 `hasMediaCacheSize` / `missCount` 观测）、`note_list_keep_alive_test.dart`。

**验证**（本地装了 Flutter 3.44.9 / Dart 3.12.2，与 CI 同版本）：

- `dart format --language-version=3.5` 无改动（`pubspec.yaml` 的 SDK 下界是 3.5，走 short style；不带该参数或缺 package config 会误判成 tall style 并「重排」558 个文件）
- `flutter analyze lib test` → 5 条 info，全部是改动前就存在于我没碰的文件里的
- `flutter test test/unit test/widget test/bug_fixes` → **1612 + 261 全通过**

## 没做的（留给下一轮）

- **根因三：37 张媒体卡永久 keepAlive + 数据事件整表替换。** `watchQuotes` 每次重发整个累积列表，`_quotes..clear()..addAll()` 换成全新 `Quote` 对象，于是每次 `setState` 重建 55~100 张卡片——`built=297`、`worstBuild=123.9ms` 就是这么来的。结构性改动，需要单独一轮并配基准。
- **`scrollPreloadThreshold = 0.35` 太早**，会改变分页时机，要先确认。
- 让测量和渲染共用一份 `buildCollapsedBlockLayout`（`plan()` 有缓存之后收益变小）。

## 复测口径

release 模式，115~119 条笔记 / `media≈32`，下滑约 28000px 后原路滑回。主要看 `slowLayouts` 里 `plain` 的耗时（改前包揽前几名），以及新增的 `planMiss+`（稳态滑动里应该接近 0，不是 0 就说明缓存键漏了维度）。`built=` 的峰值本轮没动，应该基本不变。