### PR TITLE
perf(note-list): 卡片按入参记忆化，空数据事件不再重建整列表，预览按屏幕封顶解码

### DIFF
--- a/lib/utils/optimized_image_loader.dart
+++ b/lib/utils/optimized_image_loader.dart
@@ -25,6 +25,10 @@ int? decodeSizeFor(double logicalSize, double pixelRatio) =>
 /// 由解码宽度推出总像素预算下的高度上限，见 [decodeHeightBudgetFor]。
 int? decodeHeightBudget(int? decodeWidth) => decodeHeightBudgetFor(decodeWidth);
 
+/// 全屏预览一个维度的解码上限，见 [previewDecodeDimensionFor]。
+int? previewDecodeSizeFor(double logicalSize, double pixelRatio) =>
+    previewDecodeDimensionFor(logicalSize, pixelRatio);
+
 bool isInlineDataImage(String source) => isDataUrl(source);
 
 Uint8List? decodeInlineImageBytes(String source) => tryDecodeDataUrl(source);

--- a/lib/utils/optimized_image_loader_base.dart
+++ b/lib/utils/optimized_image_loader_base.dart
@@ -50,6 +50,23 @@ int? decodeDimensionFor(double logicalSize, double pixelRatio) {
   return devicePixels.round();
 }
 
+/// 全屏预览相对屏幕尺寸的解码放大倍率。
+///
+/// 预览要能捏合放大看细节，所以不能只按屏幕像素解；但**更不能不设上限按原图解**。
+const double previewZoomHeadroom = 2.0;
+
+/// 全屏预览一个维度的解码上限（设备像素）。
+///
+/// 两个维度都传给 `ResizeImage`（走 [ResizeImagePolicy.fit] 等比缩进框内），
+/// 再由 [decodeDimensionFor] 的 [maxDecodeDimension] 封顶，单张最坏
+/// 2048×2048 ≈ 16MB。
+///
+/// 不封顶的代价是实测过的：一张 12MP 照片按原图解就是约 48MB，一次预览就能把
+/// 64MB 的 `imageCache` 整个挤空（性能日志里的 `img=1/1000, bytes=47.6MB`），
+/// 回到列表后每张缩略图都要重新解码，表现就是「滑过图片格外卡」。
+int? previewDecodeDimensionFor(double logicalSize, double pixelRatio) =>
+    decodeDimensionFor(logicalSize * previewZoomHeadroom, pixelRatio);
+
 /// 单张图片的解码总像素预算（宽 × 高）。
 ///
 /// 这是**防炸保险，不是画质旋钮**。只给解码宽度封顶时，高度会按原图比例推算：

