### PR TITLE
🎨 Palette: [补充 AskNoteFloatingButton 的无障碍提示]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -38,3 +38,6 @@
 ## 2026-08-14 - 补充思考过程组件的无障碍提示
 **Learning:** Icon-only buttons or custom interactive widgets (like `InkWell` combined with icons/text) often miss proper semantic context for screen readers. In interactive UI like AI thinking states (expanded/collapsed toggle), visually clear cues (like a rotating chevron) don't naturally translate to screen reader announcements. Using `Semantics` alongside `ExcludeSemantics` on inner components avoids redundant reading and explicitly signals the interaction model (button, expanded state) to visually impaired users.
 **Action:** Always verify that custom interactive components (`InkWell`, `GestureDetector`) wrapping text and icons are wrapped in a `Semantics` widget (providing `button: true`, `label`, and dynamic state properties like `expanded`), and exclude semantics on inner decorative or redundant text nodes.
+## 2026-08-21 - [Add tooltip to FloatingActionButton]
+**Learning:** Found an instance where `FloatingActionButton.extended` lacked a `tooltip` property, which affects accessibility for screen readers. Even if a `label` property provides visual text, a dedicated `tooltip` ensures the action's intent is clearly communicated to assistive technologies.
+**Action:** Always verify that `FloatingActionButton.extended` components have a `tooltip` attribute containing localized strings from `AppLocalizations`.

--- a/lib/widgets/ask_note_widgets.dart
+++ b/lib/widgets/ask_note_widgets.dart
@@ -54,6 +54,7 @@ class AskNoteFloatingButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FloatingActionButton.extended(
+      tooltip: AppLocalizations.of(context).askNote,
       onPressed: () {
         Navigator.of(context).push(
           MaterialPageRoute(


### PR DESCRIPTION
💡 **What:**
在 `AskNoteFloatingButton` 的 `FloatingActionButton.extended` 中添加了缺少的 `tooltip` 属性。

🎯 **Why:**
为了更好的无障碍支持。虽然 `FloatingActionButton.extended` 有可视化的 `label` 文本，但加上专有的 `tooltip` 可以保证在使用屏幕阅读器等辅助设备时，或者鼠标悬停时（在支持的平台上）能准确清晰地获得按键功能的提示语。

📸 **Before/After:**
*(No visual changes to the UI layout; accessibility properties added implicitly)*

♿ **Accessibility:**
增强了屏幕阅读设备识别，提升了无障碍体验。

---
*PR created automatically by Jules for task [5672058928112456670](https://jules.google.com/task/5672058928112456670) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `AskNoteFloatingButton` 的 `FloatingActionButton.extended` 补充 `tooltip`（来自 `AppLocalizations.of(context).askNote`），提升无障碍可读性。此前无 `tooltip`，读屏与桌面悬停无法准确报意图；现在读屏会读取提示，支持的平台将显示悬浮提示。

- 仅新增一行，不影响布局与点击行为；移动端无视觉变化，桌面/Web 增加悬浮提示。
- 更新 `.jules/palette.md` 补充规范；后续 `FloatingActionButton.extended` 应提供本地化 `tooltip`。
- 无需迁移或配置变更。

<sup>Written for commit 0f0655699c0776d328733d418f647e7858f30b8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

