### PR TITLE
🎨 Palette: [补充思考过程组件的无障碍提示]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,6 +35,6 @@
 **Learning:** IconButtons used for core actions in AI feature UIs (like "thinking" toggles, clear search icons, and stop generating buttons) often lack accessibility labels, making them unusable for screen reader users and missing hover cues on desktop.
 **Action:** When implementing or modifying AI chat interfaces and session histories, ensure that all `IconButton`s include dynamic tooltips (e.g. toggling between 'Show/Hide Thinking', or 'Send/Stop') localized via `AppLocalizations`.
 
-## 2024-08-14 - 补充思考过程组件的无障碍提示
+## 2026-08-14 - 补充思考过程组件的无障碍提示
 **Learning:** Icon-only buttons or custom interactive widgets (like `InkWell` combined with icons/text) often miss proper semantic context for screen readers. In interactive UI like AI thinking states (expanded/collapsed toggle), visually clear cues (like a rotating chevron) don't naturally translate to screen reader announcements. Using `Semantics` alongside `ExcludeSemantics` on inner components avoids redundant reading and explicitly signals the interaction model (button, expanded state) to visually impaired users.
 **Action:** Always verify that custom interactive components (`InkWell`, `GestureDetector`) wrapping text and icons are wrapped in a `Semantics` widget (providing `button: true`, `label`, and dynamic state properties like `expanded`), and exclude semantics on inner decorative or redundant text nodes.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -34,3 +34,7 @@
 ## 2026-06-27 - [Fix Missing Tooltips for AI Assistant Action Buttons]
 **Learning:** IconButtons used for core actions in AI feature UIs (like "thinking" toggles, clear search icons, and stop generating buttons) often lack accessibility labels, making them unusable for screen reader users and missing hover cues on desktop.
 **Action:** When implementing or modifying AI chat interfaces and session histories, ensure that all `IconButton`s include dynamic tooltips (e.g. toggling between 'Show/Hide Thinking', or 'Send/Stop') localized via `AppLocalizations`.
+
+## 2024-08-14 - 补充思考过程组件的无障碍提示
+**Learning:** Icon-only buttons or custom interactive widgets (like `InkWell` combined with icons/text) often miss proper semantic context for screen readers. In interactive UI like AI thinking states (expanded/collapsed toggle), visually clear cues (like a rotating chevron) don't naturally translate to screen reader announcements. Using `Semantics` alongside `ExcludeSemantics` on inner components avoids redundant reading and explicitly signals the interaction model (button, expanded state) to visually impaired users.
+**Action:** Always verify that custom interactive components (`InkWell`, `GestureDetector`) wrapping text and icons are wrapped in a `Semantics` widget (providing `button: true`, `label`, and dynamic state properties like `expanded`), and exclude semantics on inner decorative or redundant text nodes.

