### PR TITLE
fix(editor): 全屏编辑器正文不再渲染成红色粗体

### DIFF
--- a/lib/utils/quill_editor_extensions.dart
+++ b/lib/utils/quill_editor_extensions.dart
@@ -102,9 +102,13 @@ class QuillEditorExtensions {
 /// quill 段落基准样式的**唯一**纠正入口。
 ///
 /// `DefaultStyles.getInstance` 的 baseStyle 是从 `DefaultTextStyle` 拷的
-/// （颜色、字体族确实跟着主题走），但 `fontSize` 和 `height` 被硬写成 16 / 1.15。
+/// （它在 `QuillEditor` 自己的 context 上取，所以颜色、字体族确实跟着主题走），
+/// 但 `fontSize` 和 `height` 被硬写成 16 / 1.15。
 /// 1.15 对中文正文太挤，换成衬线体之后尤其闷；16 则在衬线风格把正文放大到 17
 /// （[ThemeStyleForm.bodyFontScale]）之后跟纯文本笔记对不上。
+///
+/// 纠正的时候**不能照抄那条取法**：调用点往往在 `Material` 外面，那里的
+/// `DefaultTextStyle` 是 `MaterialApp` 的报警样式。见 [paragraphStyle]。
 ///
 /// 两个用到 `QuillEditor` 的地方——笔记卡片正文和全屏编辑器——必须按同一套令牌
 /// 纠正，否则「写的时候」和「读的时候」行距不一样。规则因此放在这里一处。
@@ -127,17 +131,27 @@ class QuillThemeTypography {
 
   /// [base] 是调用方已有的正文样式（卡片会传 `bodyLarge` + 笔记颜色）。
   ///
-  /// 字号和行高**不从 [DefaultTextStyle] 取**：调用方可能没传 [base]，而那里
-  /// 往往是 `bodyMedium`(14)，直接用会把正文缩一号。规则统一成「富文本正文 =
-  /// `bodyLarge`」，兜底才轮到 quill 的硬编码值。
+  /// 基准**一律取 `textTheme.bodyLarge`，绝不取 [DefaultTextStyle]**。后者在
+  /// `Material` 之上根本不是正文样式：`MaterialApp` 会在 `Navigator` 外面铺一份
+  /// 「你还没设过样式」的报警样式（红色 `0xD0FF0000`、`bold`、`monospace`、48px、
+  /// 黄色双下划线），只有落进 `Material` 内部才会被换成真正的正文样式。页面级的
+  /// `build(context)`（全屏编辑器就是在 `Scaffold` 外面调的）拿到的正是那一份，
+  /// 于是整篇正文渲染成红色粗体等宽字——[decoration] 被清掉后连黄下划线这个
+  /// 破绽都没了。规则本来也是「富文本正文 = `bodyLarge`」，直接从主题取既消掉
+  /// 这个坑，也不再受调用点在树里深浅的影响。
   ///
-  /// `decoration` 必须显式清掉，否则 [DefaultTextStyle] 里的下划线会漏进正文。
+  /// `decoration` 仍要显式清掉：[base] 自己可能带下划线。
+  ///
+  /// `color` 必须给全：`TextLine` 用的是 `RichText`，它不继承 `DefaultTextStyle`，
+  /// 段落样式整体替换后缺 color 会在暗色模式下渲染成黑字。
   static TextStyle paragraphStyle(BuildContext context, {TextStyle? base}) {
-    final bodyLarge = Theme.of(context).textTheme.bodyLarge;
-    final inherited = DefaultTextStyle.of(context).style.merge(base);
-    return inherited.copyWith(
+    final theme = Theme.of(context);
+    final bodyLarge = theme.textTheme.bodyLarge;
+    final resolved = (bodyLarge ?? const TextStyle()).merge(base);
+    return resolved.copyWith(
       fontSize: base?.fontSize ?? bodyLarge?.fontSize ?? 16,
       height: base?.height ?? bodyLarge?.height ?? 1.15,
+      color: resolved.color ?? theme.colorScheme.onSurface,
       decoration: TextDecoration.none,
     );
   }

--- a/test/unit/utils/quill_paragraph_style_test.dart
+++ b/test/unit/utils/quill_paragraph_style_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/quill_editor_extensions.dart';
+
+/// 富文本段落基准样式不能跟着调用点在树里的深浅变。
+///
+/// 历史故障：[QuillThemeTypography.paragraphStyle] 曾经拿
+/// `DefaultTextStyle.of(context)` 当基准。`Material` 里面那是正常正文样式，可
+/// `MaterialApp` 在 `Navigator` 外面铺的是一份「你还没设过样式」的报警样式
+/// （红色 `0xD0FF0000` + `bold` + `monospace` + 48px + 黄色双下划线）。全屏编辑器
+/// 的 `build(context)` 正好在 `Scaffold` 外面，于是整篇正文被渲染成红色粗体——
+/// 字号被覆盖、下划线被清掉，最扎眼的两项（颜色、字重）反而全留了下来。
+void main() {
+  /// `MaterialApp` 那份报警样式的颜色，见 `WidgetsApp.textStyle` 的默认值。
+  const appFallbackColor = Color(0xD0FF0000);
+
+  testWidgets('Scaffold 之外算出的段落样式不会吃到 MaterialApp 的报警样式', (tester) async {
+    late TextStyle paragraph;
+    late TextStyle bodyLarge;
+    late Color onSurface;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            // 前提校验：这一层的 DefaultTextStyle 确实不是正文样式（现在是那份
+            // 报警样式），否则这条用例根本没在测东西。只比「不等于正文」，
+            // 不钉报警样式的具体取值——那是 framework 的内部常量。
+            expect(
+              DefaultTextStyle.of(context).style.color,
+              isNot(Theme.of(context).textTheme.bodyLarge!.color),
+              reason: '这一层若已经是正常正文样式，说明用例没复刻全屏编辑器的位置',
+            );
+            // 全屏编辑器就是在这个位置（Scaffold 之外）算段落样式的。
+            paragraph = QuillThemeTypography.paragraphStyle(context);
+            bodyLarge = Theme.of(context).textTheme.bodyLarge!;
+            onSurface = Theme.of(context).colorScheme.onSurface;
+            return const Scaffold();
+          },
+        ),
+      ),
+    );
+
+    expect(paragraph.color, isNot(appFallbackColor));
+    expect(paragraph.color, bodyLarge.color ?? onSurface);
+    expect(paragraph.fontWeight, bodyLarge.fontWeight);
+    expect(paragraph.fontFamily, bodyLarge.fontFamily);
+    expect(paragraph.fontSize, bodyLarge.fontSize);
+    expect(paragraph.height, bodyLarge.height);
+    expect(paragraph.decoration, TextDecoration.none);
+  });
+
+  testWidgets('Material 内外算出的段落样式必须一模一样', (tester) async {
+    late TextStyle outside;
+    late TextStyle inside;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (outerContext) {
+            outside = QuillThemeTypography.paragraphStyle(outerContext);
+            return Scaffold(
+              body: Builder(
+                builder: (innerContext) {
+                  // 笔记卡片走的是这条（Material 内部）。两边必须同一份样式，
+                  // 否则同一条笔记「写的时候」和「读的时候」长得不一样。
+                  inside = QuillThemeTypography.paragraphStyle(innerContext);
+                  return const SizedBox.shrink();
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(inside, outside);
+  });
+
+  testWidgets('base 给了的项优先，下划线仍被清掉', (tester) async {
+    late TextStyle paragraph;
+    const base = TextStyle(
+      fontSize: 21,
+      height: 2.0,
+      color: Color(0xFF123456),
+      decoration: TextDecoration.underline,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            paragraph = QuillThemeTypography.paragraphStyle(
+              context,
+              base: base,
+            );
+            return const Scaffold();
+          },
+        ),
+      ),
+    );
+
+    expect(paragraph.fontSize, 21);
+    expect(paragraph.height, 2.0);
+    expect(paragraph.color, const Color(0xFF123456));
+    expect(paragraph.decoration, TextDecoration.none);
+  });
+}

