### PR TITLE
fix(db): 升级时按当前定义补齐旧库缺失的索引和附属表

### DIFF
--- a/lib/services/database/schema_lifecycle.dart
+++ b/lib/services/database/schema_lifecycle.dart
@@ -70,6 +70,12 @@ class DatabaseSchemaLifecycle {
           fromVersion: oldVersion,
           toVersion: newVersion,
         );
+        if (newVersion == DatabaseSchemaDefinitions.schemaVersion) {
+          // 版本适配器只覆盖两个版本之间的增量。若旧库记录的版本号高于它实际
+          // 的结构（升级中断、旧构建建库、恢复的备份），缺失的索引/附属表不在
+          // 任何适配器的区间内，只能在这里按当前定义补齐，否则校验会直接失败。
+          await _repair.ensureCurrentStructure(transaction);
+        }
         await _validation.validateTransaction(transaction);
       });
       logDebug('数据库升级成功完成');

--- a/lib/services/database/schema_repair_adapter.dart
+++ b/lib/services/database/schema_repair_adapter.dart
@@ -64,49 +64,7 @@ class SchemaRepairAdapter {
   Future<void> repair(Database database) async {
     try {
       await database.transaction((transaction) async {
-        final tables = await _definitions.tableNames(transaction);
-        final missingBaseTables =
-            <String>{'quotes', 'categories'}.difference(tables);
-        if (missingBaseTables.isNotEmpty) {
-          throw StateError('无法修复缺少基础表的数据库: $missingBaseTables');
-        }
-
-        final quoteColumns =
-            await _definitions.columnNames(transaction, 'quotes');
-        for (final entry
-            in DatabaseSchemaDefinitions.repairableQuoteColumns.entries) {
-          if (!quoteColumns.contains(entry.key)) {
-            final colName = entry.key;
-            final colDef = entry.value;
-            // colDef 不是标识符且不可参数化，用白名单校验后拼入 DDL
-            if (!RegExp(
-                    r"^[a-zA-Z0-9_ ]+(?:DEFAULT (?:'[a-zA-Z0-9_]*'|[0-9]+))?$")
-                .hasMatch(colDef)) {
-              throw StateError('不安全的列定义: $colDef');
-            }
-            final safeColName = _quoteIdentifier(colName);
-            final query = 'ALTER TABLE quotes ADD COLUMN $safeColName $colDef';
-            await transaction.execute(query);
-            logDebug('数据库repair添加 quotes.$colName');
-          }
-        }
-
-        final categoryColumns =
-            await _definitions.columnNames(transaction, 'categories');
-        if (!categoryColumns.contains('icon_name')) {
-          await transaction
-              .execute('ALTER TABLE categories ADD COLUMN icon_name TEXT');
-        }
-        if (!categoryColumns.contains('last_modified')) {
-          await transaction.execute(
-            'ALTER TABLE categories ADD COLUMN last_modified TEXT',
-          );
-        }
-
-        await _definitions.ensureCurrentIndexes(transaction);
-        await _definitions.ensureQuoteTagsTable(transaction);
-        await _definitions.ensureQuoteTombstonesTable(transaction);
-        await _definitions.ensureMediaReferencesTable(transaction);
+        await ensureCurrentStructure(transaction);
         await _validation.validateTransaction(transaction);
       });
     } catch (error, stackTrace) {
@@ -118,6 +76,59 @@ class SchemaRepairAdapter {
       );
       rethrow;
     }
+  }
+
+  /// Brings any database that already holds the base tables up to the full
+  /// current structure.
+  ///
+  /// Every statement is either guarded by an existence check or uses
+  /// `IF NOT EXISTS`, so this is idempotent and safe to run both from startup
+  /// repair and at the tail of an upgrade. Version adapters only cover the
+  /// steps between two versions; a legacy database whose recorded version is
+  /// newer than its actual structure (an interrupted upgrade, a database
+  /// created by an older build, a restored backup) is only healed here.
+  Future<void> ensureCurrentStructure(DatabaseExecutor executor) async {
+    final tables = await _definitions.tableNames(executor);
+    final missingBaseTables =
+        <String>{'quotes', 'categories'}.difference(tables);
+    if (missingBaseTables.isNotEmpty) {
+      throw StateError('无法修复缺少基础表的数据库: $missingBaseTables');
+    }
+
+    final quoteColumns = await _definitions.columnNames(executor, 'quotes');
+    for (final entry
+        in DatabaseSchemaDefinitions.repairableQuoteColumns.entries) {
+      if (!quoteColumns.contains(entry.key)) {
+        final colName = entry.key;
+        final colDef = entry.value;
+        // colDef 不是标识符且不可参数化，用白名单校验后拼入 DDL
+        if (!RegExp(r"^[a-zA-Z0-9_ ]+(?:DEFAULT (?:'[a-zA-Z0-9_]*'|[0-9]+))?$")
+            .hasMatch(colDef)) {
+          throw StateError('不安全的列定义: $colDef');
+        }
+        final safeColName = _quoteIdentifier(colName);
+        final query = 'ALTER TABLE quotes ADD COLUMN $safeColName $colDef';
+        await executor.execute(query);
+        logDebug('数据库结构补齐 quotes.$colName');
+      }
+    }
+
+    final categoryColumns =
+        await _definitions.columnNames(executor, 'categories');
+    if (!categoryColumns.contains('icon_name')) {
+      await executor
+          .execute('ALTER TABLE categories ADD COLUMN icon_name TEXT');
+    }
+    if (!categoryColumns.contains('last_modified')) {
+      await executor.execute(
+        'ALTER TABLE categories ADD COLUMN last_modified TEXT',
+      );
+    }
+
+    await _definitions.ensureCurrentIndexes(executor);
+    await _definitions.ensureQuoteTagsTable(executor);
+    await _definitions.ensureQuoteTombstonesTable(executor);
+    await _definitions.ensureMediaReferencesTable(executor);
   }
 }
 