--- a/lib/widgets/ai/thinking_widget.dart
+++ b/lib/widgets/ai/thinking_widget.dart
@@ -126,65 +126,72 @@ class _ThinkingWidgetState extends State<ThinkingWidget>
           // 靠内容区左边那条竖线表示"这段是引下来的过程"。
           Material(
             color: Colors.transparent,
-            child: InkWell(
-              onTap: _toggleExpanded,
-              borderRadius: BorderRadius.circular(
-                AppShapeTokens.of(context).buttonRadius,
-              ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 6),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    // 进行中是脉冲圆点，结束后换成静态图标
-                    if (widget.inProgress)
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8),
-                        child: ScaleTransition(
-                          scale: Tween<double>(begin: 1.0, end: 1.2)
-                              .animate(_pulseController),
-                          child: Container(
-                            width: 8,
-                            height: 8,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: theme.colorScheme.primary,
+            child: Semantics(
+              button: true,
+              label: widget.inProgress ? l10n.aiThinking : l10n.thinking,
+              expanded: _isExpanded,
+              child: InkWell(
+                onTap: _toggleExpanded,
+                borderRadius: BorderRadius.circular(
+                  AppShapeTokens.of(context).buttonRadius,
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 6),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      // 进行中是脉冲圆点，结束后换成静态图标
+                      if (widget.inProgress)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 8),
+                          child: ScaleTransition(
+                            scale: Tween<double>(begin: 1.0, end: 1.2)
+                                .animate(_pulseController),
+                            child: Container(
+                              width: 8,
+                              height: 8,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: theme.colorScheme.primary,
+                              ),
                             ),
                           ),
+                        )
+                      else
+                        Padding(
+                          padding: const EdgeInsets.only(right: 8),
+                          child: Icon(
+                            Icons.lightbulb_outline,
+                            size: 16,
+                            color: muted,
+                          ),
                         ),
-                      )
-                    else
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8),
+                      // 标题文本。收起时是个名词标签（「思考」），不是
+                      // showThinking（「查看思考过程」）那种祈使句——它读起来
+                      // 像用户在对自己下指令。
+                      Flexible(
+                        child: ExcludeSemantics(
+                          child: Text(
+                            widget.inProgress ? l10n.aiThinking : l10n.thinking,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: muted,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ),
+                      // 旋转箭头
+                      RotationTransition(
+                        turns: Tween<double>(begin: 0, end: 0.5)
+                            .animate(_rotationController),
                         child: Icon(
-                          Icons.lightbulb_outline,
-                          size: 16,
-                          color: muted,
+                          Icons.expand_more,
+                          size: 18,
+                          color: muted.withValues(alpha: 0.6),
                         ),
                       ),
-                    // 标题文本。收起时是个名词标签（「思考」），不是
-                    // showThinking（「查看思考过程」）那种祈使句——它读起来
-                    // 像用户在对自己下指令。
-                    Flexible(
-                      child: Text(
-                        widget.inProgress ? l10n.aiThinking : l10n.thinking,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: muted,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    // 旋转箭头
-                    RotationTransition(
-                      turns: Tween<double>(begin: 0, end: 0.5)
-                          .animate(_rotationController),
-                      child: Icon(
-                        Icons.expand_more,
-                        size: 18,
-                        color: muted.withValues(alpha: 0.6),
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
💡 **What:** 
使用 `Semantics` 和 `ExcludeSemantics` 重新包装了 `ThinkingWidget` 中用于控制展开/折叠思考过程的自定义交互按钮（由 `InkWell` 包装的图标与文本）。

🎯 **Why:** 
原实现使用纯 `InkWell` 实现点击，但是由于内部结构（包含了会旋转的图标和随着状态变化的文字），屏幕阅读器无法清晰获取其整体“作为按钮”的含义以及它代表的当前是否展开的状态。

📸 **Before/After:** 
视觉无变化，但辅助工具（如 TalkBack / VoiceOver）能够识别出这是一个“按钮”，并能清楚播报“思考（或者展开时的相关提示词）”与当前的展开折叠状态。

♿ **Accessibility:** 
通过加上 `Semantics(button: true, label: ..., expanded: _isExpanded)` ，并用 `ExcludeSemantics` 剔除了原先容易引发重复朗读的文本节点，使得整个交互区块获得了一个清晰、唯一的语义身份。

---
*PR created automatically by Jules for task [16650302636358488690](https://jules.google.com/task/16650302636358488690) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 ThinkingWidget 的折叠/展开切换补充无障碍语义：读屏由原先分散朗读图标/文本，改为识别为一个按钮并正确播报“展开/收起”状态；视觉与对外行为不变。

- 审阅要点
  - 使用 `Semantics(button: true, label: ..., expanded: _isExpanded)` 包裹 `InkWell`，标题文本加 `ExcludeSemantics` 避免重复朗读，箭头仅作装饰；`label` 随 `inProgress` 在本地化文案间切换，`expanded` 与旋转动画/内部状态一致。
  - 无 API 或视觉变更；请在 TalkBack/VoiceOver 下验证按钮角色与展开/收起播报是否正确。
  - 更新 `.jules/palette.md`：新增 2026-08-14 指南，要求自定义交互组件使用 `Semantics` 明确角色与状态，并对内层冗余语义使用 `ExcludeSemantics`。

<sup>Written for commit 0be67b74b0c31f353ed0241066a23425df755c98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **无障碍改进**
  * 为思考组件标题栏添加屏幕阅读器语义支持，包括按钮角色、动态标签和展开状态。
  * 优化标题文本及装饰内容的语义处理，减少重复朗读，同时保持原有交互和视觉效果不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->