--- a/test/widget/utils/quill_editor_extensions_test.dart
+++ b/test/widget/utils/quill_editor_extensions_test.dart
@@ -77,6 +77,43 @@ void main() {
     expect(inside, outside);
   });
 
+  testWidgets('主题没给正文颜色时兜底到 onSurface', (tester) async {
+    // `TextLine` 用的 `RichText` 不继承 `DefaultTextStyle`，段落样式整体替换后
+    // 缺 color 会在暗色模式下画黑字，所以 `paragraphStyle` 有一条 onSurface 兜底。
+    // 默认主题的 `bodyLarge` 永远带颜色，那条分支平时走不到，这里显式造出来。
+    //
+    // `inherit: false` 不是凑巧：`ThemeData` 会把传入的 `textTheme` merge 到
+    // 默认那套上，而 `TextStyle.merge` 只有在 `inherit` 为 false 时才整体替换。
+    // 写成普通的 `TextStyle()`，null 的颜色会被默认值填回来，这条用例就白测了。
+    const onSurface = Color(0xFF00FF00);
+    final theme = ThemeData(
+      colorScheme: const ColorScheme.light(onSurface: onSurface),
+      textTheme: const TextTheme(
+        bodyLarge: TextStyle(inherit: false, fontSize: 16),
+      ),
+    );
+    late TextStyle paragraph;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Builder(
+          builder: (context) {
+            expect(
+              Theme.of(context).textTheme.bodyLarge!.color,
+              isNull,
+              reason: '前提：这套主题的正文确实没有颜色，否则测不到兜底分支',
+            );
+            paragraph = QuillThemeTypography.paragraphStyle(context);
+            return const Scaffold();
+          },
+        ),
+      ),
+    );
+
+    expect(paragraph.color, onSurface);
+  });
+
   testWidgets('base 给了的项优先，下划线仍被清掉', (tester) async {
     late TextStyle paragraph;
     const base = TextStyle(


### PR DESCRIPTION
## 现象

全屏编辑器里正文整篇是**红色 + 加粗 + 等宽字**，新建笔记和打开已有笔记都一样。笔记卡片（列表里的正文）不受影响。

## 原因

`QuillThemeTypography.paragraphStyle`（#448 引入）拿 `DefaultTextStyle.of(context)` 当段落基准样式：

```dart
final inherited = DefaultTextStyle.of(context).style.merge(base);
```

这个取法只在 `Material` **内部**成立。`MaterialApp` 会在 `Navigator` 外面铺一份「你还没设过样式」的报警样式——红色 `0xD0FF0000`、`bold`、`monospace`、48px、黄色双下划线——只有落进 `Material` 里才会被换成真正的正文样式。

而全屏编辑器是在页面的 `build(context)`（`note_full_editor_page.dart:222` → `editor_build.dart:230`）算这份样式的，那个 context 在 `Scaffold` 之上，拿到的正是报警样式。原实现又恰好把最能暴露问题的两项抹掉了：`fontSize` 被覆盖成 `bodyLarge`，`decoration` 被显式清成 `none`（当时注释里「`DefaultTextStyle` 里的下划线会漏进正文」说的就是那条黄色双下划线），于是只剩颜色和字重留在正文上。笔记卡片那条路在 `Material` 内部，所以只有编辑器中招。

## 改动

- `paragraphStyle` 的基准改为一律取 `Theme.of(context).textTheme.bodyLarge`，不再读 `DefaultTextStyle`——规则本来就是「富文本正文 = `bodyLarge`」，直接从主题取，样式因此不随调用点在树里的深浅变化。
- `color` 补上 `colorScheme.onSurface` 兜底：`TextLine` 用的 `RichText` 不继承 `DefaultTextStyle`，段落样式整体替换后缺 color 会在暗色模式下画黑字。
- 注释说明这个坑，避免以后再照抄 quill 那条 `DefaultTextStyle` 取法。

卡片那条路的像素不变：调用点传的 `base`（`bodyLarge` + 笔记颜色）本来就盖住了继承来的每一项，`fontSize` / `height` 也仍旧优先取 `base`。

## 验证

Flutter 3.47.0 stable（CI 用 3.44.x）：

- `flutter test test/unit/utils/quill_paragraph_style_test.dart` — 新增，3 个用例全过：Scaffold 之外算出的样式不带报警样式、Material 内外算出的样式完全一致、`base` 给了的项仍然优先。
- 把 `lib/utils/quill_editor_extensions.dart` 回退到修复前跑同一份测试：前两条如期失败，报的正是 `Color(alpha: 0.8157, red: 1.0)`（即 `0xD0FF0000`）和 `debugLabel: fallback style; consider putting your text in a Material` ——故障机制是实测出来的，不是推断。
- 回归：`quote_content_line_height_test.dart`、`quote_content_widget_test.dart`、`quote_item_widget_test.dart`、`quote_content_cache_test.dart` 共 55 个用例全过。
- `flutter analyze --no-fatal-infos` 与 `dart format --set-exit-if-changed`（改动文件）均无问题。

未做真机/模拟器目视确认（环境无设备）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtsdH9xgZrWQhVVNo5V91r)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复全屏编辑器正文误套用 `MaterialApp` 警示 `DefaultTextStyle`，导致整篇渲染为红色加粗等宽字；现在统一以主题 `textTheme.bodyLarge` 为基准，并在缺色时回退到 `colorScheme.onSurface`，确保 Material 内外显示一致。卡片正文不受影响。

- 将 `QuillThemeTypography.paragraphStyle` 基准改为 `Theme.of(context).textTheme.bodyLarge`，显式清 `decoration`，并在缺 `color` 时回落到 `colorScheme.onSurface`（避免 `RichText` 在暗色模式下画黑字）。
- 测试迁移至 `test/widget/utils/quill_editor_extensions_test.dart`，覆盖：Scaffold 外不吃警示样式、Material 内外一致、`base` 优先、缺色回落到 onSurface。

<sup>Written for commit 61c9a734fd20bf0eff655f9f57bea2147dc25f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 优化 Quill 段落文本样式，使编辑器内外的显示更加一致。
  * 改进默认字号、行高和文字颜色的继承与覆盖逻辑。
  * 修复缺少颜色配置时的文本显示问题。
  * 确保段落样式始终正确移除下划线效果。

* **测试**
  * 新增回归测试，覆盖不同 Material 环境下的样式一致性及基础样式优先级。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->