### PR TITLE
⚡ Bolt: [优化 database_backup_service 中的字符串分割以减少 GC 压力]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -90,3 +90,6 @@
 ## 2026-08-14 - [Replace String.split with indexOf and substring to reduce GC pressure]
 **Learning:** `String.split` generates intermediate lists and string tokens, creating high GC pressure when parsing large strings frequently. When rewriting a `for-in` loop with `split` to a `while` loop with `indexOf`, extracting a shared `StringUtils.forEachLine` helper avoids boilerplate while maintaining zero-allocation scanning.
 **Action:** Replace `split('\n')` with `StringUtils.forEachLine` in line-by-line parsers like `DeltaRichTextParser` and `DeltaBuilder` to eliminate temporary list allocations and standardize line scanning across the codebase.
+## 2025-01-20 - [Optimize String splitting to avoid memory allocation]
+**Learning:** Frequent `String.split` generates intermediate lists and strings which puts pressure on GC. Instead manual parsing using `String.indexOf` and `String.substring` minimizes allocations.
+**Action:** Replace `String.split` with manual parsing in high-frequency methods like when parsing `tagIdsString` in `DatabaseBackupService`.

--- a/lib/services/database_backup_service.dart
+++ b/lib/services/database_backup_service.dart
@@ -173,10 +173,20 @@ class DatabaseBackupService {
           // 收集标签信息（稍后批量插入）
           if (tagIdsString != null && tagIdsString.isNotEmpty) {
             final quoteId = quoteData['id'] as String;
-            final tagIds =
-                tagIdsString.split(',').where((id) => id.trim().isNotEmpty);
-            for (final tagId in tagIds) {
-              tagRelations.add({'quote_id': quoteId, 'tag_id': tagId.trim()});
+            int startIndex = 0;
+            while (startIndex < tagIdsString.length) {
+              final commaIndex = tagIdsString.indexOf(',', startIndex);
+              final tagId = commaIndex == -1
+                  ? tagIdsString.substring(startIndex)
+                  : tagIdsString.substring(startIndex, commaIndex);
+
+              final trimmedTagId = tagId.trim();
+              if (trimmedTagId.isNotEmpty) {
+                tagRelations.add({'quote_id': quoteId, 'tag_id': trimmedTagId});
+              }
+
+              if (commaIndex == -1) break;
+              startIndex = commaIndex + 1;
             }
           }
 


### PR DESCRIPTION
💡 **What:**
将 `DatabaseBackupService` 中的 `tagIdsString.split(',')` 替换为了基于 `indexOf` 和 `substring` 的 manual parsing 的 `while` 循环解析方式。

🎯 **Why:**
`String.split` 在频繁调用时（如遍历所有备份条目并解析它们的 tag id）会产生大量的中间对象（如中间 `List` 集合和所有的子字符串）。这会大幅增加垃圾回收（GC）的压力。使用 `indexOf` 进行解析可以做到零列表分配。

📊 **Impact:**
降低了在导入/备份恢复大数据集时由于大量解析操作导致的内存分配及垃圾回收频率，能让主线程更加流畅。

🔬 **Measurement:**
可通过 Flutter DevTools 的 Memory Profiler 对比替换前后的内存分配图，观察到中间 List 分配的减少。并在变更后执行了 `dart format`，`flutter analyze`，并且功能维持原样。

---
*PR created automatically by Jules for task [13184572938283895988](https://jules.google.com/task/13184572938283895988) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化备份导入时的标签解析，将对 `tagIdsString` 的 `split(',')` 替换为基于 `indexOf/substring` 的流式解析。旧行为会创建中间 List 和子字符串；新行为保持 trim 与跳过空项的语义不变，但显著减少分配和 GC，导入更顺畅。

- 审阅要点
  - 覆盖边界输入：前/后置逗号、连续逗号、含空格（如 ",a,, b ,"}），确保仍会 trim 并跳过空值，且插入顺序不变。
  - 仅影响 `DatabaseBackupService` 的标签解析路径，不改动数据结构和写入逻辑。
  - 建议用大数据集导入对比 Memory Profiler，确认临时 List 分配下降；功能回归通过现有导入用例验证。

<sup>Written for commit 16671c92efec30ba6e496ea06ca58637cf3e2455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化笔记标签导入时的字符串解析，减少不必要的内存分配。
  * 保持标签去除空白、跳过空值及关联记录生成等行为不变。

* **文档**
  * 新增字符串解析优化相关的学习笔记。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->