### PR TITLE
fix(sync): 修复 iOS 跨设备同步后笔记照片不显示

### DIFF
--- a/lib/services/database/database_import_export_mixin.dart
+++ b/lib/services/database/database_import_export_mixin.dart
@@ -84,6 +84,10 @@ mixin _DatabaseImportExportMixin on _DatabaseServiceBase {
   Future<void> _triggerPostRestoreMigrations() async {
     logDebug('开始触发恢复/合并后数据迁移与修补任务...', source: 'DatabaseService');
     try {
+      // 必须先把合并进来的媒体绝对路径重定基到本机，再重建引用：
+      // 引用表按修复前的外来路径建立的话，WebDAV 会认为云端附件无人引用而不下载。
+      // 放在最前面是因为它自带兜底、不会抛出，不该被后面的迁移失败带走。
+      await MediaPathRepairService.repairAllQuotes(database: database);
       await patchQuotesDayPeriod();
       await migrateWeatherToKey();
       await migrateDayPeriodToKey();

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -19,6 +19,7 @@ import '../utils/expiring_cache.dart';
 import '../utils/lww_utils.dart';
 import '../utils/sentry_database_tracing.dart';
 import 'large_file_manager.dart';
+import 'media_path_repair_service.dart';
 import 'media_reference_service.dart';
 import 'mmkv_service.dart';
 import 'unified_log_service.dart';
@@ -1045,6 +1046,11 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
   /// 兼容性保证：所有迁移都是向后兼容的，不会破坏现有数据
   Future<void> _performAllDataMigrations() async {
     await _schemaLifecycle.performAllDataMigrations(database);
+    // 文档目录变化（iOS 重装或从系统备份恢复会更换容器 UUID）会让笔记里记录的
+    // 媒体绝对路径整体失效，必须在首屏读取笔记之前重定基。
+    await MediaPathRepairService.repairIfBaseDirChanged(
+      database: database,
+    );
   }
 
   /// 外部调用的统一刷新入口（同步/恢复后使用）

--- a/lib/services/media_path_repair_service.dart
+++ b/lib/services/media_path_repair_service.dart
@@ -1,0 +1,223 @@
+import 'dart:convert';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../models/quote_model.dart';
+import '../utils/app_logger.dart';
+import '../utils/media_path_resolver.dart';
+import 'database_service.dart';
+import 'media_reference_service.dart';
+import 'mmkv_service.dart';
+
+/// 笔记媒体路径存量修复。
+///
+/// 笔记 Delta 里保存的是媒体文件绝对路径，而应用文档目录会在下列场景发生变化：
+///
+/// - 从其它设备同步/恢复笔记（WebDAV、局域网同步、备份还原）；
+/// - iOS 重装或从设备备份恢复后容器 UUID 变化。
+///
+/// 这两种情况都会让老笔记里的路径指向本机不存在的目录：图片渲染不出来，
+/// 媒体引用表也匹配不上，WebDAV 因此认为云端附件"无人引用"而不下载。
+/// 本服务负责把这些失效路径重新指向本机 `media/` 目录，并重建媒体引用。
+class MediaPathRepairService {
+  const MediaPathRepairService._();
+
+  /// 记录上次运行时的应用文档目录，用于发现 iOS 容器路径变化。
+  static const String baseDirKey = 'media_path_base_dir';
+
+  static const int _pageSize = 200;
+
+  /// 应用文档目录相对上次运行发生变化时执行一次修复。
+  ///
+  /// 首次运行（没有历史记录）同样会扫描一次：老用户的库里可能已经存在从其它
+  /// 设备同步进来的失效路径。之后每次启动只是一次 MMKV 读取，命中即返回。
+  static Future<MediaPathRepairReport> repairIfBaseDirChanged({
+    Database? database,
+    MMKVService? mmkvService,
+    String? appPath,
+  }) async {
+    try {
+      final mmkv = mmkvService ?? MMKVService();
+      await mmkv.init();
+
+      final currentPath = p.normalize(
+        appPath ?? (await getApplicationDocumentsDirectory()).path,
+      );
+      final lastPath = mmkv.getString(baseDirKey);
+
+      if (lastPath == currentPath) {
+        return const MediaPathRepairReport.skipped();
+      }
+
+      logInfo(
+        lastPath == null || lastPath.isEmpty
+            ? '首次检查笔记媒体路径基准目录，执行一次存量修复'
+            : '检测到应用文档目录变化，开始修复笔记媒体路径（可能来自重装或系统备份恢复）',
+        source: 'MediaPathRepairService',
+      );
+
+      final report = await repairAllQuotes(
+        database: database,
+        appPath: currentPath,
+      );
+      // 修复失败时不推进水位线，下次启动会重试。
+      if (!report.hasErrors) {
+        await mmkv.setString(baseDirKey, currentPath);
+      }
+      return report;
+    } catch (e, stack) {
+      // 启动路径上的可选修复，失败不能拖垮数据库初始化。
+      logError(
+        '媒体路径基准目录检查失败',
+        error: e,
+        stackTrace: stack,
+        source: 'MediaPathRepairService',
+      );
+      return const MediaPathRepairReport.skipped();
+    }
+  }
+
+  /// 扫描全部笔记，把指向其它设备/旧容器的媒体路径重定基到本机文档目录。
+  ///
+  /// 被改写的笔记会在同一个事务里重建媒体引用，让 WebDAV 的
+  /// "云端附件是否被引用"判断能命中。
+  ///
+  /// 全程只使用传入的 [Database] 句柄，不经过 `DatabaseService` 的查询接口：
+  /// 本方法会在数据库初始化过程中被调用，走查询接口会等待尚未完成的初始化。
+  static Future<MediaPathRepairReport> repairAllQuotes({
+    Database? database,
+    String? appPath,
+  }) async {
+    final db = database ?? DatabaseService().database;
+    final basePath =
+        p.normalize(appPath ?? (await getApplicationDocumentsDirectory()).path);
+
+    int scanned = 0;
+    int repaired = 0;
+    final errors = <String>[];
+
+    try {
+      var offset = 0;
+      while (true) {
+        // 只取含 media 片段的笔记，避免纯文本笔记参与 JSON 解析。
+        final rows = await db.rawQuery(
+          "SELECT id, content, date, delta_content FROM quotes "
+          "WHERE delta_content IS NOT NULL AND delta_content LIKE '%media%' "
+          "ORDER BY id LIMIT ? OFFSET ?",
+          [_pageSize, offset],
+        );
+        if (rows.isEmpty) break;
+
+        final updates = <String, String>{};
+        final repairedQuotes = <Quote>[];
+        for (final row in rows) {
+          scanned++;
+          final id = row['id'] as String?;
+          final deltaContent = row['delta_content'] as String?;
+          if (id == null || deltaContent == null || deltaContent.isEmpty) {
+            continue;
+          }
+
+          try {
+            final result = MediaPathResolver.rebaseDelta(
+              json.decode(deltaContent),
+              basePath,
+            );
+            if (!result.changed) continue;
+
+            final rebasedDelta = json.encode(result.delta);
+            updates[id] = rebasedDelta;
+            repairedQuotes.add(
+              Quote(
+                id: id,
+                content: (row['content'] as String?) ?? '',
+                date: (row['date'] as String?) ?? '',
+                deltaContent: rebasedDelta,
+              ),
+            );
+          } catch (e) {
+            // 单条笔记解析失败不应中断整体修复，但也绝不静默。
+            errors.add('笔记 $id 媒体路径修复失败: $e');
+            logWarning('笔记 $id 媒体路径修复失败: $e', source: 'MediaPathRepairService');
+          }
+        }
+
+        if (updates.isNotEmpty) {
+          await db.transaction((txn) async {
+            final batch = txn.batch();
+            for (final entry in updates.entries) {
+              batch.update(
+                'quotes',
+                {'delta_content': entry.value},
+                where: 'id = ?',
+                whereArgs: [entry.key],
+              );
+            }
+            await batch.commit(noResult: true);
+
+            // 引用表里存的是旧路径，必须按修复后的 Delta 重建，
+            // 否则 WebDAV 仍会因为引用计数为 0 而跳过附件下载。
+            for (final quote in repairedQuotes) {
+              await MediaReferenceService
+                  .syncQuoteMediaReferencesWithTransaction(
+                txn,
+                quote,
+                cachedAppPath: basePath,
+              );
+            }
+          });
+          repaired += updates.length;
+        }
+
+        offset += rows.length;
+        if (rows.length < _pageSize) break;
+      }
+
+      if (repaired > 0) {
+        logInfo(
+          '媒体路径修复完成：扫描 $scanned 条笔记，重写 $repaired 条',
+          source: 'MediaPathRepairService',
+        );
+      } else {
+        logDebug('媒体路径修复完成：扫描 $scanned 条笔记，无需重写',
+            source: 'MediaPathRepairService');
+      }
+    } catch (e, stack) {
+      errors.add('媒体路径修复过程失败: $e');
+      logError(
+        '媒体路径修复过程失败',
+        error: e,
+        stackTrace: stack,
+        source: 'MediaPathRepairService',
+      );
+    }
+
+    return MediaPathRepairReport(
+      scanned: scanned,
+      repaired: repaired,
+      errors: errors,
+    );
+  }
+}
+
+/// 一次媒体路径修复的结果。
+class MediaPathRepairReport {
+  const MediaPathRepairReport({
+    required this.scanned,
+    required this.repaired,
+    this.errors = const [],
+  });
+
+  const MediaPathRepairReport.skipped()
+      : scanned = 0,
+        repaired = 0,
+        errors = const [];
+
+  final int scanned;
+  final int repaired;
+  final List<String> errors;
+
+  bool get hasErrors => errors.isNotEmpty;
+}

--- a/lib/services/media_path_repair_service.dart
+++ b/lib/services/media_path_repair_service.dart
@@ -94,6 +94,7 @@ class MediaPathRepairService {
     final basePath =
         p.normalize(appPath ?? (await getApplicationDocumentsDirectory()).path);
 
+    final stopwatch = Stopwatch()..start();
     int scanned = 0;
     int repaired = 0;
     final errors = <String>[];
@@ -145,30 +146,44 @@ class MediaPathRepairService {
         }
 
         if (updates.isNotEmpty) {
-          await db.transaction((txn) async {
-            final batch = txn.batch();
-            for (final entry in updates.entries) {
-              batch.update(
-                'quotes',
-                {'delta_content': entry.value},
-                where: 'id = ?',
-                whereArgs: [entry.key],
-              );
-            }
-            await batch.commit(noResult: true);
+          try {
+            await db.transaction((txn) async {
+              final batch = txn.batch();
+              for (final entry in updates.entries) {
+                batch.update(
+                  'quotes',
+                  {'delta_content': entry.value},
+                  where: 'id = ?',
+                  whereArgs: [entry.key],
+                );
+              }
+              await batch.commit(noResult: true);
 
-            // 引用表里存的是旧路径，必须按修复后的 Delta 重建，
-            // 否则 WebDAV 仍会因为引用计数为 0 而跳过附件下载。
-            for (final quote in repairedQuotes) {
-              await MediaReferenceService
-                  .syncQuoteMediaReferencesWithTransaction(
-                txn,
-                quote,
-                cachedAppPath: basePath,
-              );
-            }
-          });
-          repaired += updates.length;
+              // 引用表里存的是旧路径，必须按修复后的 Delta 重建，
+              // 否则 WebDAV 仍会因为引用计数为 0 而跳过附件下载。
+              for (final quote in repairedQuotes) {
+                final rebuilt = await MediaReferenceService
+                    .syncQuoteMediaReferencesWithTransaction(
+                  txn,
+                  quote,
+                  cachedAppPath: basePath,
+                );
+                // 引用重建失败必须让整页回滚：若保留已重定基的 Delta 而只丢掉引用，
+                // 下次重试时 rebaseDelta 会判定"无需改写"，这些引用将永远补不回来，
+                // WebDAV 也就永远不会下载对应附件。
+                if (!rebuilt) {
+                  throw _MediaReferenceRebuildFailure(quote.id ?? '(未知ID)');
+                }
+              }
+            });
+            repaired += updates.length;
+          } on _MediaReferenceRebuildFailure catch (e) {
+            errors.add('笔记 ${e.quoteId} 媒体引用重建失败，本页修复已回滚');
+            logWarning(
+              '笔记 ${e.quoteId} 媒体引用重建失败，本页 ${updates.length} 条修复已回滚，将在下次启动重试',
+              source: 'MediaPathRepairService',
+            );
+          }
         }
 
         offset += rows.length;
@@ -177,12 +192,16 @@ class MediaPathRepairService {
 
       if (repaired > 0) {
         logInfo(
-          '媒体路径修复完成：扫描 $scanned 条笔记，重写 $repaired 条',
+          '媒体路径修复完成：扫描 $scanned 条笔记，重写 $repaired 条，'
+          '耗时 ${stopwatch.elapsedMilliseconds}ms',
           source: 'MediaPathRepairService',
         );
       } else {
-        logDebug('媒体路径修复完成：扫描 $scanned 条笔记，无需重写',
-            source: 'MediaPathRepairService');
+        logDebug(
+          '媒体路径修复完成：扫描 $scanned 条笔记，无需重写，'
+          '耗时 ${stopwatch.elapsedMilliseconds}ms',
+          source: 'MediaPathRepairService',
+        );
       }
     } catch (e, stack) {
       errors.add('媒体路径修复过程失败: $e');
@@ -200,6 +219,16 @@ class MediaPathRepairService {
       errors: errors,
     );
   }
+}
+
+/// 媒体引用重建失败的内部信号，用于回滚当前批次的 Delta 改写。
+class _MediaReferenceRebuildFailure implements Exception {
+  const _MediaReferenceRebuildFailure(this.quoteId);
+
+  final String quoteId;
+
+  @override
+  String toString() => '媒体引用重建失败: $quoteId';
 }
 
 /// 一次媒体路径修复的结果。

--- a/lib/services/media_reference_service.dart
+++ b/lib/services/media_reference_service.dart
@@ -215,15 +215,19 @@ class MediaReferenceService {
       final exactCount = exact.first['count'] as int;
       if (exactCount > 0) return exactCount;
 
-      // 兜底：老版本写入的外来绝对路径引用行只能按尾段匹配。前缀通配的 LIKE
-      // 用不上索引，因此只在精确匹配落空时才付这次扫描的代价。
+      // 兜底：老版本写入的外来绝对路径引用行只能按尾段匹配。这里用
+      // substr 做大小写敏感的后缀相等比较——SQLite 的 LIKE 对 ASCII
+      // 默认不区分大小写，会把 `.../images/A.jpg` 误算成 `images/a.jpg`
+      // 的引用，而这在区分大小写的文件系统上是两个不同的文件。
+      // 尾段带上前导分隔符，保证匹配的是完整路径段而非文件名片段。
+      // 该比较用不上索引，因此只在精确匹配落空时才付这次扫描的代价。
+      final posixSuffix = '/$posixTail';
+      final windowsSuffix = '\\$windowsTail';
       final fallback = await db.rawQuery(
         'SELECT COUNT(*) as count FROM $_tableName '
-        "WHERE file_path LIKE ? ESCAPE '\\' OR file_path LIKE ? ESCAPE '\\'",
-        [
-          '%${_escapeLikePattern('/$posixTail')}',
-          '%${_escapeLikePattern('\\$windowsTail')}',
-        ],
+        'WHERE substr(file_path, -length(?)) = ? '
+        'OR substr(file_path, -length(?)) = ?',
+        [posixSuffix, posixSuffix, windowsSuffix, windowsSuffix],
       );
 
       return fallback.first['count'] as int;
@@ -232,12 +236,6 @@ class MediaReferenceService {
       return 0;
     }
   }
-
-  /// 转义 LIKE 模式中的通配符与转义符，配合 SQL 的 `ESCAPE` 子句使用。
-  static String _escapeLikePattern(String value) => value.replaceAllMapped(
-        RegExp(r'[\\%_]'),
-        (match) => '\\${match[0]}',
-      );
 
   /// 获取笔记引用的所有媒体文件
   static Future<List<String>> getReferencedFiles(String quoteId) async {

--- a/lib/services/media_reference_service.dart
+++ b/lib/services/media_reference_service.dart
@@ -10,6 +10,7 @@ import 'package:uuid/uuid.dart';
 
 import '../models/quote_model.dart';
 import '../utils/app_logger.dart';
+import '../utils/media_path_resolver.dart';
 import 'database_service.dart';
 
 /// 媒体文件引用管理服务
@@ -173,6 +174,52 @@ class MediaReferenceService {
       return 0;
     }
   }
+
+  /// 统计云端媒体文件在本地的引用数。
+  ///
+  /// [relativeToMediaRoot] 是相对 `media/` 目录的路径（如 `images/a.jpg`），
+  /// 也就是 WebDAV 上的附件路径。除按本机标准路径精确匹配外，还会兜底匹配
+  /// 尾段相同的历史引用行——老版本会把其它设备的绝对路径原样写进引用表，
+  /// 这类记录无法精确命中，却同样说明"本地有笔记在用这个附件"。
+  ///
+  /// 仅按完整尾段（`media/<子目录>/<文件名>`）匹配，不做同名兜底，
+  /// 因此不会让用户已删除的附件被重新下载。
+  static Future<int> getReferenceCountForMediaRelativePath(
+    String relativeToMediaRoot,
+  ) async {
+    try {
+      final posixTail = MediaPathResolver.mediaRelativeTail(
+        'media/$relativeToMediaRoot',
+      );
+      if (posixTail == null) return 0;
+
+      final windowsTail = posixTail.replaceAll('/', r'\');
+      final db = await database;
+
+      final result = await db.rawQuery(
+        'SELECT COUNT(*) as count FROM $_tableName '
+        'WHERE file_path = ? OR file_path = ? '
+        "OR file_path LIKE ? ESCAPE '\\' OR file_path LIKE ? ESCAPE '\\'",
+        [
+          posixTail,
+          windowsTail,
+          '%${_escapeLikePattern('/$posixTail')}',
+          '%${_escapeLikePattern('\\$windowsTail')}',
+        ],
+      );
+
+      return result.first['count'] as int;
+    } catch (e) {
+      logDebug('统计云端媒体引用计数失败: $e');
+      return 0;
+    }
+  }
+
+  /// 转义 LIKE 模式中的通配符与转义符，配合 SQL 的 `ESCAPE` 子句使用。
+  static String _escapeLikePattern(String value) => value.replaceAllMapped(
+        RegExp(r'[\\%_]'),
+        (match) => '\\${match[0]}',
+      );
 
   /// 获取笔记引用的所有媒体文件
   static Future<List<String>> getReferencedFiles(String quoteId) async {
@@ -1079,8 +1126,9 @@ class MediaReferenceService {
   /// 同步笔记的媒体文件引用（事务内版本）
   static Future<bool> syncQuoteMediaReferencesWithTransaction(
     DatabaseExecutor txn,
-    Quote quote,
-  ) async {
+    Quote quote, {
+    String? cachedAppPath,
+  }) async {
     try {
       final quoteId = quote.id;
       if (quoteId == null) {
@@ -1089,8 +1137,8 @@ class MediaReferenceService {
       }
 
       // 获取应用目录路径缓存，避免循环中多次获取
-      final appDir = await getApplicationDocumentsDirectory();
-      final appPath = path.normalize(appDir.path);
+      final appPath = cachedAppPath ??
+          path.normalize((await getApplicationDocumentsDirectory()).path);
 
       // 先移除该笔记的所有现有引用
       await txn.delete(_tableName, where: 'quote_id = ?', whereArgs: [quoteId]);

--- a/lib/services/media_reference_service.dart
+++ b/lib/services/media_reference_service.dart
@@ -30,6 +30,15 @@ class MediaReferenceService {
     _database = db;
   }
 
+  /// 清除测试用的数据库实例
+  ///
+  /// 测试在 `tearDown` 关闭数据库后必须调用，否则静态字段会继续指向已关闭的
+  /// 句柄，同进程内后续用例会拿到失效连接。
+  @visibleForTesting
+  static void clearDatabaseForTesting() {
+    _database = null;
+  }
+
   /// 获取数据库实例
   static Future<Database> get database async {
     if (_database != null) return _database!;
@@ -196,19 +205,28 @@ class MediaReferenceService {
       final windowsTail = posixTail.replaceAll('/', r'\');
       final db = await database;
 
-      final result = await db.rawQuery(
+      // 先用可命中 idx_media_references_file_path 的精确匹配。修复后的引用都是
+      // 标准相对路径，绝大多数查询到此为止，不会退到下面的全表扫描。
+      final exact = await db.rawQuery(
         'SELECT COUNT(*) as count FROM $_tableName '
-        'WHERE file_path = ? OR file_path = ? '
-        "OR file_path LIKE ? ESCAPE '\\' OR file_path LIKE ? ESCAPE '\\'",
+        'WHERE file_path = ? OR file_path = ?',
+        [posixTail, windowsTail],
+      );
+      final exactCount = exact.first['count'] as int;
+      if (exactCount > 0) return exactCount;
+
+      // 兜底：老版本写入的外来绝对路径引用行只能按尾段匹配。前缀通配的 LIKE
+      // 用不上索引，因此只在精确匹配落空时才付这次扫描的代价。
+      final fallback = await db.rawQuery(
+        'SELECT COUNT(*) as count FROM $_tableName '
+        "WHERE file_path LIKE ? ESCAPE '\\' OR file_path LIKE ? ESCAPE '\\'",
         [
-          posixTail,
-          windowsTail,
           '%${_escapeLikePattern('/$posixTail')}',
           '%${_escapeLikePattern('\\$windowsTail')}',
         ],
       );
 
-      return result.first['count'] as int;
+      return fallback.first['count'] as int;
     } catch (e) {
       logDebug('统计云端媒体引用计数失败: $e');
       return 0;

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -1287,16 +1287,20 @@ class WebDAVSyncService extends ChangeNotifier {
     // 4. 从云端同步本地缺失附件，或清理云端已废弃的孤儿附件（解决“无限复活”Bug）
     for (final stdPath in remoteMediaFiles.keys) {
       if (!localMediaMap.containsKey(stdPath)) {
-        // 拼接成 MediaReferenceService 能够识别的标准本地完整路径或数据库存储相对路径
+        // 下载落盘的目标路径（本机 media 目录下的绝对路径）
         final localFileFullPath = p.join(
           appDir.path,
           'media',
           stdPath.replaceAll('/', p.separator),
         );
 
-        // 校验该云端文件是否在本地数据库中仍有被引用
-        final refCount = await MediaReferenceService.getReferenceCount(
-          localFileFullPath,
+        // 校验该云端文件是否在本地数据库中仍有被引用。
+        // 必须按"相对 media/ 的尾段"匹配：跨设备合并进来的笔记可能仍带着
+        // 其它设备的绝对路径，按本机绝对路径精确查会一律得到 0，
+        // 导致云端附件永远不被下载。
+        final refCount =
+            await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          stdPath,
         );
 
         if (refCount > 0) {

--- a/lib/utils/media_path_resolver.dart
+++ b/lib/utils/media_path_resolver.dart
@@ -1,0 +1,182 @@
+import 'package:path/path.dart' as p;
+
+import 'app_logger.dart';
+import 'path_security_utils.dart';
+
+/// 富文本 Delta 中媒体路径的解析与重定基。
+///
+/// 笔记的 Delta 里保存的是媒体文件的**绝对路径**，而应用文档目录在不同设备、
+/// 甚至同一台设备的不同安装之间并不一致：
+///
+/// - Android：`/data/user/0/<包名>/app_flutter`，只与包名有关，重装后不变，
+///   所有设备上完全相同；
+/// - iOS：`/var/mobile/Containers/Data/Application/<容器UUID>/Documents`，
+///   容器 UUID 每次重装/从备份恢复都会变化，跨设备更是完全不同；
+/// - Windows：与用户名、安装位置有关。
+///
+/// 因此从其它设备（或旧容器）合并进来的笔记，其媒体绝对路径在本机是失效的：
+/// 图片渲染不出来，媒体引用表也匹配不上，WebDAV 同步据此判断"云端附件无人引用"
+/// 而永远不下载。本工具负责把这类路径重新指向**本机**的 `media/` 目录。
+class MediaPathResolver {
+  const MediaPathResolver._();
+
+  /// 永久媒体目录下允许的子目录。与 `MediaFileService` 的落盘目录保持一致
+  /// （`html` 只用于临时目录，不会出现在笔记 Delta 中）。
+  static const Set<String> mediaSubFolders = {'images', 'videos', 'audios'};
+
+  static const String _mediaFolder = 'media';
+
+  /// 从任意来源的媒体路径中提取 `media/<子目录>/<文件名>` 形式的尾段。
+  ///
+  /// 同时接受正斜杠与反斜杠，因此 Windows 导出的
+  /// `C:\Users\x\Documents\media\images\a.jpg` 与 iOS 的
+  /// `/var/mobile/.../Documents/media/images/a.jpg` 都能解析出
+  /// `media/images/a.jpg`。无法识别时返回 `null`（调用方应保持原路径不变）。
+  static String? mediaRelativeTail(String rawPath) {
+    if (rawPath.isEmpty) return null;
+
+    final unified = rawPath.trim().replaceAll('\\', '/');
+    final segments = unified
+        .split('/')
+        .where((segment) => segment.isNotEmpty && segment != '.')
+        .toList();
+
+    // 从后往前找，命中最靠近文件名的那一组 media/<子目录>，避免用户目录里
+    // 恰好也叫 media 的上层目录造成误截。
+    for (var i = segments.length - 3; i >= 0; i--) {
+      if (segments[i] != _mediaFolder) continue;
+      if (!mediaSubFolders.contains(segments[i + 1])) continue;
+
+      final tail = segments.sublist(i);
+      if (tail.contains('..')) return null;
+      return tail.join('/');
+    }
+
+    return null;
+  }
+
+  /// 把笔记中记录的媒体路径解析为**本机**可用的绝对路径。
+  ///
+  /// [appPath] 为当前应用文档目录。以下几种输入都会被归一到本机路径：
+  /// 相对路径（备份包格式）、指向其它设备/旧容器的绝对路径、跨平台分隔符路径。
+  /// 已经位于本机文档目录下的路径按原样返回；无法识别的路径**保持不变**，
+  /// 绝不猜测拼接。
+  static String resolveToLocal(String rawPath, String appPath) {
+    try {
+      if (rawPath.trim().isEmpty) return rawPath;
+
+      var sanitized = rawPath.trim();
+      if (sanitized.startsWith('file://')) {
+        final uri = Uri.tryParse(sanitized);
+        if (uri != null && uri.scheme == 'file') {
+          sanitized = uri.toFilePath();
+        }
+      }
+
+      final normalizedAppPath = p.normalize(appPath);
+
+      // 已经是本机路径：无需改写。
+      if (p.isAbsolute(sanitized)) {
+        final normalized = p.normalize(sanitized);
+        if (normalized == normalizedAppPath ||
+            p.isWithin(normalizedAppPath, normalized)) {
+          return normalized;
+        }
+      }
+
+      final tail = mediaRelativeTail(sanitized);
+      if (tail == null) {
+        // 不是可识别的媒体路径（可能是历史遗留的外部文件引用），保持原样。
+        return rawPath;
+      }
+
+      final rebased = p.join(
+        normalizedAppPath,
+        tail.replaceAll('/', p.separator),
+      );
+
+      // 路径穿越防护：重定基后的路径必须仍落在文档目录内。
+      PathSecurityUtils.validateExtractionPath(rebased, normalizedAppPath);
+      return p.normalize(rebased);
+    } catch (e) {
+      logDebug('媒体路径重定基失败，保持原路径: $rawPath ($e)');
+      return rawPath;
+    }
+  }
+
+  /// 递归重写 Delta JSON 中的媒体路径，使其指向本机文档目录。
+  ///
+  /// 覆盖 `insert.image`、`insert.video` 与 `insert.custom.audio` 三种嵌入，
+  /// 与备份/还原链路处理的嵌入类型保持一致。
+  static DeltaRebaseResult rebaseDelta(dynamic deltaJson, String appPath) {
+    var changed = false;
+
+    String rewrite(String original) {
+      final resolved = resolveToLocal(original, appPath);
+      if (resolved != original) changed = true;
+      return resolved;
+    }
+
+    dynamic walk(dynamic node) {
+      if (node is Map) {
+        final result = <String, dynamic>{};
+        for (final entry in node.entries) {
+          final key = entry.key.toString();
+          final value = entry.value;
+
+          if (key == 'insert' && value is Map) {
+            result[key] = _rewriteInsert(value, rewrite);
+          } else {
+            result[key] = walk(value);
+          }
+        }
+        return result;
+      }
+
+      if (node is List) {
+        return node.map(walk).toList();
+      }
+
+      return node;
+    }
+
+    final rebased = walk(deltaJson);
+    return DeltaRebaseResult(delta: rebased, changed: changed);
+  }
+
+  static Map<String, dynamic> _rewriteInsert(
+    Map<dynamic, dynamic> insert,
+    String Function(String original) rewrite,
+  ) {
+    final result = Map<String, dynamic>.from(insert);
+
+    for (final key in const ['image', 'video']) {
+      final value = result[key];
+      if (value is String) {
+        result[key] = rewrite(value);
+      }
+    }
+
+    final custom = result['custom'];
+    if (custom is Map) {
+      final rewrittenCustom = Map<String, dynamic>.from(custom);
+      final audio = rewrittenCustom['audio'];
+      if (audio is String) {
+        rewrittenCustom['audio'] = rewrite(audio);
+      }
+      result['custom'] = rewrittenCustom;
+    }
+
+    return result;
+  }
+}
+
+/// [MediaPathResolver.rebaseDelta] 的结果：改写后的 Delta 及是否真的发生了改写。
+class DeltaRebaseResult {
+  const DeltaRebaseResult({required this.delta, required this.changed});
+
+  final dynamic delta;
+
+  /// 为 false 时调用方应跳过写回，避免无谓的数据库更新。
+  final bool changed;
+}

--- a/test/unit/services/media_path_repair_service_test.dart
+++ b/test/unit/services/media_path_repair_service_test.dart
@@ -145,63 +145,26 @@ void main() {
     expect(await deltaOf('q1'), contains('$androidDocs/media/images/a.jpg'));
   });
 
-  group('WebDAV 下载判定所依赖的引用计数', () {
-    test('修复并重建引用后，云端附件能被判定为"仍被引用"', () async {
-      await insertQuote('q1', [
-        {
-          'insert': {'image': '$androidDocs/media/images/a.jpg'},
-        },
-      ]);
+  // 修复链路的端到端断言：路径重定基后，WebDAV 的"云端附件是否被引用"判断
+  // 必须能命中。`getReferenceCountForMediaRelativePath` 自身的匹配语义
+  // 由 media_reference_service_test.dart 覆盖。
+  test('修复并重建引用后，云端附件能被判定为"仍被引用"', () async {
+    await insertQuote('q1', [
+      {
+        'insert': {'image': '$androidDocs/media/images/a.jpg'},
+      },
+    ]);
 
-      await MediaPathRepairService.repairAllQuotes(
-        database: db,
-        appPath: iosContainer,
-      );
+    await MediaPathRepairService.repairAllQuotes(
+      database: db,
+      appPath: iosContainer,
+    );
 
-      expect(
-        await MediaReferenceService.getReferenceCountForMediaRelativePath(
-          'images/a.jpg',
-        ),
-        1,
-      );
-    });
-
-    test('老版本写入的外来绝对路径引用行也能命中，不再漏下载', () async {
-      // 老版本 _normalizeFilePath 遇到非本机前缀会原样存下来源设备的绝对路径
-      await MediaReferenceService.addReference(
-        '$androidDocs/media/images/a.jpg',
-        'q1',
-        cachedAppPath: iosContainer,
-      );
-
-      expect(
-        await MediaReferenceService.getReferenceCountForMediaRelativePath(
-          'images/a.jpg',
-        ),
-        1,
-      );
-    });
-
-    test('无人引用的云端附件仍然计为 0，不会让已删除的照片复活', () async {
-      await MediaReferenceService.addReference(
-        '$iosContainer/media/images/other.jpg',
-        'q1',
-        cachedAppPath: iosContainer,
-      );
-
-      expect(
-        await MediaReferenceService.getReferenceCountForMediaRelativePath(
-          'images/a.jpg',
-        ),
-        0,
-      );
-      // 同名不同目录不算引用
-      expect(
-        await MediaReferenceService.getReferenceCountForMediaRelativePath(
-          'videos/other.jpg',
-        ),
-        0,
-      );
-    });
+    expect(
+      await MediaReferenceService.getReferenceCountForMediaRelativePath(
+        'images/a.jpg',
+      ),
+      1,
+    );
   });
 }

--- a/test/unit/services/media_path_repair_service_test.dart
+++ b/test/unit/services/media_path_repair_service_test.dart
@@ -37,6 +37,7 @@ void main() {
   });
 
   tearDown(() async {
+    MediaReferenceService.clearDatabaseForTesting();
     await db.close();
   });
 
@@ -121,6 +122,27 @@ void main() {
     expect(report.repaired, 1);
     expect(report.hasErrors, isTrue);
     expect(await deltaOf('ok'), contains('$iosContainer/media/images/b.jpg'));
+  });
+
+  test('媒体引用重建失败时整页回滚，并让报告带上错误以阻止水位线推进', () async {
+    await insertQuote('q1', [
+      {
+        'insert': {'image': '$androidDocs/media/images/a.jpg'},
+      },
+    ]);
+
+    // 丢掉引用表，模拟引用重建失败（syncQuoteMediaReferences… 内部吞异常返回 false）
+    await db.execute('DROP TABLE media_references');
+
+    final report = await MediaPathRepairService.repairAllQuotes(
+      database: db,
+      appPath: iosContainer,
+    );
+
+    expect(report.repaired, 0);
+    expect(report.hasErrors, isTrue);
+    // Delta 必须一并回滚：否则下次重试会认为"无需改写"，引用永远补不回来
+    expect(await deltaOf('q1'), contains('$androidDocs/media/images/a.jpg'));
   });
 
   group('WebDAV 下载判定所依赖的引用计数', () {

--- a/test/unit/services/media_path_repair_service_test.dart
+++ b/test/unit/services/media_path_repair_service_test.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:thoughtecho/services/media_path_repair_service.dart';
+import 'package:thoughtecho/services/media_reference_service.dart';
+
+/// 覆盖跨设备同步后媒体照片"同步完成却看不到图"的回归路径：
+/// 合并进来的笔记带着来源设备的绝对路径，本机既渲染不出图片，
+/// WebDAV 也会因为引用计数为 0 而永远不下载云端附件。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const iosContainer =
+      '/var/mobile/Containers/Data/Application/BBBB-2222/Documents';
+  const androidDocs = '/data/user/0/com.shangjin.thoughtecho/app_flutter';
+
+  late Database db;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    db = await openDatabase(inMemoryDatabasePath);
+    await db.execute('''
+      CREATE TABLE quotes(
+        id TEXT PRIMARY KEY,
+        content TEXT,
+        delta_content TEXT,
+        date TEXT
+      )
+    ''');
+    await MediaReferenceService.initializeTable(db);
+    MediaReferenceService.setDatabaseForTesting(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<void> insertQuote(String id, dynamic delta) async {
+    await db.insert('quotes', {
+      'id': id,
+      'content': '正文',
+      'delta_content': delta == null ? null : json.encode(delta),
+      'date': '2026-08-21T00:00:00.000Z',
+    });
+  }
+
+  Future<String?> deltaOf(String id) async {
+    final rows = await db.query(
+      'quotes',
+      columns: ['delta_content'],
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+    return rows.first['delta_content'] as String?;
+  }
+
+  test('把安卓设备同步过来的媒体绝对路径重定基到本机文档目录', () async {
+    await insertQuote('q1', [
+      {
+        'insert': {'image': '$androidDocs/media/images/a.jpg'},
+      },
+      {'insert': '来自安卓的笔记\n'},
+    ]);
+
+    final report = await MediaPathRepairService.repairAllQuotes(
+      database: db,
+      appPath: iosContainer,
+    );
+
+    expect(report.repaired, 1);
+    expect(report.hasErrors, isFalse);
+    expect(
+      await deltaOf('q1'),
+      contains('$iosContainer/media/images/a.jpg'),
+    );
+  });
+
+  test('重复执行不会二次改写，也不会误伤本机路径与纯文本笔记', () async {
+    await insertQuote('q1', [
+      {
+        'insert': {'image': '$iosContainer/media/images/a.jpg'},
+      },
+    ]);
+    await insertQuote('q2', [
+      {'insert': '纯文本，没有媒体\n'},
+    ]);
+
+    final report = await MediaPathRepairService.repairAllQuotes(
+      database: db,
+      appPath: iosContainer,
+    );
+
+    expect(report.repaired, 0);
+    expect(await deltaOf('q1'), contains('$iosContainer/media/images/a.jpg'));
+    expect(await deltaOf('q2'), contains('纯文本，没有媒体'));
+  });
+
+  test('单条笔记 Delta 损坏时继续修复其它笔记，并把错误记入报告', () async {
+    await db.insert('quotes', {
+      'id': 'broken',
+      'content': '正文',
+      'delta_content': '{不是合法的 media JSON',
+      'date': '2026-08-21T00:00:00.000Z',
+    });
+    await insertQuote('ok', [
+      {
+        'insert': {'image': '$androidDocs/media/images/b.jpg'},
+      },
+    ]);
+
+    final report = await MediaPathRepairService.repairAllQuotes(
+      database: db,
+      appPath: iosContainer,
+    );
+
+    expect(report.repaired, 1);
+    expect(report.hasErrors, isTrue);
+    expect(await deltaOf('ok'), contains('$iosContainer/media/images/b.jpg'));
+  });
+
+  group('WebDAV 下载判定所依赖的引用计数', () {
+    test('修复并重建引用后，云端附件能被判定为"仍被引用"', () async {
+      await insertQuote('q1', [
+        {
+          'insert': {'image': '$androidDocs/media/images/a.jpg'},
+        },
+      ]);
+
+      await MediaPathRepairService.repairAllQuotes(
+        database: db,
+        appPath: iosContainer,
+      );
+
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/a.jpg',
+        ),
+        1,
+      );
+    });
+
+    test('老版本写入的外来绝对路径引用行也能命中，不再漏下载', () async {
+      // 老版本 _normalizeFilePath 遇到非本机前缀会原样存下来源设备的绝对路径
+      await MediaReferenceService.addReference(
+        '$androidDocs/media/images/a.jpg',
+        'q1',
+        cachedAppPath: iosContainer,
+      );
+
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/a.jpg',
+        ),
+        1,
+      );
+    });
+
+    test('无人引用的云端附件仍然计为 0，不会让已删除的照片复活', () async {
+      await MediaReferenceService.addReference(
+        '$iosContainer/media/images/other.jpg',
+        'q1',
+        cachedAppPath: iosContainer,
+      );
+
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/a.jpg',
+        ),
+        0,
+      );
+      // 同名不同目录不算引用
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'videos/other.jpg',
+        ),
+        0,
+      );
+    });
+  });
+}

--- a/test/unit/services/media_reference_service_test.dart
+++ b/test/unit/services/media_reference_service_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:thoughtecho/services/media_reference_service.dart';
+
+/// `getReferenceCountForMediaRelativePath` 是 WebDAV 判断"云端附件是否仍被引用"
+/// 的依据：判错为 0 会漏下载照片，判错为正数会把用户已删除的附件重新拉回来。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const iosContainer =
+      '/var/mobile/Containers/Data/Application/BBBB-2222/Documents';
+  const androidDocs = '/data/user/0/com.shangjin.thoughtecho/app_flutter';
+
+  late Database db;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    db = await openDatabase(inMemoryDatabasePath);
+    await db.execute('''
+      CREATE TABLE quotes(
+        id TEXT PRIMARY KEY,
+        content TEXT,
+        delta_content TEXT,
+        date TEXT
+      )
+    ''');
+    await MediaReferenceService.initializeTable(db);
+    MediaReferenceService.setDatabaseForTesting(db);
+
+    // 引用行通过外键指向笔记，夹具必须先有父笔记
+    await db.insert('quotes', {
+      'id': 'q1',
+      'content': '正文',
+      'date': '2026-08-21T00:00:00.000Z',
+    });
+  });
+
+  tearDown(() async {
+    MediaReferenceService.clearDatabaseForTesting();
+    await db.close();
+  });
+
+  group('getReferenceCountForMediaRelativePath', () {
+    test('命中本机标准相对路径的引用', () async {
+      expect(
+        await MediaReferenceService.addReference(
+          '$iosContainer/media/images/a.jpg',
+          'q1',
+          cachedAppPath: iosContainer,
+        ),
+        isTrue,
+      );
+
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/a.jpg',
+        ),
+        1,
+      );
+    });
+
+    test('老版本写入的外来绝对路径引用行也能命中，不再漏下载', () async {
+      // 老版本 _normalizeFilePath 遇到非本机前缀会原样存下来源设备的绝对路径
+      expect(
+        await MediaReferenceService.addReference(
+          '$androidDocs/media/images/a.jpg',
+          'q1',
+          cachedAppPath: iosContainer,
+        ),
+        isTrue,
+      );
+
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/a.jpg',
+        ),
+        1,
+      );
+    });
+
+    test('无人引用的云端附件计为 0，不会让已删除的照片复活', () async {
+      expect(
+        await MediaReferenceService.addReference(
+          '$iosContainer/media/images/other.jpg',
+          'q1',
+          cachedAppPath: iosContainer,
+        ),
+        isTrue,
+      );
+
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/a.jpg',
+        ),
+        0,
+      );
+      // 同名不同目录不算引用
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'videos/other.jpg',
+        ),
+        0,
+      );
+    });
+
+    test('尾段匹配区分大小写，不同大小写的文件不算同一个附件', () async {
+      // 区分大小写的文件系统上 A.jpg 与 a.jpg 是两个文件；
+      // SQLite 的 LIKE 对 ASCII 默认不区分大小写，这里必须用大小写敏感的比较
+      expect(
+        await MediaReferenceService.addReference(
+          '$androidDocs/media/images/A.jpg',
+          'q1',
+          cachedAppPath: iosContainer,
+        ),
+        isTrue,
+      );
+
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/a.jpg',
+        ),
+        0,
+      );
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/A.jpg',
+        ),
+        1,
+      );
+    });
+
+    test('文件名中的 % 与 _ 按字面匹配，不当作通配符', () async {
+      expect(
+        await MediaReferenceService.addReference(
+          '$androidDocs/media/images/a%_x.jpg',
+          'q1',
+          cachedAppPath: iosContainer,
+        ),
+        isTrue,
+      );
+
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/a%_x.jpg',
+        ),
+        1,
+      );
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'images/aZZx.jpg',
+        ),
+        0,
+      );
+    });
+
+    test('无法识别为媒体尾段的路径计为 0', () async {
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          '../etc/passwd',
+        ),
+        0,
+      );
+      expect(
+        await MediaReferenceService.getReferenceCountForMediaRelativePath(
+          'html/page.html',
+        ),
+        0,
+      );
+    });
+  });
+}

