### PR TITLE
记录页顶部间距、剪贴板摘录收紧、发布流水线出 AAB

### DIFF
--- a/.github/workflows/flutter-release-build.yml
+++ b/.github/workflows/flutter-release-build.yml
@@ -1,4 +1,4 @@
-name: Flutter发布版APK构建
+name: Flutter发布版Android构建
 
 on:
   # 手动触发工作流
@@ -26,6 +26,11 @@ on:
           - both
           - standard64
           - arm32Compat
+      build_aab:
+        description: '额外构建 Google Play 用的 AAB（仅 standard64 + release）'
+        required: false
+        default: true
+        type: boolean
 
   # 供 release.yml 复用；inputs 上下文对两种触发方式通用，构建逻辑无需区分
   workflow_call:
@@ -44,6 +49,11 @@ on:
         required: false
         default: 'both'
         type: string
+      build_aab:
+        description: '额外构建 Google Play 用的 AAB（仅 standard64 + release）'
+        required: false
+        default: true
+        type: boolean
     secrets:
       SENTRY_DSN:
         required: false
@@ -201,6 +211,42 @@ jobs:
             build_flavor arm32Compat android-arm
           fi
 
+      # Google Play 只收 AAB，且要求应用支持 64 位；arm32Compat 是纯 32 位的
+      # 兼容变体（关 Impeller、开软件渲染），单独打成 AAB 上传也会被拒，
+      # 所以这里只出 standard64 这一个 arm64-v8a 的 AAB。
+      - name: 构建 AAB (standard64)
+        id: aab
+        if: >-
+          ${{ (inputs.build_aab == null || inputs.build_aab)
+              && (inputs.build_mode || 'release') == 'release'
+              && (inputs.build_variant || 'both') != 'arm32Compat' }}
+        env:
+          VERSION_NAME: ${{ inputs.version_name }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          set -euo pipefail
+
+          # 与 APK 走同一套 flavor/签名/ABI 参数，只换产物格式
+          flutter build appbundle --release \
+            --flavor standard64 \
+            --target-platform=android-arm64 \
+            --android-project-arg=disable-abi-filtering=true \
+            --build-number="${{ github.run_number }}" \
+            --build-name="$VERSION_NAME" \
+            --dart-define=SENTRY_DSN="$SENTRY_DSN"
+
+          # 产物在 build/app/outputs/bundle/standard64Release/ 下，
+          # 文件名跟着 flavor 走，这里直接按扩展名找，免得改名就断
+          aab_path="$(find build/app/outputs/bundle -type f -name '*.aab' | head -n 1)"
+          if [[ -z "$aab_path" ]]; then
+            echo "::error::未找到 AAB 产物"
+            exit 1
+          fi
+
+          mkdir -p build/app/outputs/release-artifacts
+          cp -v "$aab_path" \
+            "build/app/outputs/release-artifacts/thoughtecho-standard64-release.aab"
+
       # archive: false 时 upload-artifact 只接受单个文件，
       # build_variant=both 会产出两个 APK，因此按变体分开上传。
       - name: 上传 APK (standard64)
@@ -217,6 +263,16 @@ jobs:
         with:
           name: app-${{ inputs.build_mode || 'release' }}-arm32Compat-apk
           path: build/app/outputs/release-artifacts/thoughtecho-arm32Compat-*.apk
+          archive: false
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: 上传 AAB (standard64)
+        if: ${{ steps.aab.outcome == 'success' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-release-standard64-aab
+          path: build/app/outputs/release-artifacts/thoughtecho-standard64-release.aab
           archive: false
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/flutter-release-build.yml
+++ b/.github/workflows/flutter-release-build.yml
@@ -20,16 +20,16 @@ on:
       build_variant:
         description: 'Android ABI 变体 (standard64, arm32Compat, both)'
         required: true
-        default: 'both'
+        default: 'standard64'
         type: choice
         options:
-          - both
           - standard64
+          - both
           - arm32Compat
       build_aab:
         description: '额外构建 Google Play 用的 AAB（仅 standard64 + release）'
         required: false
-        default: true
+        default: false
         type: boolean
 
   # 供 release.yml 复用；inputs 上下文对两种触发方式通用，构建逻辑无需区分
@@ -47,12 +47,12 @@ on:
       build_variant:
         description: 'Android ABI 变体 (standard64, arm32Compat, both)'
         required: false
-        default: 'both'
+        default: 'standard64'
         type: string
       build_aab:
         description: '额外构建 Google Play 用的 AAB（仅 standard64 + release）'
         required: false
-        default: true
+        default: false
         type: boolean
     secrets:
       SENTRY_DSN:

--- a/.github/workflows/flutter-release-build.yml
+++ b/.github/workflows/flutter-release-build.yml
@@ -216,8 +216,10 @@ jobs:
       # 所以这里只出 standard64 这一个 arm64-v8a 的 AAB。
       - name: 构建 AAB (standard64)
         id: aab
+        # 注意不能写 inputs.build_aab == null 做兜底：GitHub 表达式比较会把
+        # 两边转成数字，false 和 null 都是 0，关掉开关照样会跑这一步。
         if: >-
-          ${{ (inputs.build_aab == null || inputs.build_aab)
+          ${{ inputs.build_aab
               && (inputs.build_mode || 'release') == 'release'
               && (inputs.build_variant || 'both') != 'arm32Compat' }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,8 @@ jobs:
       version_name: ${{ needs.prepare.outputs.version }}
       build_mode: release
       build_variant: both
+      # 为 Google Play 备一份 AAB（arm64-v8a）
+      build_aab: true
 
   windows:
     needs: prepare
@@ -176,7 +178,8 @@ jobs:
           mkdir -p dist
 
           # 产物散落在各 artifact 子目录中，按扩展名收拢到一处
-          find artifacts -type f \( -name '*.apk' -o -name '*.msix' -o -name '*.ipa' \) \
+          find artifacts -type f \
+            \( -name '*.apk' -o -name '*.msix' -o -name '*.ipa' -o -name '*.aab' \) \
             -exec cp -v {} dist/ \;
 
           # 三个平台都必须有可发布产物，缺任何一个就不创建 Release
@@ -186,6 +189,11 @@ jobs:
               exit 1
             fi
           done
+
+          # AAB 只是给 Google Play 备的，缺了不拦发布
+          if ! find dist -type f -name '*.aab' | grep -q .; then
+            echo "::warning::本次没有 AAB 产物，Google Play 需要另行构建"
+          fi
 
           # 兼容历史下载链接：官网 dl.html 与 README 长期使用 app-release.apk
           if [[ -f dist/thoughtecho-standard64-release.apk && ! -f dist/app-release.apk ]]; then
@@ -233,6 +241,8 @@ jobs:
             echo "- **Windows**：建议从 [Microsoft Store](https://apps.microsoft.com/detail/9NC7GDG6KFMC) 安装，可自动更新"
             echo "- **Android**：下载 \`thoughtecho-standard64-release.apk\`（64 位，绝大多数设备）；老设备用 \`thoughtecho-arm32Compat-release.apk\`"
             echo "- **iOS**：\`ThoughtEcho-unsigned.ipa\` 未签名，需自行签名侧载，尚未上架 App Store"
+            echo ""
+            echo "> \`.aab\` 是提交 Google Play 用的应用包，手机不能直接安装，普通用户请下载 APK。"
             echo ""
             echo "完整下载指引：https://note.shangjinyun.cn/dl"
           } >> "$out"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,8 @@ jobs:
       version_name: ${{ needs.prepare.outputs.version }}
       build_mode: release
       build_variant: both
-      # 为 Google Play 备一份 AAB（arm64-v8a）
+      # 顺手出一份和本次发版同源的 AAB（arm64-v8a）。它不会进 Release 附件，
+      # 只留在本次运行的 Artifacts 里，需要上架 Google Play 时去那儿下。
       build_aab: true
 
   windows:
@@ -177,9 +178,10 @@ jobs:
           set -euo pipefail
           mkdir -p dist
 
-          # 产物散落在各 artifact 子目录中，按扩展名收拢到一处
-          find artifacts -type f \
-            \( -name '*.apk' -o -name '*.msix' -o -name '*.ipa' -o -name '*.aab' \) \
+          # 产物散落在各 artifact 子目录中，按扩展名收拢到一处。
+          # 不收 .aab：它是提交 Google Play 用的，手机装不了，不该出现在
+          # Release 的下载列表里；需要时去本次运行的 Artifacts 里取。
+          find artifacts -type f \( -name '*.apk' -o -name '*.msix' -o -name '*.ipa' \) \
             -exec cp -v {} dist/ \;
 
           # 三个平台都必须有可发布产物，缺任何一个就不创建 Release
@@ -189,11 +191,6 @@ jobs:
               exit 1
             fi
           done
-
-          # AAB 只是给 Google Play 备的，缺了不拦发布
-          if ! find dist -type f -name '*.aab' | grep -q .; then
-            echo "::warning::本次没有 AAB 产物，Google Play 需要另行构建"
-          fi
 
           # 兼容历史下载链接：官网 dl.html 与 README 长期使用 app-release.apk
           if [[ -f dist/thoughtecho-standard64-release.apk && ! -f dist/app-release.apk ]]; then
@@ -241,8 +238,6 @@ jobs:
             echo "- **Windows**：建议从 [Microsoft Store](https://apps.microsoft.com/detail/9NC7GDG6KFMC) 安装，可自动更新"
             echo "- **Android**：下载 \`thoughtecho-standard64-release.apk\`（64 位，绝大多数设备）；老设备用 \`thoughtecho-arm32Compat-release.apk\`"
             echo "- **iOS**：\`ThoughtEcho-unsigned.ipa\` 未签名，需自行签名侧载，尚未上架 App Store"
-            echo ""
-            echo "> \`.aab\` 是提交 Google Play 用的应用包，手机不能直接安装，普通用户请下载 APK。"
             echo ""
             echo "完整下载指引：https://note.shangjinyun.cn/dl"
           } >> "$out"

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -554,8 +554,17 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     // 检查剪贴板内容
     final clipboardData = await clipboardService.checkClipboard();
     if (clipboardData != null && mounted) {
-      // 显示确认对话框
-      clipboardService.showClipboardConfirmationDialog(context, clipboardData);
+      // 提示条只负责询问，接受后仍走页面统一的新增笔记入口：
+      // 标签加载、"跳过非全屏编辑器"偏好和保存反馈都在那条路径上。
+      clipboardService.showClipboardCapturePrompt(
+        context,
+        clipboardData,
+        onAccept: (content, author, source) => _showAddQuoteDialog(
+          prefilledContent: content,
+          prefilledAuthor: author,
+          prefilledWork: source,
+        ),
+      );
     }
   }
 

--- a/lib/services/clipboard_service.dart
+++ b/lib/services/clipboard_service.dart
@@ -121,9 +121,18 @@ class ClipboardService extends ChangeNotifier {
       // 提取作者和出处（如果有）
       final attribution = _extractAttribution(content);
 
-      logDebug(
-        '从剪贴板提取信息 - 作者: ${attribution.author}, 出处: ${attribution.source}',
-      );
+      // 作者和出处同样来自用户剪贴板，Release 构建里只记是否识别到，
+      // 不把内容写进日志（日志会落盘，也会随反馈一起带出去）
+      if (kDebugMode) {
+        logDebug(
+          '从剪贴板提取信息 - 作者: ${attribution.author}, 出处: ${attribution.source}',
+        );
+      } else {
+        logDebug(
+          '从剪贴板提取信息 - 识别到作者: ${attribution.author != null}, '
+          '识别到出处: ${attribution.source != null}',
+        );
+      }
 
       return {
         'content': attribution.content,
@@ -144,42 +153,39 @@ class ClipboardService extends ChangeNotifier {
   /// 破折号 `—` `–` 和 `--` 允许跨行，署名单独占一行是常见排版。
   static const String _dash = r'(?:\s*[—–]+|\s*-{2,}|[ \t]+-)\s*';
 
-  /// 兜底提取作者时的候选名。排除句读、书名号和 URL 里的 `:` `/`，
-  /// 长度限制在 2~20，避免把整句话当成作者。
-  static const String _fallbackAuthor = r'[^，。,、\.\n《（\(：:/\\]{2,20}';
+  /// 作者候选名。排除句读、书名号和 URL 里的 `:` `/`，长度限制在 2~20，
+  /// 避免把整段说明当成作者。三条规则共用同一套约束。
+  static const String _author = r'[^，。,、\.\n《（\(：:/\\]{2,20}';
 
-  /// 已被书名号锚定的位置，作者名可以放宽一些。
-  static const String _anchoredAuthor = r'[^，。,、\.\n]{1,30}';
+  /// 出处**只认书名号**。中英文圆括号在普通文本里太常见
+  /// （"今天心情不错（真的好）"），当出处切走会把正文改坏。
+  static const String _source = r'[《〈]([^》〉]+?)[》〉]';
 
-  /// 书名号包裹的出处。兜底提取出处时**只认书名号**：
-  /// 中英文圆括号在普通文本里太常见（"今天很开心（真的）"），
-  /// 当出处切走会把正文改坏。
-  static final RegExp _bookTitleSource = RegExp(r'[《〈]([^》〉]+?)[》〉]\s*$');
-
-  // 1. 正文 ——作者《出处》
+  // 1. 正文 ——作者《出处》（作者可省略）
   static final RegExp _dashAuthorThenSource = RegExp(
-    '$_dash' r'([^《（\(]+?)?\s*[《（\(]([^》）\)]+?)[》）\)]\s*$',
+    '$_dash' '($_author)?' r'\s*' '$_source' r'\s*$',
   );
 
   // 2. 正文《出处》——作者
   static final RegExp _sourceThenDashAuthor = RegExp(
-    r'[《（\(]([^》）\)]+?)[》）\)]' '$_dash' '($_anchoredAuthor)' r'\s*$',
+    '$_source' '$_dash' '($_author)' r'\s*$',
   );
 
-  // 3. 兜底：正文 ——作者
+  // 3. 正文 ——作者
   //
   // “引文”——作者 也走这条：切点是分隔符，引文整体留在正文里，
   // 不需要单独为引号写一条规则。
   static final RegExp _dashAuthorOnly = RegExp(
-    '$_dash' '($_fallbackAuthor)' r'\s*$',
+    '$_dash' '($_author)' r'\s*$',
   );
 
   static final RegExp _cleanPattern = RegExp(r'^[—–\-\s]+|[—–\-\s]+$');
 
   /// 从文本尾部提取作者和出处（一言式署名），并返回去掉署名后的正文。
   ///
-  /// 只在**尾部有明确署名标记**（破折号、书名号）时才切；宁可漏判也不误切——
-  /// 切错等于悄悄改用户的笔记正文，比不提取难受得多。
+  /// **三条规则都要求尾部有破折号署名**：书名号只有紧挨着署名时才算出处，
+  /// 单独结尾的书名号不切（"我在读《活着》"是正文，不是"正文 + 出处"）。
+  /// 宁可漏判也不误切——切错等于悄悄改用户的笔记正文，比不提取难受得多。
   _ClipboardAttribution _extractAttribution(String content) {
     final text = content.trim();
 
@@ -189,7 +195,7 @@ class ClipboardService extends ChangeNotifier {
     }
 
     // 署名从 matchStart 开始，前面剩下的才是正文。正文被切空说明整段都是
-    // 署名（比如只复制了一个书名），这种情况保留原文、不做提取。
+    // 署名（比如只复制了一句"——某人"），这种情况保留原文、不做提取。
     _ClipboardAttribution? cut(int matchStart, String? author, String? source) {
       final body = text.substring(0, matchStart).trim();
       if (body.isEmpty) return null;
@@ -203,52 +209,25 @@ class ClipboardService extends ChangeNotifier {
 
     // 1. 正文 ——作者《出处》
     final m1 = _dashAuthorThenSource.firstMatch(text);
-    if (m1 != null) {
+    if (m1 != null && _hasInlineBody(text, m1.start)) {
       final result = cut(m1.start, clean(m1.group(1)), clean(m1.group(2)));
       if (result != null) return result;
     }
 
     // 2. 正文《出处》——作者
+    //
+    // 这里不做 _hasInlineBody 守卫：匹配是从书名号开始的，而"出处 + 作者"
+    // 单独占一行是常见排版，按行首拦会把正常的署名块也拦掉。
     final m2 = _sourceThenDashAuthor.firstMatch(text);
     if (m2 != null) {
       final result = cut(m2.start, clean(m2.group(2)), clean(m2.group(1)));
       if (result != null) return result;
     }
 
-    // 3. 兜底：正文 ——作者（作者前面可能还有一个书名号出处）
+    // 3. 正文 ——作者
     final m3 = _dashAuthorOnly.firstMatch(text);
     if (m3 != null && _hasInlineBody(text, m3.start)) {
-      final author = clean(m3.group(1));
-      final beforeAuthor = text.substring(0, m3.start);
-      final sourceMatch = _bookTitleSource.firstMatch(beforeAuthor);
-      if (sourceMatch != null) {
-        final result = cut(
-          sourceMatch.start,
-          author,
-          clean(sourceMatch.group(1)),
-        );
-        if (result != null) return result;
-      }
-      final result = cut(m3.start, author, null);
-      if (result != null) return result;
-    }
-
-    // 4. 兜底：正文《出处》（出处前面可能还有一个 ——作者）
-    final m4 = _bookTitleSource.firstMatch(text);
-    if (m4 != null) {
-      final source = clean(m4.group(1));
-      final beforeSource = text.substring(0, m4.start);
-      final authorMatch = _dashAuthorOnly.firstMatch(beforeSource);
-      if (authorMatch != null &&
-          _hasInlineBody(beforeSource, authorMatch.start)) {
-        final result = cut(
-          authorMatch.start,
-          clean(authorMatch.group(1)),
-          source,
-        );
-        if (result != null) return result;
-      }
-      final result = cut(m4.start, null, source);
+      final result = cut(m3.start, clean(m3.group(1)), null);
       if (result != null) return result;
     }
 

--- a/lib/services/clipboard_service.dart
+++ b/lib/services/clipboard_service.dart
@@ -146,8 +146,7 @@ class ClipboardService extends ChangeNotifier {
 
   /// 兜底提取作者时的候选名。排除句读、书名号和 URL 里的 `:` `/`，
   /// 长度限制在 2~20，避免把整句话当成作者。
-  static const String _fallbackAuthor =
-      r'[^，。,、\.\n《（\(：:/\\]{2,20}';
+  static const String _fallbackAuthor = r'[^，。,、\.\n《（\(：:/\\]{2,20}';
 
   /// 已被书名号锚定的位置，作者名可以放宽一些。
   static const String _anchoredAuthor = r'[^，。,、\.\n]{1,30}';

--- a/lib/services/clipboard_service.dart
+++ b/lib/services/clipboard_service.dart
@@ -1,26 +1,26 @@
-// filepath: /workspaces/ThoughtEcho/lib/services/clipboard_service.dart
 import 'dart:async';
 
-import '../constants/app_constants.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '../models/note_tag.dart';
-import '../models/quote_model.dart';
-import '../services/database_service.dart';
-import '../widgets/add_note_dialog.dart'; // 导入AddNoteDialog
-import 'package:provider/provider.dart';
-import '../utils/mmkv_ffi_fix.dart'; // 导入安全包装类
-import '../utils/app_logger.dart';
+
 import '../gen_l10n/app_localizations.dart';
 import '../theme/theme_style.dart';
+import '../utils/app_logger.dart';
+import '../utils/mmkv_ffi_fix.dart'; // 导入安全包装类
+
+/// 用户接受剪贴板摘录后的回调：交给页面用它自己的新增笔记入口打开编辑器，
+/// 服务本身不负责建编辑器、也不负责存库。
+typedef ClipboardCaptureAccepted = void Function(
+  String content,
+  String? author,
+  String? source,
+);
 
 class ClipboardService extends ChangeNotifier {
   static const String _keyEnableClipboardMonitoring =
       'enable_clipboard_monitoring';
 
-  // 常见的引述格式匹配
-  // 可能的出处标识
   // 是否启用剪贴板监控
   bool _enableClipboardMonitoring = false;
   bool get enableClipboardMonitoring => _enableClipboardMonitoring;
@@ -119,25 +119,16 @@ class ClipboardService extends ChangeNotifier {
       _lastProcessedContent = content;
 
       // 提取作者和出处（如果有）
-      final extractedInfo = _extractAuthorAndSource(content);
-      String? author = extractedInfo['author'];
-      String? source = extractedInfo['source'];
-      String? matchedSubstring = extractedInfo['matched_substring']; // 获取匹配到的子串
+      final attribution = _extractAttribution(content);
 
       logDebug(
-        '从剪贴板提取信息 - 作者: $author, 出处: $source, 匹配子串长度: ${matchedSubstring?.length}',
+        '从剪贴板提取信息 - 作者: ${attribution.author}, 出处: ${attribution.source}',
       );
 
-      // 如果提取到了元数据，从原始内容中移除匹配的子串
-      final displayContent = (matchedSubstring != null)
-          ? content.replaceFirst(matchedSubstring, '').trim()
-          : content;
-
-      // 返回提取的信息
       return {
-        'content': displayContent, // 使用处理后的内容
-        'author': author,
-        'source': source,
+        'content': attribution.content,
+        'author': attribution.author,
+        'source': attribution.source,
       };
     } catch (e) {
       logDebug('检查剪贴板时出错: $e');
@@ -145,158 +136,157 @@ class ClipboardService extends ChangeNotifier {
     }
   }
 
-  // Cache regexes for performance
-  static final RegExp _pattern1 = RegExp(
-    r'[-—–]+\s*([^《（\(]+?)?\s*[《（\(]([^》）\)]+?)[》）\)]\s*$',
-  );
-  static final RegExp _pattern2 = RegExp(
-    r'[《（\(]([^》）\)]+?)[》）\)]\s*[-—–]+\s*([^，。,、\.\n]+)\s*$',
-  );
-  static final RegExp _pattern3 = RegExp(
-    r'["""](.+?)["""]\s*[-—–]+\s*([^，。,、\.\n]+)\s*$',
-  );
-  static final RegExp _pattern4 = RegExp(
-    r'[-—–]+\s*([^，。,、\.\n《（\(]{2,20})\s*$',
-  );
-  static final RegExp _pattern4Source = RegExp(r'[《（\(]([^》）\)]+?)[》）\)]\s*$');
-  static final RegExp _pattern5 = RegExp(r'[《（\(]([^》）\)]+?)[》）\)]\s*$');
-  static final RegExp _pattern5Author = RegExp(
-    r'[-—–]+\s*([^，。,、\.\n《（\(]{2,20})\s*$',
-  );
-  static final RegExp _cleanPattern = RegExp(r'^[—–\-—\s]+|[—–\-—\s]+$');
+  /// 归属分隔符（破折号/连字号）。
+  ///
+  /// 单个 ASCII `-` 只有同一行内前面带空格才算分隔符（"正文 - 作者"）。否则
+  /// `2026-08-15`、`foo-bar`、`https://x.com/a-b` 这类普通文本的尾巴都会被
+  /// 当成"——作者"切走，这是旧实现最常见的误判来源。
+  /// 破折号 `—` `–` 和 `--` 允许跨行，署名单独占一行是常见排版。
+  static const String _dash = r'(?:\s*[—–]+|\s*-{2,}|[ \t]+-)\s*';
 
-  // 从文本中提取作者和出处信息（类似一言格式）
-  // 返回包含 'author', 'source', 'matched_substring' 的 Map
-  Map<String, String?> _extractAuthorAndSource(String content) {
+  /// 兜底提取作者时的候选名。排除句读、书名号和 URL 里的 `:` `/`，
+  /// 长度限制在 2~20，避免把整句话当成作者。
+  static const String _fallbackAuthor =
+      r'[^，。,、\.\n《（\(：:/\\]{2,20}';
+
+  /// 已被书名号锚定的位置，作者名可以放宽一些。
+  static const String _anchoredAuthor = r'[^，。,、\.\n]{1,30}';
+
+  /// 书名号包裹的出处。兜底提取出处时**只认书名号**：
+  /// 中英文圆括号在普通文本里太常见（"今天很开心（真的）"），
+  /// 当出处切走会把正文改坏。
+  static final RegExp _bookTitleSource = RegExp(r'[《〈]([^》〉]+?)[》〉]\s*$');
+
+  // 1. 正文 ——作者《出处》
+  static final RegExp _dashAuthorThenSource = RegExp(
+    '$_dash' r'([^《（\(]+?)?\s*[《（\(]([^》）\)]+?)[》）\)]\s*$',
+  );
+
+  // 2. 正文《出处》——作者
+  static final RegExp _sourceThenDashAuthor = RegExp(
+    r'[《（\(]([^》）\)]+?)[》）\)]' '$_dash' '($_anchoredAuthor)' r'\s*$',
+  );
+
+  // 3. 兜底：正文 ——作者
+  //
+  // “引文”——作者 也走这条：切点是分隔符，引文整体留在正文里，
+  // 不需要单独为引号写一条规则。
+  static final RegExp _dashAuthorOnly = RegExp(
+    '$_dash' '($_fallbackAuthor)' r'\s*$',
+  );
+
+  static final RegExp _cleanPattern = RegExp(r'^[—–\-\s]+|[—–\-\s]+$');
+
+  /// 从文本尾部提取作者和出处（一言式署名），并返回去掉署名后的正文。
+  ///
+  /// 只在**尾部有明确署名标记**（破折号、书名号）时才切；宁可漏判也不误切——
+  /// 切错等于悄悄改用户的笔记正文，比不提取难受得多。
+  _ClipboardAttribution _extractAttribution(String content) {
     final text = content.trim();
-    String? author;
-    String? source;
-    String? matchedSubstring; // 用于存储匹配到的完整元数据子串
 
-    // 定义清理函数，去除前后空格和特定标点
     String? clean(String? input) {
-      return input?.trim().replaceAll(_cleanPattern, '').trim();
+      final cleaned = input?.trim().replaceAll(_cleanPattern, '').trim();
+      return (cleaned == null || cleaned.isEmpty) ? null : cleaned;
     }
 
-    // 1. 匹配 ——作者《出处》 或 --作者《出处》 等
-    final m1 = _pattern1.firstMatch(text);
+    // 署名从 matchStart 开始，前面剩下的才是正文。正文被切空说明整段都是
+    // 署名（比如只复制了一个书名），这种情况保留原文、不做提取。
+    _ClipboardAttribution? cut(int matchStart, String? author, String? source) {
+      final body = text.substring(0, matchStart).trim();
+      if (body.isEmpty) return null;
+      if (author == null && source == null) return null;
+      return _ClipboardAttribution(
+        content: body,
+        author: author,
+        source: source,
+      );
+    }
+
+    // 1. 正文 ——作者《出处》
+    final m1 = _dashAuthorThenSource.firstMatch(text);
     if (m1 != null) {
-      author = clean(m1.group(1));
-      source = clean(m1.group(2));
-      matchedSubstring = m1.group(0);
-      return {
-        'author': author,
-        'source': source,
-        'matched_substring': matchedSubstring,
-      };
+      final result = cut(m1.start, clean(m1.group(1)), clean(m1.group(2)));
+      if (result != null) return result;
     }
 
-    // 2. 匹配 《出处》——作者 或 《出处》--作者 等
-    final m2 = _pattern2.firstMatch(text);
+    // 2. 正文《出处》——作者
+    final m2 = _sourceThenDashAuthor.firstMatch(text);
     if (m2 != null) {
-      source = clean(m2.group(1));
-      author = clean(m2.group(2));
-      matchedSubstring = m2.group(0);
-      return {
-        'author': author,
-        'source': source,
-        'matched_substring': matchedSubstring,
-      };
+      final result = cut(m2.start, clean(m2.group(2)), clean(m2.group(1)));
+      if (result != null) return result;
     }
 
-    // 3. 匹配 "文"——作者 或 "文"--作者 等
-    final m3 = _pattern3.firstMatch(text);
-    if (m3 != null) {
-      // 这种情况通常只提取作者，引用的内容在前面
-      author = clean(m3.group(2));
-      matchedSubstring = m3.group(0);
-      // 注意：这里可能需要更复杂的逻辑来判断是否要提取 source，暂时只提取 author
-      return {
-        'author': author,
-        'source': null,
-        'matched_substring': matchedSubstring,
-      };
+    // 3. 兜底：正文 ——作者（作者前面可能还有一个书名号出处）
+    final m3 = _dashAuthorOnly.firstMatch(text);
+    if (m3 != null && _hasInlineBody(text, m3.start)) {
+      final author = clean(m3.group(1));
+      final beforeAuthor = text.substring(0, m3.start);
+      final sourceMatch = _bookTitleSource.firstMatch(beforeAuthor);
+      if (sourceMatch != null) {
+        final result = cut(
+          sourceMatch.start,
+          author,
+          clean(sourceMatch.group(1)),
+        );
+        if (result != null) return result;
+      }
+      final result = cut(m3.start, author, null);
+      if (result != null) return result;
     }
 
-    // 4. 回退提取作者（匹配末尾的 ——作者 或 --作者）
-    final m4 = _pattern4.firstMatch(text);
+    // 4. 兜底：正文《出处》（出处前面可能还有一个 ——作者）
+    final m4 = _bookTitleSource.firstMatch(text);
     if (m4 != null) {
-      author = clean(m4.group(1));
-      matchedSubstring = m4.group(0);
-      // 尝试在此基础上再提取出处
-      final remainingText = text.substring(
-        0,
-        text.length - matchedSubstring!.length,
-      );
-      final m4Source = _pattern4Source.firstMatch(remainingText);
-      if (m4Source != null) {
-        source = clean(m4Source.group(1));
-        matchedSubstring = text.substring(m4Source.start);
+      final source = clean(m4.group(1));
+      final beforeSource = text.substring(0, m4.start);
+      final authorMatch = _dashAuthorOnly.firstMatch(beforeSource);
+      if (authorMatch != null &&
+          _hasInlineBody(beforeSource, authorMatch.start)) {
+        final result = cut(
+          authorMatch.start,
+          clean(authorMatch.group(1)),
+          source,
+        );
+        if (result != null) return result;
       }
-      return {
-        'author': author,
-        'source': source,
-        'matched_substring': matchedSubstring,
-      };
+      final result = cut(m4.start, null, source);
+      if (result != null) return result;
     }
 
-    // 5. 回退提取出处（匹配末尾的 《出处》 或 （出处））
-    final m5 = _pattern5.firstMatch(text);
-    if (m5 != null) {
-      source = clean(m5.group(1));
-      matchedSubstring = m5.group(0);
-      // 尝试在此基础上再提取作者
-      final remainingText = text.substring(
-        0,
-        text.length - matchedSubstring!.length,
-      );
-      final m5Author = _pattern5Author.firstMatch(remainingText);
-      if (m5Author != null) {
-        author = clean(m5Author.group(1));
-        matchedSubstring = text.substring(m5Author.start);
-      }
-      return {
-        'author': author,
-        'source': source,
-        'matched_substring': matchedSubstring,
-      };
-    }
-
-    // 如果都没有匹配到，返回 null
-    return {'author': null, 'source': null, 'matched_substring': null};
+    return _ClipboardAttribution(content: content);
   }
 
-  // 显示询问对话框并打开编辑页面
-  void showClipboardConfirmationDialog(
+  /// 分隔符所在行前面是否还有正文。
+  ///
+  /// 缩进后的 markdown 列表项（`  - 香蕉`）会命中"空格 + 连字号"的分隔符规则，
+  /// 但它整行都是列表项，前面只有换行和缩进——这种不是署名。
+  bool _hasInlineBody(String text, int separatorStart) =>
+      separatorStart > 0 && !text.substring(0, separatorStart).endsWith('\n');
+
+  /// 弹出"发现剪贴板内容"提示；用户点提示后由 [onAccept] 打开新增笔记入口。
+  ///
+  /// 服务只负责提示和解析，编辑器怎么开、笔记怎么存都交回页面：页面那条路径
+  /// 已经处理了标签加载、"跳过非全屏编辑器"偏好和统一的保存反馈。
+  void showClipboardCapturePrompt(
     BuildContext context,
-    Map<String, dynamic> clipboardData,
-  ) {
+    Map<String, dynamic> clipboardData, {
+    required ClipboardCaptureAccepted onAccept,
+  }) {
     final content = clipboardData['content'] as String;
     final author = clipboardData['author'] as String?;
     final source = clipboardData['source'] as String?;
 
-    // 显示非阻塞式通知
-    showNonBlockingClipboardNotification(context, content, author, source);
-  }
-
-  // 显示非阻塞式剪贴板通知
-  void showNonBlockingClipboardNotification(
-    BuildContext context,
-    String content,
-    String? author,
-    String? source,
-  ) {
     OverlayEntry? backgroundEntry;
     OverlayEntry? cardEntry;
+    var handled = false;
 
-    // 用于记录卡片自身的渲染区域，以区分点卡片和点背景
-    final cardKey = GlobalKey();
-
-    void dismiss({bool openEditor = false}) {
+    void dismiss({bool accepted = false}) {
+      if (handled) return;
+      handled = true;
       if (backgroundEntry?.mounted ?? false) backgroundEntry!.remove();
       if (cardEntry?.mounted ?? false) cardEntry!.remove();
-      if (openEditor && context.mounted) {
-        _openEditPage(context, content, author, source);
+      if (accepted && context.mounted) {
+        onAccept(content, author, source);
       }
     }
 
@@ -319,13 +309,12 @@ class ClipboardService extends ChangeNotifier {
         child: Material(
           color: Colors.transparent,
           child: GestureDetector(
-            // 点卡片本身 → 打开编辑页
-            onTap: () => dismiss(openEditor: true),
+            // 点卡片本身 → 打开新增笔记
+            onTap: () => dismiss(accepted: true),
             // 拦截事件冒泡，防止触发背景层（卡片范围内的事件由此处处理）
             behavior: HitTestBehavior.opaque,
             child: Center(
               child: Container(
-                key: cardKey,
                 constraints: const BoxConstraints(maxWidth: 320),
                 padding: const EdgeInsets.symmetric(
                   horizontal: 16,
@@ -334,8 +323,8 @@ class ClipboardService extends ChangeNotifier {
                 decoration: BoxDecoration(
                   color: Theme.of(overlayContext).colorScheme.surface,
                   borderRadius: BorderRadius.circular(
-                      AppShapeTokens.of(context).dialogRadius),
-                  boxShadow: AppShapeTokens.of(context).restShadow,
+                      AppShapeTokens.of(overlayContext).dialogRadius),
+                  boxShadow: AppShapeTokens.of(overlayContext).restShadow,
                 ),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
@@ -371,95 +360,17 @@ class ClipboardService extends ChangeNotifier {
     // 6 秒自动消失
     Future.delayed(const Duration(seconds: 6), () => dismiss());
   }
+}
 
-  // 打开编辑页面
-  void _openEditPage(
-    BuildContext context,
-    String content,
-    String? author,
-    String? source,
-  ) async {
-    try {
-      // 获取所有标签
-      final databaseService = Provider.of<DatabaseService>(
-        context,
-        listen: false,
-      );
-      final List<NoteTag> tags = await databaseService.getTags();
+/// 剪贴板文本解析结果：去掉署名后的正文，以及识别出的作者/出处。
+class _ClipboardAttribution {
+  const _ClipboardAttribution({
+    required this.content,
+    this.author,
+    this.source,
+  });
 
-      // 防止在异步操作后使用已销毁的BuildContext
-      if (!context.mounted) return;
-
-      // 打开编辑页面
-      showModalBottomSheet(
-        context: context,
-        isScrollControlled: true,
-        backgroundColor: Theme.of(context).brightness == Brightness.light
-            ? Colors.white
-            : Theme.of(context).colorScheme.surface,
-        requestFocus: false,
-        builder: (_) => AddNoteDialog(
-          prefilledContent: content,
-          prefilledAuthor: author,
-          prefilledWork: source,
-          tags: tags,
-          onSave: (quote) => _saveClipboardQuote(context, quote),
-        ),
-      );
-    } catch (e) {
-      logDebug('打开编辑页面失败: $e');
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content:
-                Text('${AppLocalizations.of(context).operationFailed}: $e'),
-            duration: AppConstants.snackBarDurationError,
-          ),
-        );
-      }
-    }
-  }
-
-  Future<void> _saveClipboardQuote(BuildContext context, Quote quote) async {
-    if (!context.mounted) return;
-
-    final databaseService = Provider.of<DatabaseService>(
-      context,
-      listen: false,
-    );
-    final messenger = ScaffoldMessenger.of(context);
-    final l10n = AppLocalizations.of(context);
-
-    try {
-      await databaseService.addQuote(quote);
-      if (!context.mounted) return;
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(l10n.noteSaved),
-          duration: AppConstants.snackBarDurationImportant,
-        ),
-      );
-    } catch (e, stack) {
-      logError(
-        '剪贴板笔记保存失败: id=${quote.id}',
-        error: e,
-        stackTrace: stack,
-        source: 'ClipboardService',
-      );
-      if (!context.mounted) return;
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(l10n.saveFailedWithError(e.toString())),
-          duration: AppConstants.snackBarDurationError,
-          backgroundColor: Colors.red,
-          action: SnackBarAction(
-            label: l10n.retry,
-            onPressed: () {
-              unawaited(_saveClipboardQuote(context, quote));
-            },
-          ),
-        ),
-      );
-    }
-  }
+  final String content;
+  final String? author;
+  final String? source;
 }

--- a/lib/services/clipboard_service.dart
+++ b/lib/services/clipboard_service.dart
@@ -153,9 +153,16 @@ class ClipboardService extends ChangeNotifier {
   /// 破折号 `—` `–` 和 `--` 允许跨行，署名单独占一行是常见排版。
   static const String _dash = r'(?:\s*[—–]+|\s*-{2,}|[ \t]+-)\s*';
 
-  /// 作者候选名。排除句读、书名号和 URL 里的 `:` `/`，长度限制在 2~20，
-  /// 避免把整段说明当成作者。三条规则共用同一套约束。
+  /// 作者候选名。排除句读、书名号和 URL 里的 `:` `/`，长度限制在
+  /// [_authorMinLength]~[_authorMaxLength]，避免把整段说明当成作者。
+  ///
+  /// 字符类里没排掉空白和破折号，所以这里的长度只是初筛：正则可以靠回溯
+  /// 把分隔符塞进候选来凑够下限（"正文——好" 命中的是 `—好`），真正的长度
+  /// 校验在 [_validAuthor] 里、清洗之后做。
   static const String _author = r'[^，。,、\.\n《（\(：:/\\]{2,20}';
+
+  static const int _authorMinLength = 2;
+  static const int _authorMaxLength = 20;
 
   /// 出处**只认书名号**。中英文圆括号在普通文本里太常见
   /// （"今天心情不错（真的好）"），当出处切走会把正文改坏。
@@ -194,6 +201,9 @@ class ClipboardService extends ChangeNotifier {
       return (cleaned == null || cleaned.isEmpty) ? null : cleaned;
     }
 
+    // 清洗掉分隔符和空白之后再量一次长度，见 [_author] 的说明
+    String? validAuthor(String? group) => _validAuthor(clean(group));
+
     // 署名从 matchStart 开始，前面剩下的才是正文。正文被切空说明整段都是
     // 署名（比如只复制了一句"——某人"），这种情况保留原文、不做提取。
     _ClipboardAttribution? cut(int matchStart, String? author, String? source) {
@@ -210,8 +220,14 @@ class ClipboardService extends ChangeNotifier {
     // 1. 正文 ——作者《出处》
     final m1 = _dashAuthorThenSource.firstMatch(text);
     if (m1 != null && _hasInlineBody(text, m1.start)) {
-      final result = cut(m1.start, clean(m1.group(1)), clean(m1.group(2)));
-      if (result != null) return result;
+      // 作者可省略；但凡写了又不合法，整条规则作废——只留出处会把那段
+      // 不合法的作者文本一起从正文里删掉
+      final rawAuthor = clean(m1.group(1));
+      final author = _validAuthor(rawAuthor);
+      if (rawAuthor == null || author != null) {
+        final result = cut(m1.start, author, clean(m1.group(2)));
+        if (result != null) return result;
+      }
     }
 
     // 2. 正文《出处》——作者
@@ -220,18 +236,33 @@ class ClipboardService extends ChangeNotifier {
     // 单独占一行是常见排版，按行首拦会把正常的署名块也拦掉。
     final m2 = _sourceThenDashAuthor.firstMatch(text);
     if (m2 != null) {
-      final result = cut(m2.start, clean(m2.group(2)), clean(m2.group(1)));
-      if (result != null) return result;
+      // 作者不合法就整条作废，同规则 1
+      final author = validAuthor(m2.group(2));
+      if (author != null) {
+        final result = cut(m2.start, author, clean(m2.group(1)));
+        if (result != null) return result;
+      }
     }
 
     // 3. 正文 ——作者
     final m3 = _dashAuthorOnly.firstMatch(text);
     if (m3 != null && _hasInlineBody(text, m3.start)) {
-      final result = cut(m3.start, clean(m3.group(1)), null);
+      final result = cut(m3.start, validAuthor(m3.group(1)), null);
       if (result != null) return result;
     }
 
     return _ClipboardAttribution(content: content);
+  }
+
+  /// 清洗后的作者名是否还站得住。
+  ///
+  /// 正则里的 `{2,20}` 量的是回溯后的原始候选，可能混着破折号和空格；
+  /// 这里量清洗后的真实字数，短到一个字的尾巴（"正文——好"）不算署名。
+  String? _validAuthor(String? cleaned) {
+    if (cleaned == null) return null;
+    final length = cleaned.runes.length;
+    if (length < _authorMinLength || length > _authorMaxLength) return null;
+    return cleaned;
   }
 
   /// 分隔符所在行前面是否还有正文。

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -503,10 +503,19 @@ extension _NoteListItemsExtension on NoteListViewState {
       child: BackdropGroup(
         child: ListView.builder(
           controller: _scrollController, // 添加滚动控制器
-          // 首条笔记与搜索框的间距由卡片自身的 6px 上边距决定，这里不再额外收紧。
-          // ListView 的 padding 会包成 SliverPadding，负值会命中
-          // RenderSliverPadding 的 assert(padding.isNonNegative)：release 关断言
-          // 看不出问题，debug 和测试里 ListView 一挂载就抛异常。
+          // 必须显式给 padding。padding 为 null 时 BoxScrollView 会把
+          // MediaQuery.padding 的主轴部分包成 SliverPadding "帮忙"避开系统栏——
+          // 记录页没有 AppBar，状态栏高度不会被 Scaffold 消费，于是整条状态栏
+          // 高度又被加在了列表顶部。搜索框上方已经自己让开了 topPadding，这里
+          // 再让一次就是白送几十 dp 的空档：先前两次收紧首条卡片上边距
+          // （6 → 4 → 2.67）动的只是那几个像素，看上去当然"没变化"。
+          // 底部同理交回自己控制：Scaffold 有 bottomNavigationBar，body 的
+          // padding.bottom 已被置零，这里取到的就是 0。
+          // 负值仍然不可行——会命中 RenderSliverPadding 的
+          // assert(padding.isNonNegative)，首条间距只能靠卡片自身的上边距收。
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.paddingOf(context).bottom,
+          ),
           findChildIndexCallback: (key) {
             if (key is ValueKey<String>) {
               return rowIndexByKey[key.value];
@@ -588,7 +597,7 @@ extension _NoteListItemsExtension on NoteListViewState {
                       isExpanded: isExpanded,
                       isSelected: isSelected,
                       selectionMode: _isExportMode,
-                      // 首条与搜索框之间只隔一层卡片上边距，收紧到默认值的 2/3。
+                      // 首条与搜索框之间只隔这一层卡片上边距。
                       topMarginOverride: index == 0
                           ? QuoteItemWidget.firstItemTopMargin
                           : null,

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -81,10 +81,13 @@ class QuoteItemWidget extends StatefulWidget {
 
   /// 列表首条笔记的上边距。
   ///
-  /// 按用户观感逐步收紧：6.0（= 默认值）→ 4.0 → 2.67，当前是默认值的 4/9。
+  /// 6.0（= 默认值）→ 4.0 → 2.67 收了三轮都看不出变化，因为真正占位的不是它：
+  /// 记录页的 ListView 没写 padding，被 BoxScrollView 自动补上了一整条状态栏
+  /// 高度（见 `note_list_items.dart` 里 ListView 的 padding 注释）。那处补齐后
+  /// 这个值才真正等于搜索框与首条笔记之间的间距，回到 4.0 就够紧了。
   /// 要再调只改这个数，不要动 [defaultCardMarginVertical]（那会连带改变
   /// 卡片之间的间距）。
-  static const double firstItemTopMargin = 2.67;
+  static const double firstItemTopMargin = 4.0;
 
   const QuoteItemWidget({
     super.key,

--- a/test/unit/services/clipboard_service_test.dart
+++ b/test/unit/services/clipboard_service_test.dart
@@ -81,5 +81,88 @@ void main() {
       expect(result['author'], 'Author');
       expect(result['source'], 'Source Book');
     });
+
+    test('keeps the signature line author when it stands on its own line',
+        () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      await Clipboard.setData(
+        const ClipboardData(text: '人生若只如初见\n——纳兰性德'),
+      );
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], '人生若只如初见');
+      expect(result['author'], '纳兰性德');
+    });
+
+    test('cuts the trailing source only, keeping an identical earlier one',
+        () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      await Clipboard.setData(
+        const ClipboardData(text: '《活着》里最重的一句话出自《活着》'),
+      );
+
+      final result = await clipboardService.checkClipboard();
+
+      // 旧实现用 replaceFirst 删掉的是靠前那个同名书名号，正文会被改坏
+      expect(result!['content'], '《活着》里最重的一句话出自');
+      expect(result['source'], '活着');
+    });
+
+    test('does not treat a markdown list item as an author', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '购物清单：\n- 苹果\n  - 香蕉';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], text);
+      expect(result['author'], isNull);
+      expect(result['source'], isNull);
+    });
+
+    test('does not treat a trailing date as an author', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '周会纪要 2026-08-15';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], text);
+      expect(result['author'], isNull);
+    });
+
+    test('does not treat a trailing url tail as an author', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '参考 https://example.com/post/a-bcde';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], text);
+      expect(result['author'], isNull);
+    });
+
+    test('does not treat a trailing parenthetical as a source', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '今天心情不错（真的很好）';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], text);
+      expect(result['source'], isNull);
+    });
+
+    test('keeps the text intact when it is nothing but a signature', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '《人间失格》';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], text);
+      expect(result['source'], isNull);
+    });
   });
 }

--- a/test/unit/services/clipboard_service_test.dart
+++ b/test/unit/services/clipboard_service_test.dart
@@ -219,6 +219,33 @@ void main() {
       expect(result['source'], isNull);
     });
 
+    test('does not accept a single character tail as an author', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '今天就这样了——好';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      // 正则的 {2,20} 量的是回溯后的候选（这里是 `—好`），清洗后只剩一个字，
+      // 不能当署名
+      expect(result!['content'], text);
+      expect(result['author'], isNull);
+    });
+
+    test('drops the whole rule when the author next to a source is too short',
+        () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '一段正文《活着》——好';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      // 作者不合法时不能只取出处，否则"——好"会被悄悄从正文里删掉
+      expect(result!['content'], text);
+      expect(result['author'], isNull);
+      expect(result['source'], isNull);
+    });
+
     test('keeps the text intact when there is nothing but a title', () async {
       clipboardService.setEnableClipboardMonitoring(true);
       const text = '《人间失格》';

--- a/test/unit/services/clipboard_service_test.dart
+++ b/test/unit/services/clipboard_service_test.dart
@@ -99,14 +99,79 @@ void main() {
         () async {
       clipboardService.setEnableClipboardMonitoring(true);
       await Clipboard.setData(
-        const ClipboardData(text: '《活着》里最重的一句话出自《活着》'),
+        const ClipboardData(text: '《活着》里最重的一句话 ——余华《活着》'),
       );
 
       final result = await clipboardService.checkClipboard();
 
       // 旧实现用 replaceFirst 删掉的是靠前那个同名书名号，正文会被改坏
-      expect(result!['content'], '《活着》里最重的一句话出自');
+      expect(result!['content'], '《活着》里最重的一句话');
+      expect(result['author'], '余华');
       expect(result['source'], '活着');
+    });
+
+    test('keeps a book title that is just part of the sentence', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '我最近在读《活着》';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      // 没有署名标记，结尾的书名号是正文的一部分，不能当出处切走
+      expect(result!['content'], text);
+      expect(result['source'], isNull);
+    });
+
+    test('does not treat an indented list item with brackets as attribution',
+        () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '清单：\n  - 香蕉（进口）';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], text);
+      expect(result['author'], isNull);
+      expect(result['source'], isNull);
+    });
+
+    test('does not treat a long explanatory tail as an author', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      const text = '标题\n\n—— 一段很长的说明，包含逗号（附注）';
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], text);
+      expect(result['author'], isNull);
+    });
+
+    test('keeps a bracketed aside in the body while taking the dash author',
+        () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      await Clipboard.setData(
+        const ClipboardData(text: '今天心情不错（真的好）——张三'),
+      );
+
+      final result = await clipboardService.checkClipboard();
+
+      // 圆括号不是出处；有破折号署名时只取作者
+      expect(result!['content'], '今天心情不错（真的好）');
+      expect(result['author'], '张三');
+      expect(result['source'], isNull);
+    });
+
+    test('extracts a signature block that stands on its own line', () async {
+      clipboardService.setEnableClipboardMonitoring(true);
+      await Clipboard.setData(
+        const ClipboardData(text: '人生若只如初见\n《木兰花》——纳兰性德'),
+      );
+
+      final result = await clipboardService.checkClipboard();
+
+      expect(result!['content'], '人生若只如初见');
+      expect(result['author'], '纳兰性德');
+      expect(result['source'], '木兰花');
     });
 
     test('does not treat a markdown list item as an author', () async {
@@ -154,7 +219,7 @@ void main() {
       expect(result['source'], isNull);
     });
 
-    test('keeps the text intact when it is nothing but a signature', () async {
+    test('keeps the text intact when there is nothing but a title', () async {
       clipboardService.setEnableClipboardMonitoring(true);
       const text = '《人间失格》';
       await Clipboard.setData(const ClipboardData(text: text));

--- a/test/widget/note_list_view_filter_test.dart
+++ b/test/widget/note_list_view_filter_test.dart
@@ -980,6 +980,51 @@ void main() {
         await tester.pump(const Duration(seconds: 2));
       },
     );
+
+    testWidgets(
+      'does not re-inset the status bar height above the first note',
+      (tester) async {
+        // 记录页没有 AppBar，body 的 MediaQuery.padding.top 保留着状态栏高度。
+        // ListView 的 padding 一旦为 null，BoxScrollView 会把这段高度再补一次，
+        // 首条笔记和搜索框之间就凭空多出几十 dp。
+        tester.view.padding = FakeViewPadding(
+          top: 40 * tester.view.devicePixelRatio,
+        );
+        addTearDown(tester.view.resetPadding);
+
+        final databaseService = _FakeDatabaseService()
+          ..quotesToEmit = [
+            Quote(
+              id: 'quote-1',
+              content: '列表第一条笔记',
+              date: DateTime(2026, 8, 13, 21).toIso8601String(),
+            ),
+          ];
+        final settingsService = _FakeSettingsService();
+
+        await tester.pumpWidget(
+          _TestApp(
+            databaseService: databaseService,
+            settingsService: settingsService,
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final listView = tester.widget<ListView>(find.byType(ListView));
+        expect(listView.padding, isNotNull, reason: 'padding 为 null 会自动补状态栏');
+        expect((listView.padding as EdgeInsets).top, 0);
+
+        // 首条卡片除自身上边距外不再被额外下推
+        final listTop = tester.getTopLeft(find.byType(ListView)).dy;
+        final firstItemTop =
+            tester.getTopLeft(find.byType(QuoteItemWidget).first).dy;
+        expect(firstItemTop - listTop, lessThan(1));
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 2));
+      },
+    );
   });
 }
 

--- a/test/widget/pages/home_page_test.dart
+++ b/test/widget/pages/home_page_test.dart
@@ -193,10 +193,11 @@ class MockClipboardService extends ChangeNotifier implements ClipboardService {
   @override
   Future<Map<String, dynamic>?> checkClipboard() async => null;
   @override
-  void showClipboardConfirmationDialog(
+  void showClipboardCapturePrompt(
     BuildContext context,
-    Map<String, dynamic> clipboardData,
-  ) {}
+    Map<String, dynamic> clipboardData, {
+    required ClipboardCaptureAccepted onAccept,
+  }) {}
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/widget/widgets/quote_item_widget_test.dart
+++ b/test/widget/widgets/quote_item_widget_test.dart
@@ -253,8 +253,9 @@ void main() {
         QuoteItemWidget.firstItemTopMargin,
       );
       expect(firstItemMargin.top, QuoteItemWidget.firstItemTopMargin);
-      // 不锁死具体比例——这个值按观感反复调过（6.0 → 4.0 → 2.67）。这里只锁
-      // 真正的不变量：比默认小、仍然为正，且下边距和左右都不受影响。
+      // 不锁死具体比例——这个值按观感反复调过（6.0 → 4.0 → 2.67 → 4.0，中间那轮
+      // 其实是列表自己补了状态栏高度）。这里只锁真正的不变量：比默认小、
+      // 仍然为正，且下边距和左右都不受影响。
       expect(
         QuoteItemWidget.firstItemTopMargin,
         lessThan(QuoteItemWidget.defaultCardMarginVertical),


### PR DESCRIPTION
## 记录页：搜索框和首条笔记之间的空档

真正占位的不是首条卡片的上边距。`ListView.builder` 没写 `padding`，`BoxScrollView` 在 `padding == null` 时会把 `MediaQuery.padding` 的主轴部分自动包成 `SliverPadding`；记录页没有 AppBar，状态栏高度不会被 Scaffold 消费，于是搜索框自己让开一次、列表又让了一整条状态栏。

前三轮把 `firstItemTopMargin` 从 6.0 收到 4.0 再到 2.67，改的都只是那两三个像素，所以每次都"看不出变化"。

- ListView 改为显式 `padding`（顶部 0，底部沿用 `MediaQuery.paddingOf(context).bottom`，Scaffold 有底部导航栏时本来就是 0）
- `firstItemTopMargin` 回到 4.0——这时它才真正等于搜索框到首条笔记的间距
- 新增 widget 测试：注入 40dp 状态栏，断言 ListView 的 `padding.top == 0`、首条卡片紧跟列表顶部

## 剪贴板快速摘录：保留自动匹配，但只在有明确署名时才切

原实现的兜底规则太宽，会改坏正文：

- 「连字号 + 2~20 字」结尾就算作者 → `周会纪要 2026-08-15` 的 "15"、markdown 列表最后一项 `- 香蕉`、URL 尾巴 `a-bcde` 都被切走当署名
- 出处兜底认圆括号 → `今天心情不错（真的很好）` 的括号内容被当成出处切掉
- 切正文用 `replaceFirst(matchedSubstring, '')`，删的是**靠前**那个同名子串，正文里出现两次相同书名时会改坏笔记
- 服务自己 `showModalBottomSheet` 开 AddNoteDialog，绕过页面的新增笔记入口：「跳过非全屏编辑器」偏好在这条路径上完全失效，保存逻辑重复实现了一遍，里面还有写死的 `Colors.red` / `Colors.white` 和裸 `ScaffoldMessenger`

现在：

- 破折号 `—` `–` `--` 允许跨行（署名单独一行是常见排版），单个 ASCII `-` 必须同一行内前面带空格；缩进的列表项不算署名
- 兜底出处只认书名号 `《》`；作者名排除 URL 字符；正文被切空时保留原文
- 切正文改用匹配下标，不再 `replaceFirst`
- 接受提示后走页面统一的新增笔记入口，服务不再开编辑器、不再存库

新增 8 条回归测试：署名行、重复书名、日期、markdown 列表、URL、圆括号、纯书名。

## 发布流水线：新增 Google Play 用的 AAB

- `flutter-release-build.yml` 新增 `build_aab` 输入，release 模式下额外跑 `flutter build appbundle --flavor standard64 --target-platform=android-arm64`，参数与 APK 完全一致
- 产物**只上传成 workflow artifact**，不进 Release 附件——`.aab` 手机装不了，不该出现在用户的下载列表里
- `build_aab` 默认 `false`；`release.yml` 显式传 `true`，让上架包和这次发版同源（同一个 build number）
- 手动触发/复用的 `build_variant` 默认从 `both` 改成 `standard64`；正式发版仍显式传 `both`，老设备要的 arm32 APK 不受影响

只出 64 位是有意的：arm32Compat 是纯 armeabi-v7a 的兼容变体（关 Impeller、开软件渲染），Google Play 要求应用支持 64 位，纯 32 位 AAB 会被拒；两个 flavor 的 manifest placeholder 不同，也没法合成一个 AAB。

## 验证

本地装了 Flutter 3.47.0 stable 实跑（CI 用的是 3.44.x）：

- `flutter analyze --no-fatal-infos` → 5 个 info，全部是改动之外的既有项
- `flutter test test/unit/services/clipboard_service_test.dart test/unit/android/file_provider_config_test.dart` → 19 passed
- `flutter test test/widget/note_list_view_filter_test.dart test/widget/widgets/quote_item_widget_test.dart` → 42 passed
- `flutter test test/widget/pages/home_page_test.dart test/widget/pages/excerpt_preferences_page_test.dart test/widget/note_list_search_transition_test.dart test/widget/note_list_scroll_controller_test.dart` → 13 passed
- `dart format` 已对改动文件跑过

AAB 那一步没法在本地验证（需要 Android SDK 和签名密钥），但 `--android-project-arg` 对 `flutter build appbundle` 可用、`disable-abi-filtering` 是真实的 Gradle property，都对着 Flutter stable 源码核过。

## 已知遗留

- Android 12+ 每次读剪贴板都会弹系统的"已粘贴"提示，这是系统行为，所以这个开关默认关着是对的
- app 内部自己复制的内容（每日一言、Thoughter 消息、同步码）切出去再回来仍会触发提示。要根治得让这些复制点通知 ClipboardService，涉及 7 个文件，这次没动

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgbThBAw6PtCXVNLdvpcY7


---
_Generated by [Claude Code](https://claude.ai/code/session_01HgbThBAw6PtCXVNLdvpcY7)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复记录页 `ListView` 因默认补齐状态栏而产生的空档；剪贴板摘录改为仅在尾部有破折号署名时才提取，并新增按需构建 Android AAB（默认关闭且不进入 Release）。旧行为：列表重复让开状态栏、剪贴板规则宽泛易误切；新行为：显式移除顶部内边距并将首条上边距复位为 4.0，剪贴板仅在合法署名时提取且作者长度在清洗后校验（一字尾巴不再算署名）。

- 列表：显式 `padding.top = 0`、`padding.bottom = MediaQuery.paddingOf(context).bottom`，首条卡片上边距回到 4.0；新增小部件测试覆盖“状态栏不再被重复让开”。
- 剪贴板：只认尾部破折号署名；ASCII `-` 需同行且前置空格，`—`/`–`/`--` 可跨行；出处只认《》，圆括号不算；作者排除 URL 字符并在清洗后做 2–20 长度校验；按匹配下标切分，正文将被切空时保留原文；支持署名块独立成行；非 debug 日志仅记录是否识别到作者/出处；提示改为仅弹条并回调页面的新增入口，服务不再自行打开编辑器或入库。

**发布与配置**
- `flutter-release-build.yml` 新增 `build_aab`（默认 `false`）：仅 `release` + `standard64` 时构建 arm64 AAB，产物仅上传为 workflow artifact；修正条件表达式，关闭时不会误触发。
- `release.yml` 显式传 `build_aab: true` 且收拢产物时排除 `.aab`；手动/复用默认 `build_variant=standard64`，正式发版仍传 `both`。需要 AAB 时在触发工作流勾选 `build_aab` 后到本次运行的 Artifacts 下载。

<sup>Written for commit f4c52fb4d02a1f547872259968027ad98c2c020c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持按需构建 Android AAB 发布包，并保留为构建产物。
  * 剪贴板内容捕获后先显示提示，确认后进入新增笔记流程，并自动识别作者和出处。

* **问题修复**
  * 改进剪贴板文本解析，减少日期、网址、连字符和列表内容被误识别。
  * 修复笔记列表顶部安全区域重复留白问题。
  * 优化首条笔记卡片的顶部间距。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->