--- a/test/unit/services/database_schema_lifecycle_test.dart
+++ b/test/unit/services/database_schema_lifecycle_test.dart
@@ -126,6 +126,50 @@ void main() {
       expect(indexes, isNotEmpty);
     });
 
+    test('heals structure no adapter in range recreates during upgrade',
+        () async {
+      final manager = DatabaseSchemaManager();
+      await manager.createTables(database);
+      // 记录版本为 20，但结构缺少 v16 才建的分类索引和附属表：旧构建建库、
+      // 升级中断或从备份恢复都会出现这种“版本号比结构新”的库。
+      await database.execute('DROP INDEX idx_categories_last_modified');
+      await database.execute('DROP TABLE media_references');
+      await database.execute('DROP TABLE quote_tombstones');
+
+      await manager.upgradeDatabase(database, 20, 21);
+      await manager.validateSchema(database);
+
+      final indexes = await database.rawQuery(
+        "SELECT name FROM sqlite_master WHERE type = 'index' "
+        "AND name = 'idx_categories_last_modified'",
+      );
+      expect(indexes, isNotEmpty);
+    });
+
+    test('keeps existing rows while healing during upgrade', () async {
+      final manager = DatabaseSchemaManager();
+      await manager.createTables(database);
+      await database.insert('categories', <String, Object?>{
+        'id': 'tag-1',
+        'name': 'Existing tag',
+        'is_default': 0,
+      });
+      await database.insert('quotes', <String, Object?>{
+        'id': 'quote-1',
+        'content': 'Existing content',
+        'date': '2025-01-01T12:00:00.000',
+      });
+      await database.execute('DROP INDEX idx_categories_last_modified');
+
+      await manager.upgradeDatabase(database, 20, 21);
+      await manager.validateSchema(database);
+
+      expect((await database.query('quotes')).single['content'],
+          'Existing content');
+      expect(
+          (await database.query('categories')).single['name'], 'Existing tag');
+    });
+
     test('repairs missing current structure from the shared definition',
         () async {
       final manager = DatabaseSchemaManager();


### PR DESCRIPTION
## 问题

把一个旧库升级到最新版时，启动直接失败并且每次启动稳定复现：

```
来源: DatabaseUpgrade
消息: 数据库升级失败: Bad state: 数据库结构不完整，缺少索引: {idx_categories_last_modified}
#0  SchemaValidationAdapter._validate (schema_repair_adapter.dart:50)
#1  DatabaseSchemaLifecycle.upgrade.<anonymous closure> (schema_lifecycle.dart:73)
```

出错链路：

1. 旧库记录的 `user_version` 已经是 16~20，但结构里没有 `idx_categories_last_modified`。这个索引只有三处会建：全新建库 `createCurrentSchema`、v16 适配器 `_upgradeToV16`、启动时的结构修复。「版本号比实际结构新」的库（旧构建建的库、升级中途被杀、从备份恢复）就会缺它。
2. 升级只跑 `oldVersion+1 .. newVersion` 区间的适配器，v16 被跳过，17~21 里没人建这个索引。
3. 升级末尾的校验却是全量的：`SchemaValidationAdapter._validate` 拿 `requiredIndexNames` 跟 `sqlite_master` 比对，缺一个就抛 `StateError`，事务回滚，`onUpgrade` 抛错，`openDatabase` 整个失败。
4. 修复路径够不着：`_checkAndFixDatabaseStructure()`（会调 `ensureCurrentIndexes` 补齐索引）排在 `_initDatabase(path)` 之后，`openDatabase` 都失败了，它永远没机会执行 —— 应用彻底打不开，且无法自愈。

同类问题此前是靠 `_upgradeToV21` 里重建 `idx_quotes_coordinates` 做单点修补的。

## 改动

- `schema_repair_adapter.dart`：把 repair 里的结构补齐逻辑抽成 `ensureCurrentStructure(DatabaseExecutor)`，repair 与升级事务共用。
- `schema_lifecycle.dart`：升级到当前 `schemaVersion` 时，在跑完版本适配器之后、全量校验之前调用它，按当前定义补齐可修复列、索引和附属表。

所有语句都带存在性判断或 `IF NOT EXISTS`，幂等、不改数据，也不影响「适配器失败则整体回滚」的行为。加 `newVersion == schemaVersion` 判断，是为了避免部分升级（如 11→15）给还不存在的列建索引。

仍会硬失败的只剩「连 `quotes`/`categories` 基础表都没有」的情况，那属于真损坏，不应静默重建。

## 测试

- 新增两个回归测试：去掉本 PR 的 lifecycle 改动后，精确复现上面的报错；加上后通过。覆盖缺 `idx_categories_last_modified` / `media_references` / `quote_tombstones`，以及升级后原有笔记和标签数据不丢。
- `flutter test test/unit/services/database_schema_lifecycle_test.dart` 8/8 通过。
- 相关的 `database_schema_manager_poi_name` / `database_service_initialization` / `backup_rollback` 全部通过。
- `flutter analyze` 无 issue；`dart format --set-exit-if-changed` 全仓干净（Flutter 3.47.1，与 CI 同版本）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rne3GAP4fqTuYcrMmJHmMX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rne3GAP4fqTuYcrMmJHmMX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
升级在校验前按当前定义补齐旧库缺失的列、索引和附属表，避免因“记录版本比实际结构新”导致的启动失败。旧行为：校验发现缺少如 idx_categories_last_modified 时直接失败并回滚；新行为：在升级到当前 schemaVersion 时先补齐再校验，仍对缺失基础表时硬失败。

- 提取结构补齐为 ensureCurrentStructure(DatabaseExecutor)，在 repair 与升级中共用。
- 在升级尾部、全量校验前调用；仅当 newVersion == schemaVersion 时执行，避免部分升级误建索引。
- 所有语句带存在性判断或 IF NOT EXISTS，幂等、与适配器同事务、不改动数据。
- 仍仅在缺少 quotes/categories 基础表时失败。

- 测试：新增覆盖“升级补齐缺失索引/附属表且不丢数据”的用例；相关单测全部通过。

<sup>Written for commit 3a8aed3ffe99f6cbeb30ea4252ac6a3427db0191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 数据库升级至当前版本时，会自动补全缺失的表、字段、索引及附属结构。
  * 修复数据库结构时，现有分类和引用数据将得到保留。

* **测试**
  * 新增数据库升级场景验证，确保结构恢复和数据保留行为正常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->