--- a/test/unit/utils/media_path_resolver_test.dart
+++ b/test/unit/utils/media_path_resolver_test.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/media_path_resolver.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const iosOldContainer =
+      '/var/mobile/Containers/Data/Application/AAAA-1111/Documents';
+  const iosNewContainer =
+      '/var/mobile/Containers/Data/Application/BBBB-2222/Documents';
+  const androidDocs = '/data/user/0/com.shangjin.thoughtecho/app_flutter';
+
+  group('mediaRelativeTail', () {
+    test('识别各平台绝对路径中的媒体尾段', () {
+      expect(
+        MediaPathResolver.mediaRelativeTail(
+          '$iosOldContainer/media/images/a.jpg',
+        ),
+        'media/images/a.jpg',
+      );
+      expect(
+        MediaPathResolver.mediaRelativeTail('$androidDocs/media/videos/v.mp4'),
+        'media/videos/v.mp4',
+      );
+      expect(
+        MediaPathResolver.mediaRelativeTail(
+          r'C:\Users\me\Documents\media\audios\a.mp3',
+        ),
+        'media/audios/a.mp3',
+      );
+      expect(
+        MediaPathResolver.mediaRelativeTail('media/images/a.jpg'),
+        'media/images/a.jpg',
+      );
+    });
+
+    test('取最靠近文件名的 media 段，避免上层同名目录误截', () {
+      expect(
+        MediaPathResolver.mediaRelativeTail(
+          '/home/media/images/docs/media/images/a.jpg',
+        ),
+        'media/images/a.jpg',
+      );
+    });
+
+    test('无法识别的路径返回 null', () {
+      expect(MediaPathResolver.mediaRelativeTail(''), isNull);
+      expect(MediaPathResolver.mediaRelativeTail('/tmp/photo.jpg'), isNull);
+      // media 下的未知子目录不参与同步，不做重定基
+      expect(
+        MediaPathResolver.mediaRelativeTail('/x/media/html/page.html'),
+        isNull,
+      );
+      expect(
+        MediaPathResolver.mediaRelativeTail('/x/media/images/../../etc/passwd'),
+        isNull,
+      );
+    });
+  });
+
+  group('resolveToLocal', () {
+    test('iOS 容器 UUID 变化后重定基到当前容器', () {
+      expect(
+        MediaPathResolver.resolveToLocal(
+          '$iosOldContainer/media/images/a.jpg',
+          iosNewContainer,
+        ),
+        '$iosNewContainer/media/images/a.jpg',
+      );
+    });
+
+    test('安卓路径同步到 iOS 后重定基', () {
+      expect(
+        MediaPathResolver.resolveToLocal(
+          '$androidDocs/media/images/a.jpg',
+          iosNewContainer,
+        ),
+        '$iosNewContainer/media/images/a.jpg',
+      );
+    });
+
+    test('Windows 分隔符路径在 POSIX 端也能重定基', () {
+      expect(
+        MediaPathResolver.resolveToLocal(
+          r'C:\Users\me\Documents\media\images\a.jpg',
+          iosNewContainer,
+        ),
+        '$iosNewContainer/media/images/a.jpg',
+      );
+    });
+
+    test('备份包里的相对路径解析为本机绝对路径', () {
+      expect(
+        MediaPathResolver.resolveToLocal(
+          'media/images/a.jpg',
+          iosNewContainer,
+        ),
+        '$iosNewContainer/media/images/a.jpg',
+      );
+    });
+
+    test('已是本机路径时保持不变', () {
+      const local = '$iosNewContainer/media/images/a.jpg';
+      expect(MediaPathResolver.resolveToLocal(local, iosNewContainer), local);
+    });
+
+    test('file:// URI 会被还原为文件路径', () {
+      expect(
+        MediaPathResolver.resolveToLocal(
+          'file://$iosOldContainer/media/images/a.jpg',
+          iosNewContainer,
+        ),
+        '$iosNewContainer/media/images/a.jpg',
+      );
+    });
+
+    test('非媒体路径保持原样，不做猜测拼接', () {
+      const external = '/storage/emulated/0/DCIM/photo.jpg';
+      expect(
+        MediaPathResolver.resolveToLocal(external, iosNewContainer),
+        external,
+      );
+    });
+  });
+
+  group('rebaseDelta', () {
+    test('重写 image/video/custom.audio 三类嵌入并标记已改写', () {
+      final delta = json.decode(json.encode([
+        {
+          'insert': {'image': '$iosOldContainer/media/images/a.jpg'},
+        },
+        {
+          'insert': {'video': '$iosOldContainer/media/videos/v.mp4'},
+        },
+        {
+          'insert': {
+            'custom': {'audio': '$iosOldContainer/media/audios/a.mp3'},
+          },
+        },
+        {'insert': '正文\n'},
+      ]));
+
+      final result = MediaPathResolver.rebaseDelta(delta, iosNewContainer);
+      expect(result.changed, isTrue);
+
+      final rebased = result.delta as List;
+      expect(
+        rebased[0]['insert']['image'],
+        '$iosNewContainer/media/images/a.jpg',
+      );
+      expect(
+        rebased[1]['insert']['video'],
+        '$iosNewContainer/media/videos/v.mp4',
+      );
+      expect(
+        rebased[2]['insert']['custom']['audio'],
+        '$iosNewContainer/media/audios/a.mp3',
+      );
+      expect(rebased[3]['insert'], '正文\n');
+    });
+
+    test('路径已经正确时 changed 为 false，调用方可跳过写回', () {
+      final delta = json.decode(json.encode([
+        {
+          'insert': {'image': '$iosNewContainer/media/images/a.jpg'},
+        },
+        {'insert': '正文\n'},
+      ]));
+
+      final result = MediaPathResolver.rebaseDelta(delta, iosNewContainer);
+      expect(result.changed, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 问题

iOS 上 WebDAV 显示"同步完成"，但笔记里的照片不出现；安卓之间同步却正常。

根因只有一个：**笔记 Delta 里存的是媒体文件的绝对路径，而 WebDAV 同步通道没有做路径重定基。**

| 平台 | 文档目录 | 是否稳定 |
|---|---|---|
| Android | `/data/user/0/<包名>/app_flutter` | 只与包名有关，重装不变，所有设备一致 |
| iOS | `/var/mobile/Containers/Data/Application/<UUID>/Documents` | 重装/系统恢复即变，跨设备完全不同 |

安卓之间同步时路径字符串恰好仍然有效，所以"能用"；到了 iOS 就整体失效：

1. 图片按失效路径渲染 → 笔记里看不到照片；
2. `MediaReferenceService.migrateExistingQuotes()` 按外来绝对路径重建引用，`_normalizeFilePath` 只在前缀等于本机文档目录时才转相对，于是引用表里存的是外来路径；
3. `_syncMediaFiles` 用本机绝对路径查引用计数，永远得到 0 → 走"跳过云端未引用附件"分支，**一张照片都不下载**；
4. 跳过不计失败，`mediaFailureCount == 0` → 状态置为 success，所以"同步完成"是真的，它只是压根没试。

普通备份/局域网同步不受影响，因为 `BackupService` 导出转相对、还原再拼回本机路径 —— 缺的正是 WebDAV 这条通道。顺带一提，修复前 **安卓 → iOS 与 iOS → 安卓 也是坏的**，只有安卓 ↔ 安卓能用。

## 改动

**`lib/utils/media_path_resolver.dart`（新增）**
从任意来源路径中提取 `media/<子目录>/<文件名>` 尾段并重定基到本机文档目录，覆盖相对路径（备份包格式）、外来绝对路径、`file://` URI 和 Windows 反斜杠路径。取最靠近文件名的 `media` 段以免上层同名目录误截；无法识别的路径原样返回，不做猜测拼接；重定基结果经 `PathSecurityUtils` 穿越校验。

**`lib/services/media_path_repair_service.dart`（新增）—— 存量修复**
- 分页扫描含媒体的笔记，重写失效路径，并在**同一事务内**按修复后的 Delta 重建媒体引用；
- 挂载在恢复/合并后的迁移链最前面（WebDAV、备份还原、局域网同步都经过），以及数据库初始化阶段按记录的文档目录变化触发（首次运行也扫一次，覆盖已被污染的老库）；
- 全程只用传入的 `Database` 句柄，不经过 `DatabaseService` 的查询接口 —— 那些接口会等待尚未完成的初始化，在 `init()` 内调用会死锁；
- 单条笔记 Delta 损坏不中断整体修复，错误计入报告；有错误时不推进 MMKV 水位线，下次启动重试。

**`lib/services/media_reference_service.dart`**
新增 `getReferenceCountForMediaRelativePath()`：按 `media/<子目录>/<文件名>` 尾段统计引用，兼容老版本写进引用表的外来绝对路径行。仍要求**完整尾段**匹配，不做同名兜底，已删除的附件不会被重新下载。`syncQuoteMediaReferencesWithTransaction` 增加可选 `cachedAppPath`。

**`lib/services/webdav_sync_service.dart`**
下载判定改用上述按尾段匹配的引用计数。

## 兼容性

- **不改同步包格式**：仍然上传绝对路径，老版本客户端读到的东西和现在完全一样，混合版本同步不会因此变坏；修复全部发生在接收端。
- **不改写 `last_modified`**：LWW 比较不受影响（`shouldUseRemote` 要求远端严格更新，平手保留本地），因此修复后的路径不会被下一轮合并冲掉，也不会在多设备之间反复覆盖。

## 验证

在 Flutter 3.47.1 下：

- `flutter analyze --no-fatal-infos lib test` —— 新增/改动文件零问题（仓库原有 4 条 info 未动）；
- 新增 18 个用例：`test/unit/utils/media_path_resolver_test.dart`、`test/unit/services/media_path_repair_service_test.dart`，覆盖 iOS 容器变更、安卓 → iOS、Windows 分隔符、相对路径、非媒体路径不动、穿越拦截、损坏 Delta 不中断、以及"修复后云端附件被判定为仍被引用 / 无人引用仍为 0"；
- `flutter test test/unit/services test/unit/utils` —— 1183 通过，3 个失败是本地 SDK 与 `flutter_quill 11.5.0` 的 `TextInputClient.onFocusReceived` 编译不兼容（`smart_push_service_test`、`smart_push_time_window_test`、`quill_ai_apply_utils_test`），已在**未应用本改动的干净工作区复现同样失败**，与本 PR 无关。
- 未做真机 iOS ↔ 安卓的端到端同步验证（此环境无设备）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRU9wK5rLVUaGwhrsDepdD)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 iOS 跨设备同步后笔记照片不显示。旧行为将媒体绝对路径写入 Delta，iOS 容器路径变化后失效，WebDAV 以为“无人引用”而不下载；新行为在合并与启动时将媒体路径重定基到本机文档目录，并按 media 尾段精确统计引用（大小写敏感），确保所需附件被下载并正确渲染。

- 实现与行为变更：新增 MediaPathResolver 与 MediaPathRepairService，从任意平台/格式提取 `media/<子目录>/<文件名>` 尾段并重定基到本机 `Documents/media`，覆盖相对路径、外来绝对路径、`file://`、Windows 分隔符；同一事务内重写 Delta 并重建媒体引用，路径穿越由 PathSecurityUtils 校验。引用重建失败现在会抛出并回滚整页，错误记入报告，`MMKV` 水位线不推进，下一次启动重试。接入点：`_triggerPostRestoreMigrations` 最先执行存量修复；`_performAllDataMigrations` 在文档目录变化时触发一次修复，避免初始化期死锁；修复日志包含耗时。
- 引用计数与下载：新增 `MediaReferenceService.getReferenceCountForMediaRelativePath`，先按标准相对路径精确匹配，落空时再按“相对 media/ 尾段”兜底匹配历史外来绝对路径；兜底匹配改为大小写敏感的后缀相等，避免把 `A.jpg` 误算为 `a.jpg`；`WebDAVSyncService` 以此计数决定下载。
- 兼容性与发布：不改同步包格式；不改写 `last_modified`；修复仅发生在接收端，混合版本同步行为不变；无需迁移动作。

<sup>Written for commit 7dd4b0c1e3a36381dbed909078db720037c522ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 自动修复因设备或应用文档目录变化导致失效的图片、视频和音频路径。
  - 支持跨设备同步及数据合并后的媒体引用重建。
  - 云端同步时可按相对路径正确识别并下载仍被笔记引用的媒体附件。

- **错误修复**
  - 改善媒体路径迁移失败时的错误报告与后续处理。
  - 失败的媒体引用重建将回滚当前处理并继续后续任务。
  - 避免有效媒体因设备路径不同而无法恢复或下载。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->