--- a/lib/widgets/motion_photo_preview_page.dart
+++ b/lib/widgets/motion_photo_preview_page.dart
@@ -288,7 +288,19 @@ class _MotionPhotoPreviewPageState extends State<MotionPhotoPreviewPage> {
   }
 
   Widget _buildImageContent() {
-    final provider = createOptimizedImageProvider(widget.imageUrl);
+    // 预览**不按原图解码**：一张 12MP 照片解出来约 48MB，一次预览就足以把 64MB 的
+    // imageCache 挤空，回到记录页时每张缩略图都得重新解码（性能日志里
+    // `img=1/1000, bytes=47.6MB` 之后紧接着 `pending=17`、worstRaster 45ms）。
+    // 按屏幕尺寸的 previewZoomHeadroom 倍封顶，捏合放大仍有余量。
+    final logicalSize = MediaQuery.sizeOf(context);
+    final pixelRatio = MediaQuery.devicePixelRatioOf(context);
+    final provider = createOptimizedImageProvider(
+      widget.imageUrl,
+      // 两个维度都给：`ResizeImage` 因此走 fit 策略等比缩进框内，横图竖图都不变形，
+      // 单张解码上界也就被这个框钉死了。
+      cacheWidth: previewDecodeSizeFor(logicalSize.width, pixelRatio),
+      cacheHeight: previewDecodeSizeFor(logicalSize.height, pixelRatio),
+    );
     if (provider == null) {
       return const Center(
         child:

--- a/lib/widgets/note_list/note_list_data_stream.dart
+++ b/lib/widgets/note_list/note_list_data_stream.dart
@@ -2,11 +2,34 @@ part of '../note_list_view.dart';
 
 /// Data stream and subscription management for NoteListViewState.
 extension _NoteListDataStreamExtension on NoteListViewState {
+  /// 数据事件推来的列表是否与当前 `_quotes` **逐条同一个实例**。
+  ///
+  /// `watchQuotes` 每次都重发整个累积列表（`List.from(_currentQuotes)`），而
+  /// `_currentQuotes` 是增量维护的：没被重新查询过的笔记还是原来那批 [Quote]
+  /// 对象。于是"翻到最后一页""重复通知"这类什么都没变的事件可以逐指针比出来。
+  /// [Quote] 全字段 final，同一实例就意味着内容一定没变，跳过重建不可能漏更新。
+  ///
+  /// 这件事值得比：照旧整表替换的话，一个空事件就是一轮整列表 setState。实测
+  /// 首滑期间两个这样的事件重建了 241 次卡片（`built=155` + `built=86`），
+  /// 而列表内容一条都没变。
+  bool _isSameQuoteInstances(List<Quote> list) {
+    if (list.length != _quotes.length) return false;
+    for (var i = 0; i < list.length; i++) {
+      if (!identical(list[i], _quotes[i])) return false;
+    }
+    return true;
+  }
+
   void _scheduleExpandableQuoteCheck() {
+    // **不要**在这里把 _hasExpandableQuoteCached 清成 false。清了之后下面那句
+    // `_hasExpandableQuoteCached != hasExpandable` 比的是刚清掉的值而不是旧答案，
+    // 于是只要列表里有可折叠笔记（常态），每个数据事件都必然多出一次整列表
+    // setState —— 实测日志里数据事件后紧跟的第二轮上百次卡片重建就是它。
+    // 顺带还会让功能引导的目标短暂消失一帧。旧答案留着，新答案算出来再比。
     _hasExpandableQuoteComputed = false;
-    _hasExpandableQuoteCached = false;
 
     if (_quotes.isEmpty) {
+      _hasExpandableQuoteCached = false;
       return;
     }
 
@@ -105,25 +128,36 @@ extension _NoteListDataStreamExtension on NoteListViewState {
           // 列表被整表替换前的偏移，用于事件后校正被夹紧的滚动位置。
           final double? offsetBeforeUpdate = _safeScrollOffset;
 
-          _updateState(() {
-            if (isFirstLoad) {
-              _quotes.clear();
-            }
-            _quotes
-              ..clear()
-              ..addAll(
-                list,
-              ); // Simplified: always replace for consistency, but flag prevents extra sets
-            _hasMore = dbHasMore;
+          // 内容逐条同一实例、分页标志也没变 = 这次事件什么都没改变，
+          // 唯一还需要落地的 _isLoading 由自己的 ValueNotifier 驱动底部指示器，
+          // 不需要整列表重建。两个前提都要：
+          // - 空列表时 _isLoading 决定的是加载态还是空状态，会真的改变树形；
+          // - _hasMore 参与 itemCount，翻转必须走 setState。
+          final bool quotesUnchanged = list.isNotEmpty &&
+              _hasMore == dbHasMore &&
+              _isSameQuoteInstances(list);
+
+          if (quotesUnchanged) {
             _isLoading = isLoadMorePage;
-            _pruneExpansionControllers();
-            // 注意：此处不递增 _resultsVersion。
-            // _initializeDataStream 的 stream 持续接收事件（含 load more），
-            // 若递增则 resultsKey 变化，AnimatedSwitcher 会销毁旧 ListView 并
-            // 创建从偏移量 0 开始的新 ListView，导致列表跳回顶部。
-            // 搜索/筛选切换动画由 _updateStreamSubscription 的首个数据事件负责递增。
-          });
-          _guardScrollAnchorAfterDataEvent(offsetBeforeUpdate);
+          } else {
+            _updateState(() {
+              _quotes
+                ..clear()
+                ..addAll(list);
+              _hasMore = dbHasMore;
+              _isLoading = isLoadMorePage;
+              _pruneExpansionControllers();
+              // 注意：此处不递增 _resultsVersion。
+              // _initializeDataStream 的 stream 持续接收事件（含 load more），
+              // 若递增则 resultsKey 变化，AnimatedSwitcher 会销毁旧 ListView 并
+              // 创建从偏移量 0 开始的新 ListView，导致列表跳回顶部。
+              // 搜索/筛选切换动画由 _updateStreamSubscription 的首个数据事件负责递增。
+            });
+          }
+          // 没换过列表就没有新的夹紧可记；传 null 让它只重试挂起的还原。
+          _guardScrollAnchorAfterDataEvent(
+            quotesUnchanged ? null : offsetBeforeUpdate,
+          );
 
           if (_loadMorePerfRecording &&
               (_quotes.length > _loadMorePerfStartCount || !_hasMore)) {
@@ -132,7 +166,11 @@ extension _NoteListDataStreamExtension on NoteListViewState {
           if (isLoadMorePage) {
             _settleLoadMoreGateAfterPage();
           }
-          _scheduleExpandableQuoteCheck();
+          // 列表没变，"有没有可展开的笔记"就不会变。照常调用反而先把缓存清成
+          // false，再排一次帧回调重算同一个答案。
+          if (!quotesUnchanged) {
+            _scheduleExpandableQuoteCheck();
+          }
 
           if (widget.onGuideTargetsReady != null) {
             WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -392,13 +430,24 @@ extension _NoteListDataStreamExtension on NoteListViewState {
           final bool dbHasMore = db.hasMoreQuotes;
           final double? offsetBeforeUpdate =
               pendingScrollToTop ? null : _safeScrollOffset;
-          _updateState(() {
-            _quotes.clear();
-            _quotes.addAll(list);
-            _hasMore = dbHasMore;
+          // 同 _initializeDataStream：什么都没变的事件不重建整列表。
+          // 还等着归零时不能跳过——那一步要靠这次事件把新结果落地后再 jumpTo(0)。
+          final bool quotesUnchanged = !pendingScrollToTop &&
+              list.isNotEmpty &&
+              _hasMore == dbHasMore &&
+              _isSameQuoteInstances(list);
+          if (quotesUnchanged) {
             _isLoading = isLoadMorePage;
-            _pruneExpansionControllers();
-          });
+          } else {
+            _updateState(() {
+              _quotes
+                ..clear()
+                ..addAll(list);
+              _hasMore = dbHasMore;
+              _isLoading = isLoadMorePage;
+              _pruneExpansionControllers();
+            });
+          }
 
           // 筛选条件变化：新结果的第一次事件到达后回到顶部。
           // 之前依赖 ListView 换 key 重建来隐式归零，现在列表常驻，需显式归零。
@@ -421,7 +470,9 @@ extension _NoteListDataStreamExtension on NoteListViewState {
             // 筛选/排序切换回到第一页后重新预取，让新结果集也覆盖首次快滑。
             _scheduleIdlePrefetch();
           }
-          _scheduleExpandableQuoteCheck();
+          if (!quotesUnchanged) {
+            _scheduleExpandableQuoteCheck();
+          }
 
           if (widget.onGuideTargetsReady != null) {
             WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -432,7 +483,9 @@ extension _NoteListDataStreamExtension on NoteListViewState {
 
           // 没有走"保留滚动位置"分支时，由通用锚点保护兜住列表变短造成的位移。
           if (savedScrollOffset == null) {
-            _guardScrollAnchorAfterDataEvent(offsetBeforeUpdate);
+            _guardScrollAnchorAfterDataEvent(
+              quotesUnchanged ? null : offsetBeforeUpdate,
+            );
           }
 
           // Restore scroll position smoothly (only if preserveScrollPosition is true)

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -422,7 +422,7 @@ extension _NoteListItemsExtension on NoteListViewState {
 
     // 优化：提前创建标签映射，避免在 item builder 中重复计算
     // 将整体复杂度从 O(L * T) 优化为 O(L + T)，其中构建映射为 O(L)，每次查找为 O(1)
-    final tagMap = {for (var t in _effectiveTags) t.id: t};
+    final tagMap = _obtainTagMap();
     final rowIndexByKey = <String, int>{
       for (var i = 0; i < _quotes.length; i++)
         if (_quotes[i].id case final id?) 'note-list-row-$id': i,
@@ -590,75 +590,20 @@ extension _NoteListItemsExtension on NoteListViewState {
 
                   Widget itemWidget = ValueListenableBuilder<bool>(
                     valueListenable: expansionNotifier,
-                    builder: (context, isExpanded, child) => QuoteItemWidget(
+                    builder: (context, isExpanded, child) => _obtainQuoteItem(
+                      quoteId: quoteId,
                       quote: quote,
+                      index: index,
                       tagMap: tagMap,
-                      selectedTagIds: widget.selectedTagIds,
                       isExpanded: isExpanded,
                       isSelected: isSelected,
-                      selectionMode: _isExportMode,
-                      // 首条与搜索框之间只隔这一层卡片上边距。
-                      topMarginOverride: index == 0
-                          ? QuoteItemWidget.firstItemTopMargin
-                          : null,
-                      onToggleExpanded: (expanded) {
-                        if (expansionNotifier.value != expanded) {
-                          expansionNotifier.value = expanded;
-                        }
-                        _expandedItems[quoteId] = expanded;
-
-                        final bool requiresAlignment =
-                            QuoteItemWidget.needsExpansionFor(quote);
-
-                        if (!expanded && requiresAlignment) {
-                          final waitDuration =
-                              QuoteItemWidget.expandCollapseDuration +
-                                  const Duration(milliseconds: 80);
-                          Future.delayed(waitDuration, () {
-                            if (!mounted) return;
-                            WidgetsBinding.instance.addPostFrameCallback((_) {
-                              if (!mounted) return;
-                              unawaited(
-                                _positionAndAlignQuote(
-                                  quoteId,
-                                  index,
-                                  forceAlignToTop: false,
-                                ),
-                              );
-                            });
-                          });
-                        }
-                      },
-                      onEdit: () => widget.onEdit(quote),
-                      // 折叠动画播完后才真正删除：时序由 [NoteItemMotion] 的完成
-                      // 回调驱动，不再用挂钟定时器猜动画什么时候结束。
-                      onDelete: () => _beginNoteDelete(quote),
-                      onAskAI: () => widget.onAskAI(quote),
-                      onGenerateCard: widget.onGenerateCard != null
-                          ? () => widget.onGenerateCard!(quote)
-                          : null,
-                      onExportPdf: () {
-                        HapticFeedback.selectionClick();
-                        _updateState(() {
-                          _isExportMode = true;
-                          _selectedExportNoteIds.clear();
-                          if (quote.id != null) {
-                            _selectedExportNoteIds.add(quote.id!);
-                          }
-                        });
-                      },
-                      onFavorite: widget.onFavorite != null
-                          ? () => widget.onFavorite!(quote)
-                          : null,
-                      onLongPressFavorite: widget.onLongPressFavorite != null
-                          ? () => widget.onLongPressFavorite!(quote)
-                          : null,
-                      favoriteButtonGuideKey: attachFavoriteGuideKey
+                      expansionNotifier: expansionNotifier,
+                      favoriteGuideKey: attachFavoriteGuideKey
                           ? widget.favoriteButtonGuideKey
                           : null,
-                      moreButtonGuideKey:
+                      moreGuideKey:
                           attachMoreGuideKey ? widget.moreButtonGuideKey : null,
-                      foldToggleGuideKey:
+                      foldGuideKey:
                           attachFoldGuideKey ? widget.foldToggleGuideKey : null,
                     ),
                   );
@@ -758,6 +703,167 @@ extension _NoteListItemsExtension on NoteListViewState {
       _reconcileScrollAnchor(null);
       _checkAndFixScrollExtentAnomaly();
     });
+  }
+
+  /// 标签映射表，只在标签本身变化时重建。
+  ///
+  /// 它是 [_obtainQuoteItem] 记忆化键的一员：每次 build 都新建一个 Map 的话，
+  /// 身份永远对不上，记忆化就一次都命不中。
+  Map<String, NoteTag> _obtainTagMap() {
+    final tags = _effectiveTags;
+    final cached = _tagMapCache;
+    if (cached != null && _isSameTagList(_tagMapSource, tags)) {
+      return cached;
+    }
+    final map = {for (final tag in tags) tag.id: tag};
+    _tagMapSource = List<NoteTag>.unmodifiable(tags);
+    _tagMapCache = map;
+    return map;
+  }
+
+  bool _isSameTagList(List<NoteTag>? a, List<NoteTag> b) {
+    if (a == null || a.length != b.length) return false;
+    for (var i = 0; i < b.length; i++) {
+      if (!identical(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  /// 取这条笔记的卡片 widget，输入没变就返回**上一次那个实例**。
+  ///
+  /// 这是整列表重建的主要解药。`Element.updateChild` 里有一条短路：
+  ///
+  /// ```dart
+  /// if (hasSameSuperclass && child.widget == newWidget) { ... }  // framework.dart
+  /// ```
+  ///
+  /// 新旧 widget 是同一个实例时，整棵子树连 build 都不进 —— 也就顺带跳过了
+  /// [QuoteItemWidget] 里那两层 `LayoutBuilder`、折叠判定的 `TextPainter` 和
+  /// `CollapsedRichTextMetrics.plan()`。而这些正是"一次 setState 重建上百张卡片"
+  /// 的全部成本：实测 `built=140` 的那一帧 `worstBuild=89.8ms`。
+  ///
+  /// 记忆化**不会**让卡片错过 Inherited 依赖的更新：主题、语言、
+  /// `context.select` 的那几项设置都由框架直接把依赖它们的 Element 标脏，
+  /// 和父级传下来的是不是同一个 widget 无关。这里挡掉的只有"入参没变"那种重建，
+  /// 而入参正是下面这张键覆盖的东西。
+  ///
+  /// 回调不进键：它们在**调用时**才去读 `widget.onEdit` 一类的最新值，所以父组件
+  /// 换一批回调下来也不需要让缓存失效。只有可空的那几个要记住"当时是不是 null"，
+  /// 因为它决定按钮画不画。
+  Widget _obtainQuoteItem({
+    required String quoteId,
+    required Quote quote,
+    required int index,
+    required Map<String, NoteTag> tagMap,
+    required bool isExpanded,
+    required bool isSelected,
+    required ValueNotifier<bool> expansionNotifier,
+    required GlobalKey? favoriteGuideKey,
+    required GlobalKey? moreGuideKey,
+    required GlobalKey? foldGuideKey,
+  }) {
+    final cached = _quoteItemMemos[quoteId];
+    if (cached != null &&
+        cached.matches(
+          quote: quote,
+          index: index,
+          tagMap: tagMap,
+          selectedTagIds: widget.selectedTagIds,
+          isExpanded: isExpanded,
+          isSelected: isSelected,
+          selectionMode: _isExportMode,
+          hasGenerateCard: widget.onGenerateCard != null,
+          hasFavorite: widget.onFavorite != null,
+          hasLongPressFavorite: widget.onLongPressFavorite != null,
+          favoriteGuideKey: favoriteGuideKey,
+          moreGuideKey: moreGuideKey,
+          foldGuideKey: foldGuideKey,
+        )) {
+      _quoteItemMemoHits++;
+      return cached.widget;
+    }
+
+    _quoteItemMemoMisses++;
+    final built = QuoteItemWidget(
+      quote: quote,
+      tagMap: tagMap,
+      selectedTagIds: widget.selectedTagIds,
+      isExpanded: isExpanded,
+      isSelected: isSelected,
+      selectionMode: _isExportMode,
+      // 首条与搜索框之间只隔这一层卡片上边距。
+      topMarginOverride: index == 0 ? QuoteItemWidget.firstItemTopMargin : null,
+      onToggleExpanded: (expanded) {
+        if (expansionNotifier.value != expanded) {
+          expansionNotifier.value = expanded;
+        }
+        _expandedItems[quoteId] = expanded;
+
+        final bool requiresAlignment = QuoteItemWidget.needsExpansionFor(quote);
+
+        if (!expanded && requiresAlignment) {
+          final waitDuration = QuoteItemWidget.expandCollapseDuration +
+              const Duration(milliseconds: 80);
+          Future.delayed(waitDuration, () {
+            if (!mounted) return;
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted) return;
+              unawaited(
+                _positionAndAlignQuote(
+                  quoteId,
+                  index,
+                  forceAlignToTop: false,
+                ),
+              );
+            });
+          });
+        }
+      },
+      onEdit: () => widget.onEdit(quote),
+      // 折叠动画播完后才真正删除：时序由 [NoteItemMotion] 的完成
+      // 回调驱动，不再用挂钟定时器猜动画什么时候结束。
+      onDelete: () => _beginNoteDelete(quote),
+      onAskAI: () => widget.onAskAI(quote),
+      onGenerateCard: widget.onGenerateCard != null
+          ? () => widget.onGenerateCard!(quote)
+          : null,
+      onExportPdf: () {
+        HapticFeedback.selectionClick();
+        _updateState(() {
+          _isExportMode = true;
+          _selectedExportNoteIds.clear();
+          if (quote.id != null) {
+            _selectedExportNoteIds.add(quote.id!);
+          }
+        });
+      },
+      onFavorite:
+          widget.onFavorite != null ? () => widget.onFavorite!(quote) : null,
+      onLongPressFavorite: widget.onLongPressFavorite != null
+          ? () => widget.onLongPressFavorite!(quote)
+          : null,
+      favoriteButtonGuideKey: favoriteGuideKey,
+      moreButtonGuideKey: moreGuideKey,
+      foldToggleGuideKey: foldGuideKey,
+    );
+
+    _quoteItemMemos[quoteId] = _QuoteItemMemo(
+      widget: built,
+      quote: quote,
+      index: index,
+      tagMap: tagMap,
+      selectedTagIds: widget.selectedTagIds,
+      isExpanded: isExpanded,
+      isSelected: isSelected,
+      selectionMode: _isExportMode,
+      hasGenerateCard: widget.onGenerateCard != null,
+      hasFavorite: widget.onFavorite != null,
+      hasLongPressFavorite: widget.onLongPressFavorite != null,
+      favoriteGuideKey: favoriteGuideKey,
+      moreGuideKey: moreGuideKey,
+      foldGuideKey: foldGuideKey,
+    );
+    return built;
   }
 
   bool _shouldKeepAliveNoteListItem(int index, Quote quote) {
@@ -1372,5 +1478,84 @@ class _SlowItemLayoutSample {
     return '$index:$quoteId:$kind:'
         '${(durationMicros / 1000.0).toStringAsFixed(1)}ms:'
         'h=$oldHeightText→${height.toStringAsFixed(0)}';
+  }
+}
+
+/// [_NoteListItemsExtension._obtainQuoteItem] 的记忆化条目。
+///
+/// 存的是"上次用什么入参建出了哪个 widget"。字段就是那张键 —— 加参数时必须同步
+/// 加到这里，漏一个就会让卡片停在旧数据上。
+@immutable
+class _QuoteItemMemo {
+  const _QuoteItemMemo({
+    required this.widget,
+    required this.quote,
+    required this.index,
+    required this.tagMap,
+    required this.selectedTagIds,
+    required this.isExpanded,
+    required this.isSelected,
+    required this.selectionMode,
+    required this.hasGenerateCard,
+    required this.hasFavorite,
+    required this.hasLongPressFavorite,
+    required this.favoriteGuideKey,
+    required this.moreGuideKey,
+    required this.foldGuideKey,
+  });
+
+  final Widget widget;
+  final Quote quote;
+  final int index;
+  final Map<String, NoteTag> tagMap;
+  final List<String> selectedTagIds;
+  final bool isExpanded;
+  final bool isSelected;
+  final bool selectionMode;
+  final bool hasGenerateCard;
+  final bool hasFavorite;
+  final bool hasLongPressFavorite;
+  final GlobalKey? favoriteGuideKey;
+  final GlobalKey? moreGuideKey;
+  final GlobalKey? foldGuideKey;
+
+  /// [quote] 按实例比：[Quote] 全字段 final，同一实例就是同样的内容。
+  /// [selectedTagIds] 按内容比：父组件常常传一份等价的新列表下来，按身份比会让
+  /// 每次父级重建都全部失效 —— 而那正是最需要命中的场合。
+  bool matches({
+    required Quote quote,
+    required int index,
+    required Map<String, NoteTag> tagMap,
+    required List<String> selectedTagIds,
+    required bool isExpanded,
+    required bool isSelected,
+    required bool selectionMode,
+    required bool hasGenerateCard,
+    required bool hasFavorite,
+    required bool hasLongPressFavorite,
+    required GlobalKey? favoriteGuideKey,
+    required GlobalKey? moreGuideKey,
+    required GlobalKey? foldGuideKey,
+  }) {
+    if (!identical(this.quote, quote) ||
+        this.index != index ||
+        !identical(this.tagMap, tagMap) ||
+        this.isExpanded != isExpanded ||
+        this.isSelected != isSelected ||
+        this.selectionMode != selectionMode ||
+        this.hasGenerateCard != hasGenerateCard ||
+        this.hasFavorite != hasFavorite ||
+        this.hasLongPressFavorite != hasLongPressFavorite ||
+        !identical(this.favoriteGuideKey, favoriteGuideKey) ||
+        !identical(this.moreGuideKey, moreGuideKey) ||
+        !identical(this.foldGuideKey, foldGuideKey)) {
+      return false;
+    }
+    if (identical(this.selectedTagIds, selectedTagIds)) return true;
+    if (this.selectedTagIds.length != selectedTagIds.length) return false;
+    for (var i = 0; i < selectedTagIds.length; i++) {
+      if (this.selectedTagIds[i] != selectedTagIds[i]) return false;
+    }
+    return true;
   }
 }

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -164,6 +164,8 @@ extension _NoteListScrollExtension on NoteListViewState {
     _scrollSessionStartQuoteContentStats = QuoteContent.debugCacheStats();
     _scrollSessionStartQuoteItemStats = QuoteItemWidget.getCacheStats();
     _scrollSessionStartImageEmbedStats = QuillImageEmbedPerfStats.snapshot();
+    _scrollSessionStartMemoHits = _quoteItemMemoHits;
+    _scrollSessionStartMemoMisses = _quoteItemMemoMisses;
     final imageCache = PaintingBinding.instance.imageCache;
     _scrollSessionStartImageCount = imageCache.currentSize;
     _scrollSessionStartImageBytes = imageCache.currentSizeBytes;
@@ -322,6 +324,11 @@ extension _NoteListScrollExtension on NoteListViewState {
     final builtRange = _scrollSessionItemBuildCount == 0
         ? 'none'
         : '$_scrollSessionMinBuiltIndex-$_scrollSessionMaxBuiltIndex';
+    // 卡片记忆化：miss 才是真正建了一张新卡，hit 是被 Element.updateChild 短路掉的
+    // 那些。整列表重建时 hit 应该几乎等于重建的条目数，miss 只剩真正变了的那几条。
+    final itemMemoStats = 'size=${_quoteItemMemos.length},'
+        'hit+${_quoteItemMemoHits - _scrollSessionStartMemoHits},'
+        'miss+${_quoteItemMemoMisses - _scrollSessionStartMemoMisses}';
     final activityStats =
         'stateΔ=${_stateUpdateCount - _scrollSessionStartStateUpdateCount},'
         'buildΔ=${_noteListBuildCount - _scrollSessionStartNoteListBuildCount},'
@@ -356,7 +363,7 @@ extension _NoteListScrollExtension on NoteListViewState {
       'end=${_scrollSessionLastMaxExtent.round()},'
       'range=${_scrollSessionMinMaxExtent.round()}-${_scrollSessionMaxMaxExtent.round()},'
       'changes=$_scrollSessionExtentChangeCount}, '
-      'activity={$activityStats}, '
+      'activity={$activityStats}, itemMemo={$itemMemoStats}, '
       'itemLayout={$itemLayoutStats}, slowLayouts=[$slowLayouts]',
       source: 'NoteListView.Perf',
     );

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -25,8 +25,17 @@ extension _NoteListScrollExtension on NoteListViewState {
     final cacheSize = stats['cacheSize'] ?? 0;
     final cacheHits = stats['cacheHits'] ?? 0;
     final baselineHits = baseline?['cacheHits'];
+    // 头部测宽（日期/位置/天气）每张新卡片必然未命中 —— 日期逐条不同，
+    // 缓存按文本做键。它和 expandWorkUs、planWorkUs 一起把 itemLayout 拆开。
+    final headerMisses = stats['headerMisses'] ?? 0;
+    final headerWork = stats['headerWorkMicros'] ?? 0;
+    final baselineHeaderMisses = baseline?['headerMisses'];
+    final baselineHeaderWork = baseline?['headerWorkMicros'];
     return 'item=$cacheSize,hit=$cacheHits'
-        '${baselineHits == null ? '' : ',Δhit+${cacheHits - baselineHits}'}';
+        '${baselineHits == null ? '' : ',Δhit+${cacheHits - baselineHits}'}'
+        ',headerWorstUs=${stats['headerWorstWorkMicros'] ?? 0}'
+        '${baselineHeaderMisses == null ? '' : ',headerMiss+${headerMisses - baselineHeaderMisses}'}'
+        '${baselineHeaderWork == null ? '' : ',headerWorkUs+${headerWork - baselineHeaderWork}'}';
   }
 
   String _formatSignedInt(int value) {

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -212,6 +212,14 @@ class NoteListViewState extends State<NoteListView> {
   /// 切换时只重建那一格，不会牵动已加载的上百个 item。
   final ValueNotifier<bool> _loadMoreIndicator = ValueNotifier<bool>(true);
 
+  /// 是否还有下一页。
+  ///
+  /// 它直接参与 `itemCount`，所以翻转必须走 setState —— 尾部占位格**不能**常驻。
+  /// 试过把它改成 ValueNotifier 驱动的常驻格子（想省掉整列表重建），但
+  /// `SliverMultiBoxAdaptorElement._extrapolateMaxScrollOffset` 会按已建条目的
+  /// 平均高度去估还没建出来的尾部格：itemCount 常年多一格，`maxScrollExtent`
+  /// 就常年多估一张卡片的高度，等用户真滑到底、那一格以 0 高建出来时再缩回去 ——
+  /// 又是一次"滚动范围骤减 → 偏移被夹紧 → 列表往回弹"。这条路走不通。
   bool _hasMore = true;
   static const int _pageSize = AppConstants.defaultPageSize;
   StreamSubscription<List<Quote>>? _quotesSub;

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -189,6 +189,19 @@ class NoteListViewState extends State<NoteListView> {
   // 分页和懒加载状态
   final List<Quote> _quotes = [];
 
+  /// 按笔记 ID 记住上次建出来的卡片 widget，见 [_obtainQuoteItem]。
+  ///
+  /// 入参没变时返回同一个实例，`Element.updateChild` 会整棵子树短路掉 ——
+  /// 分页落地、父组件重建这类"数据没变却全表重建"的场合因此几乎不要钱。
+  /// 条目数跟着 `_quotes` 走，由 [_pruneExpansionControllers] 一起清理。
+  final Map<String, _QuoteItemMemo> _quoteItemMemos = {};
+  int _quoteItemMemoHits = 0;
+  int _quoteItemMemoMisses = 0;
+
+  /// 标签映射表及其来源，见 [_obtainTagMap]。
+  List<NoteTag>? _tagMapSource;
+  Map<String, NoteTag>? _tagMapCache;
+
   bool _isLoadingBacking = true; // 初始化为 true，避免闪现"无笔记"
 
   /// 分页加载中标志。既是 `_loadMore` 的并发闸门，也决定底部指示器是否可见。
@@ -325,6 +338,8 @@ class NoteListViewState extends State<NoteListView> {
   Map<String, dynamic>? _scrollSessionStartQuoteContentStats;
   Map<String, int>? _scrollSessionStartQuoteItemStats;
   Map<String, int>? _scrollSessionStartImageEmbedStats;
+  int _scrollSessionStartMemoHits = 0;
+  int _scrollSessionStartMemoMisses = 0;
   int _scrollSessionStartImageCount = 0;
   int _scrollSessionStartImageBytes = 0;
   int _scrollSessionItemLayoutCount = 0;
@@ -1056,6 +1071,8 @@ class NoteListViewState extends State<NoteListView> {
       }
       return false;
     });
+    // 记忆化的卡片跟着 `_quotes` 走：笔记不在列表里了就没人再问它，留着只占内存。
+    _quoteItemMemos.removeWhere((id, _) => !activeIds.contains(id));
   }
 
   @override

--- a/lib/widgets/quote_content_widget.dart
+++ b/lib/widgets/quote_content_widget.dart
@@ -255,6 +255,9 @@ class QuoteContent extends StatelessWidget {
         // 折叠富文本真正的排版成本在这里。IR 解析（richText）便宜得多，
         // 只盯着它会以为折叠态已经没有成本了。
         'plan': CollapsedRichTextPlanCache.stats,
+        // 折叠判定：每张卡片首布局都要走一遍，此前完全没有计量，
+        // 见 [_QuotePlainTextLayoutExpansionCache] 的说明。
+        'expansion': _QuotePlainTextLayoutExpansionCache.stats,
       };
 
   /// Returns a compact one-line summary suitable for copy/paste performance logs.
@@ -278,6 +281,9 @@ class QuoteContent extends StatelessWidget {
     final plan = Map<String, dynamic>.from(
       stats['plan'] as Map<String, dynamic>,
     );
+    final expansion = Map<String, dynamic>.from(
+      stats['expansion'] as Map<String, dynamic>,
+    );
 
     final buffer = StringBuffer()
       ..write('doc=${document['cacheSize']}')
@@ -296,7 +302,10 @@ class QuoteContent extends StatelessWidget {
       ..write(',mediaMiss=${media['missCount']}')
       ..write(',plan=${plan['cacheSize']}')
       ..write('/${plan['maxSize']}')
-      ..write(',planWorstUs=${plan['worstWorkMicros']}');
+      ..write(',planWorstUs=${plan['worstWorkMicros']}')
+      ..write(',expand=${expansion['cacheSize']}')
+      ..write('/${expansion['maxSize']}')
+      ..write(',expandWorstUs=${expansion['worstWorkMicros']}');
 
     if (baseline != null) {
       final baselineDocument = Map<String, dynamic>.from(
@@ -310,6 +319,9 @@ class QuoteContent extends StatelessWidget {
       );
       final baselinePlan = Map<String, dynamic>.from(
         baseline['plan'] as Map<String, dynamic>? ?? const {},
+      );
+      final baselineExpansion = Map<String, dynamic>.from(
+        baseline['expansion'] as Map<String, dynamic>? ?? const {},
       );
 
       buffer
@@ -340,7 +352,13 @@ class QuoteContent extends StatelessWidget {
         ..write(',planWorkUs+')
         ..write(_debugIntDelta(plan, baselinePlan, 'workMicros'))
         ..write(',planWorstUs=')
-        ..write(_debugNewWorst(plan, baselinePlan));
+        ..write(_debugNewWorst(plan, baselinePlan))
+        ..write(',expandMiss+')
+        ..write(_debugIntDelta(expansion, baselineExpansion, 'missCount'))
+        ..write(',expandWorkUs+')
+        ..write(_debugIntDelta(expansion, baselineExpansion, 'workMicros'))
+        ..write(',expandWorstUs=')
+        ..write(_debugNewWorst(expansion, baselineExpansion));
     }
 
     return buffer.toString();
@@ -1143,6 +1161,25 @@ class _QuotePlainTextLayoutExpansionCache {
   static const int _maxCacheSize = 300;
   static const int _pruneBatchSize = 50;
 
+  // 这条路是**每张卡片每次首布局都要走一遍**的：它在 `LayoutBuilder` 里跑一次
+  // `TextPainter.layout`（富文本则是一次 `plan()`），就为了回答"要不要展开入口"。
+  // 2026-08-13 的诊断点名它"一个计数器都没有"，于是此后每一轮都只能猜首滑的成本
+  // 落在哪。补上之后，`itemLayout` 总时间减掉 expandWorkUs 和 planWorkUs，
+  // 剩下的才是真正的 widget 布局。
+  static int _hitCount = 0;
+  static int _missCount = 0;
+  static int _workMicros = 0;
+  static int _worstWorkMicros = 0;
+
+  static Map<String, dynamic> get stats => {
+        'cacheSize': _cache.length,
+        'maxSize': _maxCacheSize,
+        'hitCount': _hitCount,
+        'missCount': _missCount,
+        'workMicros': _workMicros,
+        'worstWorkMicros': _worstWorkMicros,
+      };
+
   static bool getOrCreate({
     required Quote quote,
     required TextStyle? style,
@@ -1173,6 +1210,7 @@ class _QuotePlainTextLayoutExpansionCache {
     );
     final existing = _cache.remove(key);
     if (existing != null) {
+      _hitCount++;
       existing.touch();
       _cache[key] = existing;
       return existing.exceedsCollapsedHeight;
@@ -1182,7 +1220,14 @@ class _QuotePlainTextLayoutExpansionCache {
       _pruneOldest();
     }
 
+    final stopwatch = Stopwatch()..start();
     final exceedsCollapsedHeight = builder();
+    stopwatch.stop();
+    _missCount++;
+    _workMicros += stopwatch.elapsedMicroseconds;
+    if (stopwatch.elapsedMicroseconds > _worstWorkMicros) {
+      _worstWorkMicros = stopwatch.elapsedMicroseconds;
+    }
     _cache[key] = _PlainTextLayoutExpansionCacheEntry(
       exceedsCollapsedHeight: exceedsCollapsedHeight,
     );
@@ -1191,6 +1236,10 @@ class _QuotePlainTextLayoutExpansionCache {
 
   static void clear() {
     _cache.clear();
+    _hitCount = 0;
+    _missCount = 0;
+    _workMicros = 0;
+    _worstWorkMicros = 0;
   }
 
   static void _pruneOldest() {

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -139,6 +139,10 @@ class QuoteItemWidget extends StatefulWidget {
   static const int _headerTextWidthPruneBatchSize = 128;
   static int _headerTextWidthCacheHits = 0;
   static int _headerTextWidthCacheMisses = 0;
+  // 每张卡片首布局都要测 1~3 段头部文字（日期、位置、天气），而日期逐条不同，
+  // 缓存按文本做键 ⇒ 首次必然未命中。它是首滑成本的另一个嫌疑人，一并计量。
+  static int _headerTextWidthWorkMicros = 0;
+  static int _headerTextWidthWorstWorkMicros = 0;
 
   /// 清理折叠判断缓存，常用于测试或手动刷新场景。
   static void clearExpansionCache() {
@@ -151,6 +155,8 @@ class QuoteItemWidget extends StatefulWidget {
     _headerTextWidthCache.clear();
     _headerTextWidthCacheHits = 0;
     _headerTextWidthCacheMisses = 0;
+    _headerTextWidthWorkMicros = 0;
+    _headerTextWidthWorstWorkMicros = 0;
   }
 
   /// 获取折叠缓存当前状态，便于调试观察命中率。
@@ -165,6 +171,9 @@ class QuoteItemWidget extends StatefulWidget {
       'cacheSize': _expansionCache.length,
       'cacheHits': _cacheHitCount,
       'expandableCount': expandableCount,
+      'headerMisses': _headerTextWidthCacheMisses,
+      'headerWorkMicros': _headerTextWidthWorkMicros,
+      'headerWorstWorkMicros': _headerTextWidthWorstWorkMicros,
     };
   }
 
@@ -173,6 +182,8 @@ class QuoteItemWidget extends StatefulWidget {
         'cacheSize': _headerTextWidthCache.length,
         'cacheHits': _headerTextWidthCacheHits,
         'cacheMisses': _headerTextWidthCacheMisses,
+        'workMicros': _headerTextWidthWorkMicros,
+        'worstWorkMicros': _headerTextWidthWorstWorkMicros,
       };
 
   /// 测试辅助方法，等价于 [clearExpansionCache]。
@@ -342,6 +353,7 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
     }
 
     QuoteItemWidget._headerTextWidthCacheMisses++;
+    final stopwatch = Stopwatch()..start();
     final textPainter = TextPainter(
       text: TextSpan(text: text, style: style),
       maxLines: 1,
@@ -350,6 +362,13 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
     )..layout();
 
     final width = textPainter.width;
+    stopwatch.stop();
+    QuoteItemWidget._headerTextWidthWorkMicros += stopwatch.elapsedMicroseconds;
+    if (stopwatch.elapsedMicroseconds >
+        QuoteItemWidget._headerTextWidthWorstWorkMicros) {
+      QuoteItemWidget._headerTextWidthWorstWorkMicros =
+          stopwatch.elapsedMicroseconds;
+    }
     if (QuoteItemWidget._headerTextWidthCache.length >=
         QuoteItemWidget._maxHeaderTextWidthCacheSize) {
       final keysToRemove = QuoteItemWidget._headerTextWidthCache.keys

--- a/test/unit/utils/optimized_image_loader_base_test.dart
+++ b/test/unit/utils/optimized_image_loader_base_test.dart
@@ -57,6 +57,47 @@ void main() {
       });
     });
 
+    group('previewDecodeDimensionFor', () {
+      test('按屏幕尺寸留出放大余量，但仍受解码上限约束', () {
+        const logicalWidth = 400.0;
+        const pixelRatio = 2.0;
+
+        expect(
+          previewDecodeDimensionFor(logicalWidth, pixelRatio),
+          (logicalWidth * previewZoomHeadroom * pixelRatio).round(),
+        );
+        // 余量再大也不能越过单维上限，否则封顶就形同虚设。
+        expect(previewDecodeDimensionFor(1200, 3.0), maxDecodeDimension);
+      });
+
+      test('两个维度都封顶后，单张预览的解码内存有硬上界', () {
+        // 这是这条路存在的全部理由：不封顶按原图解，一张 12MP 照片就是约 48MB，
+        // 一次预览足以把 64MB 的 imageCache 挤空，回到列表后缩略图全部要重解。
+        const bytesPerPixel = 4;
+        final worstCaseBytes =
+            maxDecodeDimension * maxDecodeDimension * bytesPerPixel;
+
+        expect(worstCaseBytes < 20 * 1024 * 1024, isTrue);
+        for (final logicalSize in <double>[360, 430, 800, 1600]) {
+          for (final pixelRatio in <double>[1.0, 2.0, 3.5]) {
+            final decoded = previewDecodeDimensionFor(logicalSize, pixelRatio);
+            expect(decoded, isNotNull);
+            expect(
+              decoded! <= maxDecodeDimension,
+              isTrue,
+              reason: 'size=$logicalSize dpr=$pixelRatio',
+            );
+          }
+        }
+      });
+
+      test('非法尺寸或像素比返回 null，沿用不设上限的语义', () {
+        expect(previewDecodeDimensionFor(0, 2.0), isNull);
+        expect(previewDecodeDimensionFor(double.nan, 2.0), isNull);
+        expect(previewDecodeDimensionFor(400, 0), isNull);
+      });
+    });
+
     group('decodeHeightBudgetFor', () {
       test('高度上限乘以解码宽度不超过总像素预算', () {
         for (final width in <int>[160, 688, 1032, 2048]) {

--- a/test/unit/widgets/collapsed_expansion_stats_test.dart
+++ b/test/unit/widgets/collapsed_expansion_stats_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/widgets/quote_content_widget.dart';
+
+/// 折叠判定（`exceedsCollapsedHeightForLayout`）是**每张卡片首次布局都要走一遍**的
+/// 热路径：它在 `LayoutBuilder` 里跑一次 `TextPainter.layout`。
+///
+/// 2026-08-13 的诊断点名它"一个计数器都没有"，于是此后每一轮优化都只能猜首滑的
+/// 成本落在哪。这个测试钉住计量本身：计数器不动 = 日志里那一栏永远是 0 =
+/// 下一轮又要靠猜。
+void main() {
+  Map<String, dynamic> expansionStats() =>
+      QuoteContent.debugCacheStats()['expansion'] as Map<String, dynamic>;
+
+  bool judge(Quote quote) => QuoteContent.exceedsCollapsedHeightForLayout(
+        quote: quote,
+        style: const TextStyle(fontSize: 16, height: 1.5),
+        maxWidth: 300,
+        textDirection: TextDirection.ltr,
+        textScaler: TextScaler.noScaling,
+      );
+
+  setUp(QuoteContent.clearCacheForTesting);
+  tearDown(QuoteContent.clearCacheForTesting);
+
+  test('首次判定记一次 miss，并把实际耗时计进 workMicros', () {
+    final quote = Quote(
+      id: 'judged-1',
+      content: List.filled(40, '折叠判定要真的排一遍版才知道超没超').join('\n'),
+      date: DateTime(2026, 8, 18).toIso8601String(),
+    );
+
+    expect(expansionStats()['missCount'], 0);
+
+    expect(judge(quote), isTrue);
+
+    expect(expansionStats()['missCount'], 1);
+    expect(
+      expansionStats()['workMicros'] as int,
+      greaterThan(0),
+      reason: '真的跑了一次 TextPainter，耗时不该记成 0',
+    );
+    expect(expansionStats()['worstWorkMicros'] as int, greaterThan(0));
+  });
+
+  test('同一条笔记再判定走缓存，只加 hit 不再加 miss', () {
+    final quote = Quote(
+      id: 'judged-2',
+      content: '短到不需要折叠',
+      date: DateTime(2026, 8, 18).toIso8601String(),
+    );
+
+    judge(quote);
+    final workAfterFirst = expansionStats()['workMicros'] as int;
+
+    judge(quote);
+
+    expect(expansionStats()['missCount'], 1);
+    expect(expansionStats()['hitCount'], 1);
+    expect(
+      expansionStats()['workMicros'],
+      workAfterFirst,
+      reason: '命中缓存不该再累加耗时，否则日志会把命中也算成成本',
+    );
+  });
+}

--- a/test/widget/note_list_view_data_event_test.dart
+++ b/test/widget/note_list_view_data_event_test.dart
@@ -13,6 +13,7 @@ import 'package:thoughtecho/models/note_tag.dart';
 import 'package:thoughtecho/models/quote_model.dart';
 import 'package:thoughtecho/services/database_service.dart';
 import 'package:thoughtecho/services/settings_service.dart';
+import 'package:thoughtecho/widgets/note_list/note_item_motion.dart';
 import 'package:thoughtecho/widgets/note_list_view.dart';
 import 'package:thoughtecho/widgets/quote_item_widget.dart';
 
@@ -35,6 +36,12 @@ List<Quote> _makeQuotes(int count, {bool expandable = false}) => [
               .toIso8601String(),
         ),
     ];
+
+/// 探测"列表项有没有被重建"用的是动效层而不是 [QuoteItemWidget]：
+/// 后者会被 `_obtainQuoteItem` 记忆化，重建与否都是同一个实例，测不出重建。
+/// 动效层每次 itemBuilder 都新建，实例变了就说明这一格真的重建过。
+NoteItemMotion _firstItemMotion(WidgetTester tester) =>
+    tester.widget<NoteItemMotion>(find.byType(NoteItemMotion).first);
 
 QuoteItemWidget _firstItem(WidgetTester tester) =>
     tester.widget<QuoteItemWidget>(find.byType(QuoteItemWidget).first);
@@ -78,7 +85,7 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 
-        final itemBefore = _firstItem(tester);
+        final itemBefore = _firstItemMotion(tester);
         final extentBefore = _noteListScrollPosition(tester).maxScrollExtent;
 
         // watchQuotes 每次都重发整个累积列表：分页到底、重复通知推来的就是这样
@@ -88,7 +95,7 @@ void main() {
         await tester.pump(const Duration(milliseconds: 50));
 
         expect(
-          identical(_firstItem(tester), itemBefore),
+          identical(_firstItemMotion(tester), itemBefore),
           isTrue,
           reason: '内容没变的数据事件不应触发整列表重建',
         );
@@ -126,15 +133,61 @@ void main() {
         // 换一批新实例，模拟一次真实的数据变更：这次事件本身必须重建。
         databaseService.emit(_makeQuotes(6, expandable: true), hasMore: true);
         await tester.pump();
-        final afterDataEvent = _firstItem(tester);
+        final afterDataEvent = _firstItemMotion(tester);
 
         // 帧末回调若又排了一次 setState，下一帧就会再换一批 widget 实例。
         await tester.pump();
 
         expect(
-          identical(_firstItem(tester), afterDataEvent),
+          identical(_firstItemMotion(tester), afterDataEvent),
           isTrue,
           reason: '可展开性没变时不该再触发一次整列表重建',
+        );
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 2));
+        await databaseService.disposeStream();
+      },
+    );
+
+    testWidgets(
+      '整列表重建时，入参没变的卡片复用同一个 widget 实例',
+      (tester) async {
+        // 有些重建躲不掉（这里用 `_hasMore` 翻转触发，父组件重建同理）。躲不掉时
+        // 至少要让它便宜：入参没变的卡片返回同一个实例，`Element.updateChild`
+        // 会把整棵子树短路掉，连折叠判定和排版计划都不重跑。
+        final databaseService = _StreamingFakeDatabaseService();
+        final settingsService = _FakeSettingsService();
+        final quotes = _makeQuotes(12);
+
+        await tester.pumpWidget(
+          _TestApp(
+            databaseService: databaseService,
+            settingsService: settingsService,
+          ),
+        );
+        await tester.pump();
+
+        databaseService.emit(quotes, hasMore: true);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final motionBefore = _firstItemMotion(tester);
+        final itemBefore = _firstItem(tester);
+
+        databaseService.emit(quotes, hasMore: false);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(
+          identical(_firstItemMotion(tester), motionBefore),
+          isFalse,
+          reason: '这次事件确实重建了列表，否则下面那条断言不成立',
+        );
+        expect(
+          identical(_firstItem(tester), itemBefore),
+          isTrue,
+          reason: '入参没变的卡片应当复用同一个 widget 实例',
         );
 
         await tester.pumpWidget(const SizedBox.shrink());
@@ -196,7 +249,7 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 
-        final itemBefore = _firstItem(tester);
+        final itemBefore = _firstItemMotion(tester);
 
         // 笔记被编辑过：重新查询出来的是新对象，必须重建。
         databaseService.emit(
@@ -213,7 +266,7 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 50));
 
-        expect(identical(_firstItem(tester), itemBefore), isFalse);
+        expect(identical(_firstItemMotion(tester), itemBefore), isFalse);
         expect(find.text('改过内容的第一条'), findsOneWidget);
 
         await tester.pumpWidget(const SizedBox.shrink());

--- a/test/widget/note_list_view_data_event_test.dart
+++ b/test/widget/note_list_view_data_event_test.dart
@@ -1,0 +1,365 @@
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:thoughtecho/controllers/search_controller.dart';
+import 'package:thoughtecho/gen_l10n/app_localizations.dart';
+import 'package:thoughtecho/models/app_settings.dart';
+import 'package:thoughtecho/models/local_ai_settings.dart';
+import 'package:thoughtecho/models/note_tag.dart';
+import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/services/database_service.dart';
+import 'package:thoughtecho/services/settings_service.dart';
+import 'package:thoughtecho/widgets/note_list_view.dart';
+import 'package:thoughtecho/widgets/quote_item_widget.dart';
+
+int? _listItemCount(WidgetTester tester) {
+  final listView = tester.widget<ListView>(find.byType(ListView));
+  return (listView.childrenDelegate as SliverChildBuilderDelegate)
+      .estimatedChildCount;
+}
+
+/// [expandable] 为真时正文长到超过折叠盒高度，笔记因此带展开入口。
+List<Quote> _makeQuotes(int count, {bool expandable = false}) => [
+      for (var i = 0; i < count; i++)
+        Quote(
+          id: 'quote-$i',
+          content: expandable
+              ? List.filled(30, '数据事件测试笔记 $i 的正文').join('\n')
+              : '数据事件测试笔记 $i',
+          date: DateTime(2026, 8, 17, 9)
+              .subtract(Duration(minutes: i))
+              .toIso8601String(),
+        ),
+    ];
+
+QuoteItemWidget _firstItem(WidgetTester tester) =>
+    tester.widget<QuoteItemWidget>(find.byType(QuoteItemWidget).first);
+
+ScrollPosition _noteListScrollPosition(WidgetTester tester) {
+  final listView = tester.widget<ListView>(find.byType(ListView));
+  for (final element in find
+      .descendant(
+        of: find.byWidget(listView),
+        matching: find.byType(Scrollable),
+      )
+      .evaluate()) {
+    final scrollable = element.widget as Scrollable;
+    if (identical(scrollable.controller, listView.controller)) {
+      return ((element as StatefulElement).state as ScrollableState).position;
+    }
+  }
+  throw StateError('未找到笔记列表的 ScrollPosition');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('NoteListView 数据事件', () {
+    testWidgets(
+      '重复推来同一批笔记实例时不重建列表项',
+      (tester) async {
+        final databaseService = _StreamingFakeDatabaseService();
+        final settingsService = _FakeSettingsService();
+        final quotes = _makeQuotes(12);
+
+        await tester.pumpWidget(
+          _TestApp(
+            databaseService: databaseService,
+            settingsService: settingsService,
+          ),
+        );
+        await tester.pump();
+
+        databaseService.emit(quotes, hasMore: true);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final itemBefore = _firstItem(tester);
+        final extentBefore = _noteListScrollPosition(tester).maxScrollExtent;
+
+        // watchQuotes 每次都重发整个累积列表：分页到底、重复通知推来的就是这样
+        // 一份逐条同一实例的列表，内容一个字都没变。
+        databaseService.emit(quotes, hasMore: true);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(
+          identical(_firstItem(tester), itemBefore),
+          isTrue,
+          reason: '内容没变的数据事件不应触发整列表重建',
+        );
+        expect(
+          _noteListScrollPosition(tester).maxScrollExtent,
+          closeTo(extentBefore, 0.5),
+        );
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 2));
+        await databaseService.disposeStream();
+      },
+    );
+
+    testWidgets(
+      '"有没有可展开笔记"的回填不再多排一次整列表重建',
+      (tester) async {
+        // 数据事件本身重建一次是应该的；此前帧末的可展开性回填会**再**重建一次，
+        // 因为它先把缓存清成 false，再拿新答案和刚清掉的值比。
+        final databaseService = _StreamingFakeDatabaseService();
+        final settingsService = _FakeSettingsService();
+
+        await tester.pumpWidget(
+          _TestApp(
+            databaseService: databaseService,
+            settingsService: settingsService,
+          ),
+        );
+        await tester.pump();
+
+        databaseService.emit(_makeQuotes(6, expandable: true), hasMore: true);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // 换一批新实例，模拟一次真实的数据变更：这次事件本身必须重建。
+        databaseService.emit(_makeQuotes(6, expandable: true), hasMore: true);
+        await tester.pump();
+        final afterDataEvent = _firstItem(tester);
+
+        // 帧末回调若又排了一次 setState，下一帧就会再换一批 widget 实例。
+        await tester.pump();
+
+        expect(
+          identical(_firstItem(tester), afterDataEvent),
+          isTrue,
+          reason: '可展开性没变时不该再触发一次整列表重建',
+        );
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 2));
+        await databaseService.disposeStream();
+      },
+    );
+
+    testWidgets(
+      '翻到最后一页仍然要重建，尾部占位跟着收起',
+      (tester) async {
+        // `_hasMore` 参与 itemCount，所以这次事件必须走 setState。尾部那一格
+        // 不能常驻：常驻会让 maxScrollExtent 长期多估一张卡片的高度。
+        final databaseService = _StreamingFakeDatabaseService();
+        final settingsService = _FakeSettingsService();
+        final quotes = _makeQuotes(12);
+
+        await tester.pumpWidget(
+          _TestApp(
+            databaseService: databaseService,
+            settingsService: settingsService,
+          ),
+        );
+        await tester.pump();
+
+        databaseService.emit(quotes, hasMore: true);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(_listItemCount(tester), quotes.length + 1);
+
+        databaseService.emit(quotes, hasMore: false);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(_listItemCount(tester), quotes.length);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 2));
+        await databaseService.disposeStream();
+      },
+    );
+
+    testWidgets(
+      '推来新的笔记实例时照常重建列表项',
+      (tester) async {
+        final databaseService = _StreamingFakeDatabaseService();
+        final settingsService = _FakeSettingsService();
+
+        await tester.pumpWidget(
+          _TestApp(
+            databaseService: databaseService,
+            settingsService: settingsService,
+          ),
+        );
+        await tester.pump();
+
+        databaseService.emit(_makeQuotes(12), hasMore: true);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final itemBefore = _firstItem(tester);
+
+        // 笔记被编辑过：重新查询出来的是新对象，必须重建。
+        databaseService.emit(
+          [
+            Quote(
+              id: 'quote-0',
+              content: '改过内容的第一条',
+              date: DateTime(2026, 8, 17, 9).toIso8601String(),
+            ),
+            ..._makeQuotes(12).skip(1),
+          ],
+          hasMore: true,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(identical(_firstItem(tester), itemBefore), isFalse);
+        expect(find.text('改过内容的第一条'), findsOneWidget);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump(const Duration(seconds: 2));
+        await databaseService.disposeStream();
+      },
+    );
+  });
+}
+
+class _TestApp extends StatelessWidget {
+  const _TestApp({
+    required this.databaseService,
+    required this.settingsService,
+  });
+
+  final DatabaseService databaseService;
+  final SettingsService settingsService;
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<DatabaseService>.value(value: databaseService),
+        ChangeNotifierProvider<SettingsService>.value(value: settingsService),
+        ChangeNotifierProvider(create: (_) => NoteSearchController()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+        home: Material(
+          child: NoteListView(
+            tags: const <NoteTag>[],
+            selectedTagIds: const [],
+            onTagSelectionChanged: (_) {},
+            searchQuery: '',
+            sortType: 'time',
+            sortAscending: false,
+            onSortChanged: (_, __) {},
+            onSearchChanged: (_) {},
+            onEdit: (_) {},
+            onDelete: (_) {},
+            onAskAI: (_) {},
+            selectedWeathers: const [],
+            selectedDayPeriods: const [],
+            onFilterChanged: (_, __) {},
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StreamingFakeDatabaseService extends DatabaseService {
+  _StreamingFakeDatabaseService() : super.forTesting();
+
+  final StreamController<List<Quote>> _controller =
+      StreamController<List<Quote>>.broadcast();
+  bool _hasMoreQuotes = true;
+
+  @override
+  bool get isInitialized => true;
+
+  @override
+  bool get hasMoreQuotes => _hasMoreQuotes;
+
+  @override
+  Stream<List<Quote>> watchQuotes({
+    List<String>? tagIds,
+    String? categoryId,
+    int limit = 20,
+    String orderBy = 'date DESC',
+    String? searchQuery,
+    List<String>? selectedWeathers,
+    List<String>? selectedDayPeriods,
+    bool includeDeleted = false,
+  }) {
+    return _controller.stream;
+  }
+
+  @override
+  Future<void> loadMoreQuotes({
+    List<String>? tagIds,
+    String? categoryId,
+    String? searchQuery,
+    List<String>? selectedWeathers,
+    List<String>? selectedDayPeriods,
+    bool? includeDeleted,
+    int? refillCount,
+    bool suppressNotify = false,
+  }) async {}
+
+  @override
+  Future<List<NoteTag>> getTags() async => const [];
+
+  /// 真实实现推的是 `List.from(_currentQuotes)`：列表对象是新的，元素是原来那批。
+  void emit(List<Quote> quotes, {required bool hasMore}) {
+    _hasMoreQuotes = hasMore;
+    _controller.add(List<Quote>.from(quotes));
+  }
+
+  Future<void> disposeStream() => _controller.close();
+}
+
+class _FakeSettingsService extends ChangeNotifier implements SettingsService {
+  @override
+  AppSettings get appSettings => AppSettings.defaultSettings();
+
+  @override
+  LocalAISettings get localAISettings => LocalAISettings.defaultSettings();
+
+  @override
+  bool get requireBiometricForHidden => false;
+
+  @override
+  String get noteCardMediaStyle => NoteCardMediaStyle.thumbnail;
+
+  @override
+  bool get showFavoriteButton => true;
+
+  @override
+  bool get enableFirstOpenScrollPerfMonitor => false;
+
+  @override
+  bool get noteListDisableCardShadows => false;
+
+  @override
+  bool get noteListDisableBackdropBlur => false;
+
+  @override
+  bool get showExactTime => false;
+
+  @override
+  bool get showNoteEditTime => false;
+
+  @override
+  String get exportFormat => 'pdf';
+
+  @override
+  bool get prioritizeBoldContentInCollapse => false;
+
+  @override
+  String get noteInsertAnimationType => 'slide';
+
+  @override
+  noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('SettingsService.${invocation.memberName} 未实现');
+}


### PR DESCRIPTION
接着 `docs/note-list-perf-analysis-2026-08-13.md`。两轮日志，三组改动。

## 一、整列表重建太贵（主线）

### 第二轮日志（全小图、未点开过大图）指认的真凶

| session | dataΔ | built | worstBuild | worstFrame | eventWorst | 触发源 |
|---|---|---|---|---|---|---|
| scroll-3 | 1 | 107@0-54 | — | — | 58.3ms | 分页 100→120 |
| scroll-8 | 1 | 119@11-119 | **80.1ms** | 82.4ms | 102.3ms | 分页 |
| scroll-11 | 0 | **140@0-119** | **89.8ms** | 99.6ms | 107.6ms | `widgetΔ=1/depsΔ=1` 父组件重建 |

三次全是**真**事件或父级重建。只挡"内容没变的数据事件"一条都挡不住。

### 改法：卡片按入参记忆化

入参没变就返回**上次那个 widget 实例**，`Element.updateChild` 里的

```dart
if (hasSameSuperclass && child.widget == newWidget) { ... }   // framework.dart:4027
```

会把整棵子树短路掉 —— 连带跳过 `QuoteItemWidget` 里的两层 `LayoutBuilder`、折叠判定的
`TextPainter` 和 `CollapsedRichTextMetrics.plan()`。那 80~90ms 建帧的内容基本就是这些。

键覆盖：quote 实例、index、tagMap、selectedTagIds、展开/选中/多选态、三个引导 key、
三个可空回调的有无。

两个刻意的设计：

- **回调不进键。** 它们在调用时才读 `widget.onEdit` 一类的最新值，所以父组件换一批
  回调下来不需要失效 —— 而父组件重建（scroll-11）恰恰是最需要命中的场合。
- **Inherited 依赖不受影响。** 主题、语言、`context.select` 的那几项设置由框架直接把
  依赖它们的 Element 标脏，和父级传下来的是不是同一个 widget 无关。记忆化挡掉的只有
  "入参没变"那类重建，而入参正是上面那张键。

配套：`tagMap` 改成按标签内容缓存（每次 build 都新建 Map 的话键永远对不上）；记忆化条目
跟着 `_quotes` 在 `_pruneExpansionControllers` 里一起清理。

### 顺带挡住两类白跑的重建

- **空数据事件**：`watchQuotes` 每次重发整个累积列表，而 `_currentQuotes` 是增量维护的，
  没被重新查询过的笔记还是原来那批实例。逐指针比一遍，全同就跳过 `setState`。
- **可展开性回填**：`_scheduleExpandableQuoteCheck` 先把缓存清成 `false`，帧末再拿新答案
  和**刚清掉的值**比 —— 只要列表里有可折叠笔记（常态），每个数据事件都必然**再**排一次
  整列表 `setState`。旧答案留着、算完再比即可，顺带不再让引导目标闪一帧。

### 试过但走不通的一条路（留了注释）

想把 `_hasMore` 也改成 ValueNotifier 驱动的常驻尾部格。实测不行：
`_extrapolateMaxScrollOffset` 会按已建条目的平均高度去估还没建出来的尾部格，`itemCount`
常年多一格，`maxScrollExtent` 就常年多估一张卡片（实测 156.75px，不是占位格的 80px），
滑到底那一格以 0 高建出来时再缩回去 —— 又是一次「滚动范围骤减 → 偏移被夹紧 → 列表回弹」。

## 二、大图预览按原图解码，把整个 imageCache 挤空

第一轮日志里：

```
imageCache={img=1/1000, live=25, pending=17, bytes=47.6MB/64.0MB}
```

缓存里只剩 1 张图占 47.6MB（≈4080×3060，一张 12MP 原图），列表那 31 张缩略图（共 2.1MB）
全被挤掉，紧接着的滑动 `pending=17`、`worstRaster=45.5ms`、`worstFrame=78.2ms`。

`MotionPhotoPreviewPage` 建 provider 时不设任何解码上限，而两种卡片版式都解不出这个数
（缩略图 144×144 = 83KB，通栏约 0.8MB），`imageEmbed` 全程为 0 也排除了 Quill 嵌入。
改成按屏幕尺寸的 2 倍封顶（两维都给，`ResizeImage` 走 `fit` 等比缩进框内），
再由 `maxDecodeDimension` 兜底，单张最坏 2048×2048 ≈ 16MB。

> 注：第二轮日志全程没点开过大图，`imageCache` 稳定在 2.1MB/31 张 —— 这条修的是另一个
> 场景，对第二轮那种纯滑动没有影响。

## 三、读日志的口径变化

性能日志新增 `itemMemo={size=,hit+,miss+}`。

**`built=` 统计的是 itemBuilder 调用次数，记忆化命中时它照样计数**，所以下一轮
`built=140` 大概率还是 140 —— 判断有没有省下来要看 `miss+`：整列表重建时
`miss+` 应该只剩真正变了的那几条。

## 验证

- `flutter analyze --no-fatal-infos lib/`：只剩两条与本次无关的既有 info。
- 新增回归测试 5 条 + 预览解码上限 3 条，每条都验证过**去掉对应修复即失败**
  （分别关掉空事件跳过 / 恢复清缓存写法 / 关掉记忆化，各挂一条，互不重叠）。
- `test/widget/` 全量 276 条 + `test/unit/widgets/` 等 122 条全绿。
- 未做真机复测：这台机器没有设备，实际改善要靠下一轮日志确认。

## 还没动

1. **真·首滑（scroll-1）不在本次射程内**。它 `built=16` 全是**第一次**建出来的卡片，
   记忆化按定义帮不上忙。要继续就得让单张卡片首次建/首次布局更便宜，或者趁静止期
   预热 `plan()` / 折叠判定的缓存（`planMiss+16`、`planWorkUs+14599` 这些现在都落在滚动帧里）。
2. **测量与渲染各排一遍版**：`plan()` 里用测量调色板构造一次 span，
   `_CollapsedRichTextBlock.build` 用主题调色板再构造一次。共用需要把调色板并进 plan 的
   缓存键，改动落在被反复调过的敏感区。
3. **`scrollPreloadThreshold = 0.35`**：记忆化之后分页重建不再贵，这条的意义变小了。
4. **冷启动图片重解**：`imageCache` 纯内存，重启即失，要落盘缩略图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae8WcZAvLbBCUEpWPYm1bM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化全屏图片预览的解码尺寸，在保持清晰度的同时降低内存占用。
  * 优化笔记列表更新与滚动性能，减少不必要的卡片重建，提升浏览流畅度。
  * 改进标签和笔记卡片复用，列表数据未变化时避免重复刷新。
* **界面改进**
  * 统一分页加载占位区域的高度，提升加载过程中的视觉稳定性。
  * 优化展开状态及分页占位内容的处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->