### PR TITLE
记录页首条笔记与搜索框的间距放回 12.0

### DIFF
--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -84,10 +84,13 @@ class QuoteItemWidget extends StatefulWidget {
   /// 6.0（= 默认值）→ 4.0 → 2.67 收了三轮都看不出变化，因为真正占位的不是它：
   /// 记录页的 ListView 没写 padding，被 BoxScrollView 自动补上了一整条状态栏
   /// 高度（见 `note_list_items.dart` 里 ListView 的 padding 注释）。那处补齐后
-  /// 这个值才真正等于搜索框与首条笔记之间的间距，回到 4.0 就够紧了。
+  /// 这个值才真正等于搜索框与首条笔记之间的间距——搜索框容器的下边距是 0，
+  /// 首条卡片上方就只剩这一层。4.0 实测贴得太紧，放回 12.0：正好等于两张卡片
+  /// 之间的间距（上下各 [defaultCardMarginVertical]），首条与搜索框的呼吸感
+  /// 和列表内部一致，又远小于先前那条白送的状态栏高度。
   /// 要再调只改这个数，不要动 [defaultCardMarginVertical]（那会连带改变
   /// 卡片之间的间距）。
-  static const double firstItemTopMargin = 4.0;
+  static const double firstItemTopMargin = 12.0;
 
   const QuoteItemWidget({
     super.key,

--- a/test/widget/widgets/quote_item_widget_test.dart
+++ b/test/widget/widgets/quote_item_widget_test.dart
@@ -253,14 +253,15 @@ void main() {
         QuoteItemWidget.firstItemTopMargin,
       );
       expect(firstItemMargin.top, QuoteItemWidget.firstItemTopMargin);
-      // 不锁死具体比例——这个值按观感反复调过（6.0 → 4.0 → 2.67 → 4.0，中间那轮
-      // 其实是列表自己补了状态栏高度）。这里只锁真正的不变量：比默认小、
-      // 仍然为正，且下边距和左右都不受影响。
+      // 不锁死具体数值——这个值按观感反复调过（6.0 → 4.0 → 2.67 → 4.0 → 12.0，
+      // 中间几轮其实是列表自己补了状态栏高度）。这里只锁真正的不变量：为正、
+      // 不超过两张卡片之间的间距（否则首条就比列表内部还松），
+      // 且下边距和左右都不受影响。
+      expect(QuoteItemWidget.firstItemTopMargin, greaterThan(0));
       expect(
         QuoteItemWidget.firstItemTopMargin,
-        lessThan(QuoteItemWidget.defaultCardMarginVertical),
+        lessThanOrEqualTo(QuoteItemWidget.defaultCardMarginVertical * 2),
       );
-      expect(QuoteItemWidget.firstItemTopMargin, greaterThan(0));
       expect(
         firstItemMargin.bottom,
         QuoteItemWidget.defaultCardMarginVertical,


### PR DESCRIPTION
上一轮（#479）修掉「ListView 重复补状态栏高度」之后，`QuoteItemWidget.firstItemTopMargin` 才真正等于搜索框与首条笔记之间的间距——搜索框容器的下边距是 0，首条卡片上方只剩这一层。但那一轮把它留在了 4.0，实测贴得太紧，首条笔记像是黏在搜索框上。

改成 **12.0**：正好等于两张卡片之间的间距（上下各 `defaultCardMarginVertical = 6.0`），首条与搜索框的呼吸感和列表内部一致，也远小于之前那条白送的状态栏高度。

要再调只改 `lib/widgets/quote_item_widget.dart` 里那一个常量，不要动 `defaultCardMarginVertical`（那会连带改变卡片之间的间距）。

## 测试

`test/widget/widgets/quote_item_widget_test.dart` 里原先锁的 `firstItemTopMargin < defaultCardMarginVertical` 随之作废：那条不变量成立的前提是把这个值当成「收紧量」，现在的约束是「不超过卡片之间的间距」，改锁上界为 2 倍默认值（仍然锁为正、下边距和左右不受影响）。

开发容器里没有 Flutter SDK，`flutter test` / `flutter analyze` 未在本地跑过，依赖 CI 验证。改动只有一个常量和一条断言，已 grep 确认没有其他引用点。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEzQJAqm1NYhr29Q2znMk5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将记录页搜索框与首条笔记的间距从 4.0 调整为 12.0，避免首条笔记“黏在”搜索框上。旧行为：修复去除 ListView 自动补的状态栏高度后，4.0 成为唯一实际间距，过紧；新行为：12.0 (= 2 × `defaultCardMarginVertical`)，与列表内部卡片间距一致。

**评审要点**
- 将 `QuoteItemWidget.firstItemTopMargin` 常量改为 12.0；请勿改动 `defaultCardMarginVertical`（否则会影响卡片间距）。
- 测试更新为：值需大于 0，且不超过 `defaultCardMarginVertical * 2`；底/左右边距断言保持不变。
- 影响范围：仅影响首条卡片与搜索框之间的垂直间距，卡片间距和其它布局不变。

<sup>Written for commit fc2d82e381126b68f8f922dab701994220d9a302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 增加搜索框与首条笔记卡片之间的顶部间距，使页面布局更协调。
  * 保持卡片之间及左右边距的一致性。

* **测试**
  * 更新首条卡片间距校验，确保间距为正值且处于合理范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->