### PR TITLE
Align modal bottom sheets and buttons with Material 3 specifications

### DIFF
--- a/lib/pages/backup_restore_page.dart
+++ b/lib/pages/backup_restore_page.dart
@@ -100,7 +100,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
             // 备份按钮
             SizedBox(
               width: double.infinity,
-              child: ElevatedButton.icon(
+              child: FilledButton.icon(
                 onPressed: _isLoading ? null : _handleBackup,
                 icon: _isLoading
                     ? const SizedBox(
@@ -112,7 +112,7 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
                 label: Text(
                   _isLoading ? l10n.creatingBackup : l10n.createBackup,
                 ),
-                style: ElevatedButton.styleFrom(
+                style: FilledButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 12),
                 ),
               ),
@@ -192,14 +192,12 @@ class _BackupRestorePageState extends State<BackupRestorePage> {
 
             SizedBox(
               width: double.infinity,
-              child: ElevatedButton.icon(
+              child: FilledButton.tonalIcon(
                 onPressed: _isLoading ? null : _handleRestore,
                 icon: const Icon(Icons.folder_open),
                 label: Text(l10n.selectBackupFileToRestore),
-                style: ElevatedButton.styleFrom(
+                style: FilledButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 12),
-                  backgroundColor: Theme.of(context).colorScheme.secondary,
-                  foregroundColor: Theme.of(context).colorScheme.onSecondary,
                 ),
               ),
             ),
@@ -734,9 +732,9 @@ Details: $e''';
                 onPressed: () => Navigator.of(context).pop(false),
                 child: Text(l10n.cancel),
               ),
-              ElevatedButton(
+              FilledButton(
                 onPressed: () => Navigator.of(context).pop(true),
-                style: ElevatedButton.styleFrom(
+                style: FilledButton.styleFrom(
                   backgroundColor: Theme.of(context).colorScheme.error,
                   foregroundColor: Theme.of(context).colorScheme.onError,
                 ),

--- a/lib/pages/home/home_capture_actions.dart
+++ b/lib/pages/home/home_capture_actions.dart
@@ -70,6 +70,7 @@ class HomeCaptureActions {
     var resultText = l10n.featureComingSoon;
     await showModalBottomSheet<void>(
       context: context,
+      showDragHandle: true,
       isScrollControlled: true,
       backgroundColor: Theme.of(context).colorScheme.surface,
       builder: (sheetContext) {

--- a/lib/pages/home/home_note_editor_actions.dart
+++ b/lib/pages/home/home_note_editor_actions.dart
@@ -96,6 +96,7 @@ class HomeNoteEditorActions {
     if (!isMounted() || !context.mounted) return;
     await showModalBottomSheet<void>(
       context: context,
+      showDragHandle: true,
       isScrollControlled: true,
       backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
       requestFocus: false,
@@ -123,6 +124,7 @@ class HomeNoteEditorActions {
 
     showModalBottomSheet<void>(
       context: context,
+      showDragHandle: true,
       isScrollControlled: true,
       backgroundColor: Theme.of(context).brightness == Brightness.light
           ? Colors.white

--- a/lib/pages/license_page.dart
+++ b/lib/pages/license_page.dart
@@ -90,10 +90,10 @@ class _LicensePageState extends State<LicensePage> {
 
   Widget _buildLicenseFileSection(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    return ElevatedButton.icon(
+    return FilledButton.icon(
       icon: const Icon(Icons.verified_user_outlined),
       label: Text(l10n.viewAppLicense),
-      style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(44)),
+      style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(44)),
       onPressed: () => _showLicenseDialog(context),
     );
   }
@@ -328,13 +328,13 @@ class _LicensePageState extends State<LicensePage> {
         ),
         const SizedBox(height: 12),
         const SizedBox(height: 12),
-        ElevatedButton.icon(
+        FilledButton.tonalIcon(
           onPressed: () => _launchUrl(
             'https://flutter.dev/docs/development/packages-and-plugins/using-packages',
           ),
           icon: const Icon(Icons.open_in_new),
           label: Text(l10n.viewFullDependencyList),
-          style: ElevatedButton.styleFrom(
+          style: FilledButton.styleFrom(
             minimumSize: const Size.fromHeight(40),
           ),
         ),
@@ -402,7 +402,7 @@ class _LicensePageState extends State<LicensePage> {
       children: [
         Text(l10n.systemLicensesDesc, style: const TextStyle(fontSize: 14)),
         const SizedBox(height: 12),
-        ElevatedButton.icon(
+        FilledButton.icon(
           onPressed: () {
             Navigator.push(
               context,
@@ -413,7 +413,7 @@ class _LicensePageState extends State<LicensePage> {
           },
           icon: const Icon(Icons.article_outlined),
           label: Text(l10n.viewSystemLicenses),
-          style: ElevatedButton.styleFrom(
+          style: FilledButton.styleFrom(
             minimumSize: const Size.fromHeight(44),
           ),
         ),

--- a/lib/pages/logs_page.dart
+++ b/lib/pages/logs_page.dart
@@ -205,6 +205,7 @@ class _LogsPageState extends State<LogsPage> {
   void _showLogDetails(LogEntry log) {
     showModalBottomSheet(
       context: context,
+      showDragHandle: true,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (context) => _buildLogDetailsSheet(log),
@@ -770,6 +771,7 @@ class _LogsPageState extends State<LogsPage> {
   void _showFilterDialog() {
     showModalBottomSheet(
       context: context,
+      showDragHandle: true,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (context) => _buildFilterBottomSheet(),

--- a/lib/pages/note_editor/editor_metadata_dialog.dart
+++ b/lib/pages/note_editor/editor_metadata_dialog.dart
@@ -7,6 +7,7 @@ extension _NoteEditorMetadataDialog on _NoteFullEditorPageState {
     final l10n = AppLocalizations.of(context);
     await showModalBottomSheet(
       context: context,
+      showDragHandle: true,
       isScrollControlled: true,
       useSafeArea: true,
       backgroundColor: theme.colorScheme.surface,
@@ -31,21 +32,6 @@ extension _NoteEditorMetadataDialog on _NoteFullEditorPageState {
               builder: (context, scrollController) {
                 return Column(
                   children: [
-                    Container(
-                      padding: const EdgeInsets.symmetric(vertical: 12),
-                      child: Container(
-                        width: 40,
-                        height: 4,
-                        decoration: BoxDecoration(
-                          color:
-                              theme.colorScheme.onSurfaceVariant.applyOpacity(
-                            // MODIFIED
-                            0.4,
-                          ),
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                      ),
-                    ),
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
                       child: Row(

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -437,10 +437,10 @@ class SettingsPageState extends State<SettingsPage> {
                           style: theme.textTheme.titleSmall,
                         ),
                         const SizedBox(height: 8.0),
-                        ElevatedButton.icon(
+                        FilledButton.tonalIcon(
                           icon: const Icon(Icons.search),
                           label: Text(l10n.settingsSearchCity),
-                          style: ElevatedButton.styleFrom(
+                          style: FilledButton.styleFrom(
                             minimumSize: const Size.fromHeight(50),
                           ),
                           onPressed: () {
@@ -851,7 +851,7 @@ class SettingsPageState extends State<SettingsPage> {
                                 url: _projectUrl,
                               ),
                               const SizedBox(height: 8),
-                              ElevatedButton.icon(
+                              FilledButton.icon(
                                 onPressed: () {
                                   Navigator.pop(dialogContext);
                                   Navigator.push(
@@ -867,7 +867,7 @@ class SettingsPageState extends State<SettingsPage> {
                                 style: _primaryButtonStyle(context),
                               ),
                               const SizedBox(height: 8),
-                              ElevatedButton.icon(
+                              FilledButton.icon(
                                 onPressed: () {
                                   Navigator.pop(dialogContext);
                                   Navigator.push(
@@ -1343,7 +1343,7 @@ class SettingsPageState extends State<SettingsPage> {
     required String url,
   }) {
     return Center(
-      child: ElevatedButton.icon(
+      child: FilledButton.icon(
         style: _primaryButtonStyle(context),
         onPressed: () => _launchUrl(url),
         icon: Icon(icon, size: 18),
@@ -1355,7 +1355,7 @@ class SettingsPageState extends State<SettingsPage> {
 
   // 统一按钮样式方法，作为类的私有工具方法，便于在文件内复用
   ButtonStyle _primaryButtonStyle(BuildContext context) =>
-      ElevatedButton.styleFrom(
+      FilledButton.styleFrom(
         minimumSize: const Size.fromHeight(44),
         shape: RoundedRectangleBorder(
           borderRadius:

--- a/lib/pages/tag_settings_page.dart
+++ b/lib/pages/tag_settings_page.dart
@@ -114,7 +114,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                         ),
                       ),
                       const SizedBox(width: 8),
-                      ElevatedButton.icon(
+                      FilledButton.icon(
                         icon: _isLoading
                             ? const SizedBox(
                                 width: 16,
@@ -357,7 +357,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                             style: const TextStyle(color: Colors.blue),
                           ),
                           const Spacer(),
-                          ElevatedButton(
+                          FilledButton(
                             child: Text(l10n.select),
                             onPressed: () {
                               setState(
@@ -622,7 +622,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
               onPressed: () => Navigator.pop(dialogContext),
               child: Text(l10n.cancel),
             ),
-            ElevatedButton(
+            FilledButton(
               onPressed: () async {
                 final newName = nameController.text.trim();
                 if (newName.isEmpty) return;
@@ -900,7 +900,7 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
                       style: const TextStyle(color: Colors.blue),
                     ),
                     const Spacer(),
-                    ElevatedButton(
+                    FilledButton(
                       child: Text(l10n.select),
                       onPressed: () {
                         Navigator.of(context).pop(_emojiSearchController.text);

--- a/lib/pages/thoughter/thoughter_ui.dart
+++ b/lib/pages/thoughter/thoughter_ui.dart
@@ -1217,6 +1217,7 @@ extension _ThoughterUI on _ThoughterPageState {
         String? savedId;
         await showModalBottomSheet<void>(
           context: context,
+          showDragHandle: true,
           isScrollControlled: true,
           builder: (_) => AddNoteDialog(
             prefilledContent: artifact.content,
@@ -1280,6 +1281,7 @@ extension _ThoughterUI on _ThoughterPageState {
     } else {
       await showModalBottomSheet<void>(
         context: context,
+        showDragHandle: true,
         isScrollControlled: true,
         builder: (_) => AddNoteDialog(
           initialQuote: proposed,
@@ -1381,6 +1383,7 @@ extension _ThoughterUI on _ThoughterPageState {
       String? savedNoteId;
       await showModalBottomSheet(
         context: context,
+        showDragHandle: true,
         isScrollControlled: true,
         backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
         builder: (_) => AddNoteDialog(

--- a/lib/pages/trash_page.dart
+++ b/lib/pages/trash_page.dart
@@ -214,6 +214,7 @@ class _TrashPageState extends State<TrashPage> {
     try {
       final selected = await showModalBottomSheet<int>(
         context: context,
+        showDragHandle: true,
         builder: (context) => SafeArea(
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 16.0),

--- a/lib/pages/user_guide_page.dart
+++ b/lib/pages/user_guide_page.dart
@@ -375,7 +375,7 @@ class _UserGuidePageState extends State<UserGuidePage> {
                       SizedBox(height: 16),
                       Text(_error!, textAlign: TextAlign.center),
                       SizedBox(height: 16),
-                      ElevatedButton.icon(
+                      FilledButton.icon(
                         onPressed: _loadManual,
                         icon: Icon(Icons.refresh),
                         label: Text(l10n.retry),

--- a/lib/pages/webdav_sync_page.dart
+++ b/lib/pages/webdav_sync_page.dart
@@ -92,7 +92,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                 style: TextStyle(color: Theme.of(context).colorScheme.error),
               ),
             ),
-            ElevatedButton(
+            FilledButton(
               onPressed: () {
                 Navigator.pop(context);
               },
@@ -599,7 +599,7 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                       ),
                       SizedBox(width: 16),
                       Expanded(
-                        child: ElevatedButton.icon(
+                        child: FilledButton.icon(
                           onPressed: syncService.isSyncing
                               ? null
                               : () => _saveAndSync(syncService),
@@ -617,10 +617,8 @@ class _WebDAVSyncPageState extends State<WebDAVSyncPage> {
                           label: Text(syncService.enabled
                               ? l10n.webdavSaveAndSync
                               : l10n.webdavEnableSync),
-                          style: ElevatedButton.styleFrom(
+                          style: FilledButton.styleFrom(
                             padding: const EdgeInsets.symmetric(vertical: 14),
-                            backgroundColor: theme.colorScheme.primary,
-                            foregroundColor: theme.colorScheme.onPrimary,
                           ),
                         ),
                       ),

--- a/lib/widgets/ai_options_menu.dart
+++ b/lib/widgets/ai_options_menu.dart
@@ -66,6 +66,7 @@ class AiOptionsMenu extends StatelessWidget {
 
     return showModalBottomSheet(
       context: context,
+      showDragHandle: true,
       backgroundColor: theme.colorScheme.surface,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(
@@ -155,18 +156,6 @@ class AiOptionsMenu extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // 拖拽指示条
-              Center(
-                child: Container(
-                  width: 40,
-                  height: 4,
-                  margin: const EdgeInsets.only(bottom: 16),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.onSurfaceVariant.applyOpacity(0.4),
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
-              ),
               // 标题
               Padding(
                 padding: const EdgeInsets.only(bottom: 16),

--- a/lib/widgets/note_list/note_list_items.dart
+++ b/lib/widgets/note_list/note_list_items.dart
@@ -94,6 +94,7 @@ extension _NoteListItemsExtension on NoteListViewState {
                                       context.read<SettingsService>();
                                   showModalBottomSheet(
                                     context: context,
+                                    showDragHandle: true,
                                     isScrollControlled: true,
                                     backgroundColor: Theme.of(
                                       context,

--- a/lib/widgets/onboarding/page_views.dart
+++ b/lib/widgets/onboarding/page_views.dart
@@ -75,6 +75,7 @@ class _WelcomePageViewState extends State<WelcomePageView>
   Future<void> _openLanguageSheet() async {
     final selected = await showModalBottomSheet<String>(
       context: context,
+      showDragHandle: true,
       backgroundColor: Theme.of(context).colorScheme.surface,
       builder: (sheetContext) => _LanguageSheet(
         selectedCode: _currentLanguageCode,

--- a/lib/widgets/svg_card_widget.dart
+++ b/lib/widgets/svg_card_widget.dart
@@ -491,11 +491,11 @@ class _ActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ElevatedButton.icon(
+    return FilledButton.icon(
       onPressed: enabled ? onPressed : null,
       icon: Icon(icon, size: 18),
       label: Text(label),
-      style: ElevatedButton.styleFrom(
+      style: FilledButton.styleFrom(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         shape: RoundedRectangleBorder(
           borderRadius:

--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -87,17 +87,6 @@ class UpdateBottomSheet extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          // 顶部拖拽指示器
-          Container(
-            margin: const EdgeInsets.only(top: 8),
-            width: 40,
-            height: 4,
-            decoration: BoxDecoration(
-              color: colorScheme.onSurfaceVariant.withAlpha(128),
-              borderRadius: BorderRadius.circular(2),
-            ),
-          ),
-
           // 标题区域
           Padding(
             padding: const EdgeInsets.fromLTRB(24, 16, 24, 8),
@@ -270,17 +259,6 @@ class UpdateBottomSheet extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          // 顶部拖拽指示器
-          Container(
-            margin: const EdgeInsets.only(top: 8),
-            width: 40,
-            height: 4,
-            decoration: BoxDecoration(
-              color: colorScheme.onSurfaceVariant.withAlpha(128),
-              borderRadius: BorderRadius.circular(2),
-            ),
-          ),
-
           // 标题区域
           Padding(
             padding: const EdgeInsets.fromLTRB(24, 16, 24, 8),
@@ -524,6 +502,7 @@ class UpdateBottomSheet extends StatelessWidget {
     if (!versionInfo.hasUpdate && showNoUpdateMessage) {
       return showModalBottomSheet<void>(
         context: context,
+        showDragHandle: true,
         isScrollControlled: true,
         backgroundColor: Colors.transparent,
         builder: (context) => UpdateBottomSheet(
@@ -591,6 +570,7 @@ class UpdateBottomSheet extends StatelessWidget {
 
     return showModalBottomSheet<void>(
       context: context,
+      showDragHandle: true,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (context) =>


### PR DESCRIPTION
This change aligns modal bottom sheets and button components across the application with Material 3 guidelines. It configures `showDragHandle: true` on all bottom sheet dialogs, removes custom hand-drawn drag bars, and converts leftover `ElevatedButton` instances to `FilledButton` / `FilledButton.tonal` / `OutlinedButton`.

---
*PR created automatically by Jules for task [9768957491286321752](https://jules.google.com/task/9768957491286321752) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将全局模态底部抽屉与按钮对齐到 Material 3。旧行为：自绘或无拖拽条、普遍使用 ElevatedButton；新行为：在 `showModalBottomSheet` 统一启用 `showDragHandle: true` 并移除自绘手柄，替换为 `FilledButton`/`FilledButton.tonal`/`OutlinedButton`，带来一致的 M3 体验与可访问性。

- 审阅指引
  - 确认所有 `showModalBottomSheet` 均设置 `showDragHandle: true`，无残留自绘手柄（例如更新弹层、AI 菜单、编辑器元数据对话等）。
  - 关注按钮替换后的视觉与状态：颜色对比、禁用态、最小高度与内边距在备份/恢复、设置、许可证、WebDAV、日志、用户指南等页面是否一致。
  - 验证长内容与键盘场景下的抽屉交互（`isScrollControlled` 未变），确保滚动与焦点行为正常。

- 发布/迁移
  - 无调用方代码迁移要求；如有仅针对 `ElevatedButton` 的主题配置，请补充 `FilledButton` 相关主题以维持一致外观。
  - 预期的小范围视觉变化：按钮层级与色彩按 M3 调整，抽屉顶部显示系统拖拽手柄。

<sup>Written for commit 8efbfba3784f30146c0ee13294ac10e34e9be6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

