### PR TITLE
fix(note-list): 正文里的空行不再把折叠预览整段吞掉

### DIFF
--- a/lib/widgets/note_list/collapsed_rich_text.dart
+++ b/lib/widgets/note_list/collapsed_rich_text.dart
@@ -625,11 +625,23 @@ class CollapsedRichTextMetrics {
       // 得到空计划）。对后面的块也强画一行的话，剩余空间只有几个像素时照样塞一整
       // 行进去，盒子被撑破——`Column` 真的溢出，debug 下就是那条黄黑警示带。
       final bool isFirstBlock = entries.isEmpty;
+      // **空段落量不出任何一行**：文本为空时引擎直接清空行表，只把段落高度设成
+      // strut 高度，于是 `computeLineMetrics()` 返回空表而 `height` 大于 0。
+      // 照「一行都排不下」处理的话，用户在正文里敲的空行会把它自己**连同后面的
+      // 全部内容**一起从计划里删掉——第一行是空行的长笔记，折叠预览整个是白的。
+      //
+      // 渲染侧对同一份 span 会实打实画出一行（高度就是这里的 `painter.height`），
+      // 所以补一行、并按同一个高度记账，测量和渲染才不会漂开。
       final lines = painter.computeLineMetrics();
+      final lineHeights = lines.isEmpty
+          ? <double>[
+              painter.height > 0 ? painter.height : layout.minLineHeight,
+            ]
+          : <double>[for (final line in lines) line.height];
       var fittedLines = 0;
       var fittedHeight = 0.0;
-      for (final line in lines) {
-        final next = fittedHeight + line.height;
+      for (final lineHeight in lineHeights) {
+        final next = fittedHeight + lineHeight;
         if (next > remainingHeight + 0.5 &&
             !(isFirstBlock && fittedLines == 0)) {
           break;
@@ -638,7 +650,7 @@ class CollapsedRichTextMetrics {
         fittedLines++;
       }
       final bool blockTruncated =
-          painter.didExceedMaxLines || fittedLines < lines.length;
+          painter.didExceedMaxLines || fittedLines < lineHeights.length;
       painter.dispose();
 
       if (fittedLines <= 0) {

--- a/test/unit/widgets/collapsed_rich_text_blank_line_test.dart
+++ b/test/unit/widgets/collapsed_rich_text_blank_line_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/delta_rich_text_parser.dart';
+import 'package:thoughtecho/widgets/note_list/collapsed_rich_text.dart';
+
+/// 正文里的**空行**在折叠计划里的待遇。
+///
+/// 这里守的是一个具体的回归：用户在笔记开头敲一个回车（第一行空、第二行才有字），
+/// 列表卡片的折叠预览整个变成空白，只剩一个展开入口；把那个空行删掉，正文又出来
+/// 了。原因是空段落量不出任何 line metrics——引擎对空文本直接清空行表，只把段落
+/// 高度设成 strut 高度——而计划把「一行都量不出来」当成「一行都放不下」，于是
+/// 那个空块连同**它后面的全部内容**一起被丢掉。
+///
+/// 空行是用户敲进去的内容，展开态照样占一行，折叠预览也必须照样排一行。
+void main() {
+  const TextStyle baseStyle = TextStyle(fontSize: 16, height: 1.5);
+  const double width = 320;
+  const double limit = 160;
+
+  CollapsedRichTextPlan planOf(String delta) {
+    return CollapsedRichTextMetrics.plan(
+      blocks: parseDeltaRichText(delta),
+      baseStyle: baseStyle,
+      maxWidth: width,
+      limit: limit,
+      showMedia: false,
+    );
+  }
+
+  String longBody() => '折叠盒只有 160px，可是正文可以写很长很长。' * 20;
+
+  test('第一行是空行时，后面的正文照样排进计划', () {
+    final delta = jsonEncode([
+      {'insert': '\n${longBody()}\n'},
+    ]);
+
+    final blocks = parseDeltaRichText(delta);
+    expect(blocks.first.isBlank, isTrue, reason: '前置条件：第一个块就是那个空行');
+
+    final plan = planOf(delta);
+
+    expect(plan.isEmpty, isFalse, reason: '计划为空时卡片正文整个不画，用户看到一张白卡片');
+    expect(plan.entries, hasLength(2), reason: '空行一块、正文一块，都要排上');
+    expect(plan.entries.first.block.isBlank, isTrue);
+    expect(plan.entries.first.maxLines, 1, reason: '空行占一行，和展开态一致');
+    expect(plan.entries.last.maxLines, greaterThan(1), reason: '正文要按剩余像素铺满折叠盒');
+    expect(plan.height, greaterThan(limit / 2));
+    expect(plan.height, lessThanOrEqualTo(limit + 0.5));
+    expect(plan.truncated, isTrue, reason: '长正文没排完，展开入口还得留着');
+  });
+
+  test('正文中间的空行不会把后面的段落截掉', () {
+    final delta = jsonEncode([
+      {'insert': '第一段\n\n第二段\n'},
+    ]);
+
+    final plan = planOf(delta);
+
+    expect(plan.entries, hasLength(3));
+    expect(plan.entries[1].block.isBlank, isTrue);
+    expect(plan.entries.last.block.plainText, '第二段');
+    expect(plan.truncated, isFalse, reason: '三行远不到 160px，不该判成截断');
+  });
+
+  test('空行占掉的高度算进总高，和渲染出来的一致', () {
+    final withBlank = planOf(jsonEncode([
+      {'insert': '\n正文\n'},
+    ]));
+    final withoutBlank = planOf(jsonEncode([
+      {'insert': '正文\n'},
+    ]));
+
+    // 空行不是零高：多出来的正好是一行加一个块间距。
+    expect(
+      withBlank.height,
+      greaterThan(withoutBlank.height + CollapsedRichText.blockGap),
+    );
+  });
+}


### PR DESCRIPTION
## 现象

富文本笔记的第一行是空行（开头敲了一个回车）时，记录页卡片的折叠预览**整个是白的**，只剩一个展开入口；把那个空行删掉，正文才出来。空行在正文中间时，从那一行起后面的段落全部不显示。

只影响全屏编辑器存的 delta 笔记（`editSource == 'fullscreen'`），纯文本那条路正常。

## 病因

`CollapsedRichTextMetrics._computePlan` 逐块量行，把「量不出一行」当成了「一行都放不下」：

```dart
final lines = painter.computeLineMetrics();
...
if (fittedLines <= 0) { truncated = true; break; }   // 这个块和它后面的全丢掉
```

而**空段落量不出任何一行**。skia 的 `ParagraphImpl::layout` 对空文本走的是这条分支：

```cpp
this->computeEmptyMetrics();
this->fLines.clear();               // 行表被清空
fHeight = fEmptyMetrics.height();   // 高度却大于 0
```

`getLineMetrics` 遍历 `fLines`，于是 `computeLineMetrics()` 返回空表、`height` 大于 0。计划因此在空行处 `break`：

- 空行在第一块 → `entries` 为空 → `plan.isEmpty` → 卡片正文渲染成 `SizedBox.shrink()`，一张白卡片（`truncated` 仍为真，所以展开箭头还在，内容没丢，只是预览看不见）；
- 空行在中间 → 从那一行起的全部正文不进计划。

## 改动

行数改成按 `lineHeights` 记账：量不出行时补一行，高度取 `painter.height` —— 渲染侧 `Text.rich` 对同一份 span 画出来的正是这个高度，**测量和渲染仍然出自同一次量、不会漂开**（这份代码的核心不变量）。空行现在和展开态一样占一行。

行为只在「块量不出行」这一种情况下改变，其余路径逐位不变。

## 测试

新增 `test/unit/widgets/collapsed_rich_text_blank_line_test.dart`：首行空行、中间空行、空行高度计入总高。三条在改动前全部失败（`plan.isEmpty` 为真 / 只排到 1 个块 / 高度差 0.0），改动后通过。

本地 Flutter 3.47.1（与 CI 同版本）验证：

- `dart format --set-exit-if-changed` 两个改动文件：无变化
- `flutter analyze --no-fatal-infos` 两个改动文件：No issues found
- `flutter test` 折叠相关 5 个文件（含 golden）：42 passed
- `flutter test` 卡片 / 预热 / 缓存相关 7 个文件：83 passed

## 留待决定

开头的空行现在会照实占掉 160px 预览里的一行。要不要像 `visibleBlocks` 丢尾部空块那样把**开头**的空块也丢掉（预览更省地方，但和展开态不再逐行一致）？本 PR 按「不丢内容、和展开态对齐」处理，没动这块。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFpvUg3odzmSxLub8Q3waB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFpvUg3odzmSxLub8Q3waB)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复折叠预览在正文含空行时被整段吞掉的问题。之前首行或中间出现空段落会被当作“无法排版”而丢弃后续内容；现在空行按一行计入，折叠预览与展开态一致。

- 审阅要点
  - 仅调整 `CollapsedRichTextMetrics._computePlan` 的行数记账：量不出行时补一行，高度取 `painter.height`；其余逻辑不变。
  - 验证首行空行不再让 `plan` 为空，中间空行不截断后续；`truncated` 判定与溢出处理保持原样。
  - 影响范围限于全屏编辑器保存的富文本 delta；纯文本路径不变。注意：开头空行现在会实际占用预览的一行。

<sup>Written for commit 242ee6fc907207d173233754f7d78b24b29b8a11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复折叠富文本中空段落高度计算不正确的问题。
  * 空行现在会作为独立行保留，并正确计入折叠高度。
  * 改善空行位于开头或正文之间时的内容截断判断，避免后续文本被错误截断。

* **Tests**
  * 新增空行显示与高度计算的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->