### PR TITLE
perf(note-list): 缓存被清空后重新预热，帧预算按真实刷新率算

### DIFF
--- a/docs/note-list-warmup-invalidation-2026-08-22.md
+++ b/docs/note-list-warmup-invalidation-2026-08-22.md
@@ -1,0 +1,95 @@
+# 记录页：预热在空转，日志用的是别人家屏幕的尺子（2026-08-22）
+
+接着 `docs/note-list-first-paint-cost-2026-08-19.md` 和 489c0fc（空闲预热 + 缓存区预建）。
+这一份回答的问题是：预热和预建都上了，**为什么「不是冷启动也卡」**。
+
+---
+
+## 一句话结论
+
+两件事同时成立：
+
+1. **空闲预热在空转。** App 进后台会把测量缓存整排清空，而预热的游标停在列表末尾，
+   没有任何东西把它拨回去 —— 回到前台后缓存是空的、游标是满的，每张卡片滑进来
+   都要重新算一遍折叠判定和折叠排版。
+2. **日志看不见这件事。** 帧的 jank 阈值写死 16.6ms（60Hz 的一帧），用户的屏是
+   120Hz（一帧 8.3ms）。`frameJank=0` 和「明显觉得卡」可以同时成立。
+
+---
+
+## 证据：用户 2026-08-22 那四段 log
+
+`warmup=` 说预热跑完了 121 条、发了 31 次 precache。可同一行里的缓存尺寸全部对不上：
+
+| 指标 | 日志值 | 预热真跑过的话 |
+|---|---|---|
+| `expand`（折叠判定缓存） | 59 | ≥121 |
+| `ir`（DeltaRichTextCache） | 20 | 40（`rich=40`） |
+| `plan`（折叠排版缓存） | 36 | ≥40 |
+| `imageCache.img` | 15 | ~31 |
+
+`expand=59` 恰好等于 `tracked=59`（`_expandedItems.length`，「一共建出来过几张卡」），
+scroll-5 那段则是 `expand=44 / tracked=44`。**缓存里没有一条是预热的份，全是卡片
+自己现算的。** 三个缓存的上限分别是 300/200/300，都远没到，不是被挤掉的。
+
+清空的地方在 `lib/main.dart` 的 `didChangeAppLifecycleState`：`paused` 时
+`QuoteContent.resetCaches()` 把 document / heightEstimate / expansion / controller /
+media / richText / plan 七个缓存一起清掉（Android 侧后台还会清 Flutter 自己的
+imageCache，正好解释 31 → 15）。而 `_resetIdleLayoutWarmup()` 只在**列表内容变化**时
+被调用，宽度和版式都没变，游标就一直停在 `121/121`：下一轮 tick 进来直接判定
+「暖完了」，转头去撑缓存区。
+
+## 剩下那一半：尺子不对
+
+| session | eventJank | eventWorst | frameJank | avgFrame | 说明 |
+|---|---|---|---|---|---|
+| scroll-8 | 15/106 | 25.2ms | **0** | 3.0ms | build+raster 很小，帧却在丢 |
+| scroll-6 | 14/141 | 82.8ms | 2 | 4.4ms | 这段撞上了分页 |
+
+`frameJank` 只统计 `buildDuration + rasterDuration`，阈值 16600 —— 120Hz 上那是
+两帧。而 vsync 到 build 之间的等待不进账，**整帧被跳过更不会留下任何 FrameTiming**。
+`eventAvg=12.2ms`（120Hz 期望 8.33ms）说明确实在丢帧，但那是滚动事件的间隔，
+拖拽期混着触摸采样率，不能当帧率用。
+
+---
+
+## 这一轮做了什么
+
+- `QuoteContent.cacheGeneration`：`resetCaches()` 每清一次自增一次。预热 tick 拿它
+  和宽度、版式一起比对，代号变了就把游标拨回 0 并清掉 precache 去重集合。
+  这样任何清缓存的路径都会自动触发重暖，不用让 NoteListView 去认识 App 生命周期。
+- `NoteListViewState` 监听 `AppLifecycleState.resumed`，回前台排一轮预热。
+  没被清过的话那一轮全是查表命中，几乎不花时间。
+- `lib/utils/frame_timing_stats.dart`：一帧的预算按 `display.refreshRate` 算
+  （120Hz → 8333µs），首滑 / 加载更多 / 滚动会话三处共用同一份换算，`16600` 从此
+  只此一处、且不再是常量。`JankDetector` 的 32ms 同样改成「两帧」。
+- 日志新增 `dropped=`（按相邻两帧 vsync 间隔折算出的、根本没产出的帧数）、
+  `worstGap=`、`avgSpan=` / `worstSpan=`（`totalSpan`，含 build 之前的等待）、
+  `worstVsync=`（`vsyncOverhead`）。
+- `warmup={}` 新增 `expand=` / `plan=`（预热**自己**做掉的测量量）、`gen=`、
+  `rewarm=`。`items` 只数循环转了几圈，转空圈时它照样很好看；这两个增量才是
+  「预热真的落地了」的证据。
+
+## 下一轮该看什么
+
+拿到新日志先看三个数：
+
+- `warmup` 里的 `expand=` / `plan=` 有没有涨。是 0 就说明预热仍然没落地，
+  别再往下猜。
+- `rewarm=` 有没有随着切后台次数增加。
+- `dropped=` 和 `frameJank=`。如果 `frameJank` 仍然接近 0 而 `dropped` 很大，
+  说明成本不在 build/raster 里，要往 UI 线程的非帧工作（定时器、平台通道、GC）
+  和光栅线程排队去找。
+
+还没做、按优先级排：
+
+1. **排版量封顶。** `planWorstUs=15486`（单条笔记一次 plan 15.5ms）、首个
+   rich-image 卡片 `itemLayout 18.3ms`。`_computePlan` 和渲染侧的 `Text.rich`
+   都把**整块正文**交给引擎，`maxLines` 只限制保留几行，断行仍然要跑全文 ——
+   折叠盒只有 160px，成本却随笔记长度线性增长。两侧用同一个字符上限截一刀。
+2. **分页别落在惯性里。** scroll-6 是唯一真掉帧的一段，也正是
+   `loadMoreStartΔ=1` 那段（15 次挂载、9 次解码）。新页到达即刻预热，
+   并把预热的「在滚就整轮放弃」改成按帧余量切片。
+3. **iOS 的 Sentry profiling。** `profilesSampleRate` 目前是 null（仅 iOS/macOS
+   支持）。打开它并把滚动会话包成一个 transaction，才能拿到函数级的火焰图 ——
+   profiling 只在有活跃 transaction 时采样，而滑动本身不产生 transaction。

--- a/lib/utils/frame_timing_stats.dart
+++ b/lib/utils/frame_timing_stats.dart
@@ -1,0 +1,152 @@
+import 'dart:ui' show FramePhase, FrameTiming;
+
+/// 一块屏幕上「一帧有多少微秒」。120Hz 是 8333，60Hz 是 16667。
+///
+/// 记录页的性能日志原来把这个数写死成 `16600`（60Hz 的一帧），而且在三处各写了
+/// 一遍。120Hz 屏上它等于「连丢两帧才算一次 jank」，于是 `frameJank=0` 和「用户
+/// 明显觉得卡」可以同时成立 —— 一整轮诊断都被这个常量带偏过。
+///
+/// 取不到刷新率（[refreshRate] 为 0 或非有限值）时退回 60Hz：那是最宽松的一档，
+/// 宁可漏报也不要凭空造出一堆 jank。上下限只用来挡住畸形取值。
+int frameBudgetMicrosForRefreshRate(double refreshRate) {
+  if (!refreshRate.isFinite || refreshRate <= 0) return 16667;
+  return (1000000 / refreshRate).round().clamp(4000, 33334);
+}
+
+/// 一段 [FrameTiming] 的汇总。
+///
+/// [dropped] 是这里唯一能看见「帧根本没产出」的量。`buildDuration` 和
+/// `rasterDuration` 只覆盖引擎真的开工的那两段：vsync 到 build 之间的等待不进账，
+/// 整帧被跳过更不会留下任何 [FrameTiming]。只有拿相邻两帧的 vsync 时间戳去除以
+/// 一帧的预算，才数得出中间空掉了几帧 —— 而那正是「build+raster 都只有 3ms，
+/// 滑动却明显不跟手」时唯一有用的那个数。
+class FrameTimingStats {
+  const FrameTimingStats({
+    required this.budgetMicros,
+    required this.frames,
+    required this.jank,
+    required this.dropped,
+    required this.avgFrameMs,
+    required this.worstFrameMs,
+    required this.avgBuildMs,
+    required this.worstBuildMs,
+    required this.avgRasterMs,
+    required this.worstRasterMs,
+    required this.avgSpanMs,
+    required this.worstSpanMs,
+    required this.worstVsyncOverheadMs,
+    required this.worstGapMs,
+  });
+
+  /// 手指停住、惯性走完都会在时间戳上留下一段很长的空档，那不是卡顿而是「没在滑」。
+  /// 超过这个长度的间隔只记进 [worstGapMs]，不折算成丢帧。
+  static const int maxCountedGapMicros = 200000;
+
+  factory FrameTimingStats.of(
+    List<FrameTiming> timings, {
+    required int budgetMicros,
+  }) {
+    var jank = 0;
+    var dropped = 0;
+    var totalFrame = 0;
+    var totalBuild = 0;
+    var totalRaster = 0;
+    var totalSpan = 0;
+    var worstFrame = 0;
+    var worstBuild = 0;
+    var worstRaster = 0;
+    var worstSpan = 0;
+    var worstVsyncOverhead = 0;
+    var worstGap = 0;
+    int? previousVsync;
+
+    for (final timing in timings) {
+      final build = timing.buildDuration.inMicroseconds;
+      final raster = timing.rasterDuration.inMicroseconds;
+      final frame = build + raster;
+      final span = timing.totalSpan.inMicroseconds;
+      final vsyncOverhead = timing.vsyncOverhead.inMicroseconds;
+
+      totalFrame += frame;
+      totalBuild += build;
+      totalRaster += raster;
+      totalSpan += span;
+      if (frame > worstFrame) worstFrame = frame;
+      if (build > worstBuild) worstBuild = build;
+      if (raster > worstRaster) worstRaster = raster;
+      if (span > worstSpan) worstSpan = span;
+      if (vsyncOverhead > worstVsyncOverhead) {
+        worstVsyncOverhead = vsyncOverhead;
+      }
+      if (frame > budgetMicros) jank++;
+
+      final vsync = timing.timestampInMicroseconds(FramePhase.vsyncStart);
+      final previous = previousVsync;
+      if (previous != null) {
+        final gap = vsync - previous;
+        if (gap > worstGap) worstGap = gap;
+        if (gap > 0 && gap < maxCountedGapMicros) {
+          final skipped = (gap / budgetMicros).round() - 1;
+          if (skipped > 0) dropped += skipped;
+        }
+      }
+      previousVsync = vsync;
+    }
+
+    final count = timings.length;
+    double avg(int total) => count == 0 ? 0.0 : (total / count) / 1000.0;
+
+    return FrameTimingStats(
+      budgetMicros: budgetMicros,
+      frames: count,
+      jank: jank,
+      dropped: dropped,
+      avgFrameMs: avg(totalFrame),
+      worstFrameMs: worstFrame / 1000.0,
+      avgBuildMs: avg(totalBuild),
+      worstBuildMs: worstBuild / 1000.0,
+      avgRasterMs: avg(totalRaster),
+      worstRasterMs: worstRaster / 1000.0,
+      avgSpanMs: avg(totalSpan),
+      worstSpanMs: worstSpan / 1000.0,
+      worstVsyncOverheadMs: worstVsyncOverhead / 1000.0,
+      worstGapMs: worstGap / 1000.0,
+    );
+  }
+
+  final int budgetMicros;
+  final int frames;
+
+  /// build + raster 超过一帧预算的帧数。
+  final int jank;
+
+  /// 按 vsync 间隔折算出来的、根本没产出的帧数。
+  final int dropped;
+  final double avgFrameMs;
+  final double worstFrameMs;
+  final double avgBuildMs;
+  final double worstBuildMs;
+  final double avgRasterMs;
+  final double worstRasterMs;
+
+  /// vsync 到光栅结束的整段耗时，包含了 build+raster 之外的等待。
+  final double avgSpanMs;
+  final double worstSpanMs;
+  final double worstVsyncOverheadMs;
+  final double worstGapMs;
+
+  String toCompactText() {
+    return 'budget=${(budgetMicros / 1000.0).toStringAsFixed(1)}ms, '
+        'frames=$frames, frameJank=$jank, dropped=$dropped, '
+        'avgFrame=${avgFrameMs.toStringAsFixed(1)}ms, '
+        'worstFrame=${worstFrameMs.toStringAsFixed(1)}ms, '
+        'avgBuild=${avgBuildMs.toStringAsFixed(1)}ms, '
+        'worstBuild=${worstBuildMs.toStringAsFixed(1)}ms, '
+        'avgRaster=${avgRasterMs.toStringAsFixed(1)}ms, '
+        'worstRaster=${worstRasterMs.toStringAsFixed(1)}ms, '
+        'avgSpan=${avgSpanMs.toStringAsFixed(1)}ms, '
+        'worstSpan=${worstSpanMs.toStringAsFixed(1)}ms, '
+        'worstVsync=${worstVsyncOverheadMs.toStringAsFixed(1)}ms, '
+        'worstGap=${worstGapMs.toStringAsFixed(1)}ms';
+  }
+}

--- a/lib/utils/jank_detector.dart
+++ b/lib/utils/jank_detector.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/scheduler.dart';
 import 'package:thoughtecho/services/unified_log_service.dart';
+import 'package:thoughtecho/utils/frame_timing_stats.dart';
 
 /// 零开销的 UI 卡顿/掉帧自动检测器
 class JankDetector {
@@ -19,18 +21,39 @@ class JankDetector {
     }
   }
 
+  /// 「连丢两帧」是多少微秒，按这块屏真实的刷新率算：120Hz 是 16667，
+  /// 60Hz 是 33334。
+  ///
+  /// 原来写死 32ms 并注明「基于 60fps 屏幕 16.6ms/帧」。120Hz 屏一帧只有 8.3ms，
+  /// 那个阈值等于连丢四帧才报一次，日志里于是一片安静而人明显觉得卡。取不到刷新率
+  /// 时退回 60Hz 的口径，宁可漏报也不要凭空造出一堆告警。
+  ///
+  /// 单位是微秒不是毫秒：`Duration.inMilliseconds` 直接截断，33.9ms 的一帧读出来
+  /// 是 33，正好卡在阈值下面。
+  /// 刷新率走 binding 而不是 `PlatformDispatcher.instance`：测试里前者才是
+  /// 能被改写的那个，后者永远是宿主机的真实屏幕。
+  @visibleForTesting
+  static int get jankThresholdMicros {
+    final rate = SchedulerBinding
+            .instance.platformDispatcher.implicitView?.display.refreshRate ??
+        0.0;
+    return frameBudgetMicrosForRefreshRate(rate) * 2;
+  }
+
   static void init() {
     if (_initialized) {
       return;
     }
     _initialized = true;
     SchedulerBinding.instance.addTimingsCallback((List<FrameTiming> timings) {
+      final thresholdMicros = jankThresholdMicros;
       for (final timing in timings) {
-        final buildMs = timing.buildDuration.inMilliseconds;
-        final rasterMs = timing.rasterDuration.inMilliseconds;
+        final buildMicros = timing.buildDuration.inMicroseconds;
+        final rasterMicros = timing.rasterDuration.inMicroseconds;
+        final buildMs = buildMicros ~/ 1000;
+        final rasterMs = rasterMicros ~/ 1000;
 
-        // 阈值：32ms 约等于连丢两帧 (基于 60fps 屏幕 16.6ms/帧)
-        if (buildMs > 32 || rasterMs > 32) {
+        if (buildMicros > thresholdMicros || rasterMicros > thresholdMicros) {
           final now = DateTime.now();
           // 触发节流阀，避免动画持续卡顿时疯狂写入数据库
           if (_lastLogTime == null ||

--- a/lib/widgets/note_list/collapsed_rich_text.dart
+++ b/lib/widgets/note_list/collapsed_rich_text.dart
@@ -749,6 +749,10 @@ class CollapsedRichTextPlanCache {
     return existing;
   }
 
+  /// 未命中次数。空闲预热拿它给自己记账（见 `note_list_warmup.dart`）：
+  /// 读一个 int 就够了，不必为此建一张 [stats] map。
+  static int get missCount => _missCount;
+
   static void _recordMiss(int workMicros) {
     _missCount++;
     _workMicros += workMicros;

--- a/lib/widgets/note_list/note_list_scroll.dart
+++ b/lib/widgets/note_list/note_list_scroll.dart
@@ -2,6 +2,20 @@ part of '../note_list_view.dart';
 
 /// Scroll-related methods for NoteListViewState.
 extension _NoteListScrollExtension on NoteListViewState {
+  /// 这块屏一帧有多少微秒，见 [frameBudgetMicrosForRefreshRate]。
+  int get _frameBudgetMicros {
+    var rate = 0.0;
+    if (mounted) {
+      rate = View.maybeOf(context)?.display.refreshRate ?? 0.0;
+    }
+    if (rate <= 0) {
+      rate = WidgetsBinding
+              .instance.platformDispatcher.implicitView?.display.refreshRate ??
+          0.0;
+    }
+    return frameBudgetMicrosForRefreshRate(rate);
+  }
+
   String _quoteContentCacheStatsText() {
     return QuoteContent.debugCompactCacheStats();
   }
@@ -252,6 +266,10 @@ extension _NoteListScrollExtension on NoteListViewState {
             ? 'up'
             : 'still';
 
+    // 一帧的预算取一次，下面的事件间隔和帧统计共用同一个口径。
+    final budgetMicros = _frameBudgetMicros;
+    final eventJankThresholdMicros = (budgetMicros * 1.5).round();
+
     var jankyIntervals = 0;
     var worstIntervalMicros = 0;
     var totalIntervalMicros = 0;
@@ -262,54 +280,23 @@ extension _NoteListScrollExtension on NoteListViewState {
       if (interval > worstIntervalMicros) {
         worstIntervalMicros = interval;
       }
-      if (interval > 20000) {
+      // 事件间隔的阈值也跟着预算走：原来写死 20ms，在 120Hz 上等于「连丢两帧半
+      // 才算一次」，正好把这块屏最常见的丢一帧漏掉。
+      if (interval > eventJankThresholdMicros) {
         jankyIntervals++;
       }
     }
 
-    var jankyFrames = 0;
-    var totalFrameMicros = 0;
-    var totalBuildMicros = 0;
-    var totalRasterMicros = 0;
-    var worstFrameMs = 0.0;
-    var worstBuildMs = 0.0;
-    var worstRasterMs = 0.0;
-    for (final timing in _scrollSessionFrameTimings) {
-      final buildMicros = timing.buildDuration.inMicroseconds;
-      final rasterMicros = timing.rasterDuration.inMicroseconds;
-      final totalMicros = buildMicros + rasterMicros;
-      totalFrameMicros += totalMicros;
-      totalBuildMicros += buildMicros;
-      totalRasterMicros += rasterMicros;
-      final frameMs = totalMicros / 1000.0;
-      final buildMs = buildMicros / 1000.0;
-      final rasterMs = rasterMicros / 1000.0;
-      if (frameMs > worstFrameMs) {
-        worstFrameMs = frameMs;
-      }
-      if (buildMs > worstBuildMs) {
-        worstBuildMs = buildMs;
-      }
-      if (rasterMs > worstRasterMs) {
-        worstRasterMs = rasterMs;
-      }
-      if (totalMicros > 16600) {
-        jankyFrames++;
-      }
-    }
+    final frameStats = FrameTimingStats.of(
+      _scrollSessionFrameTimings,
+      budgetMicros: budgetMicros,
+    );
 
     final intervalSamples =
         (_scrollSessionUpdateMicros.length - 1).clamp(0, 1 << 30);
     final avgIntervalMs = intervalSamples == 0
         ? 0.0
         : (totalIntervalMicros / intervalSamples) / 1000.0;
-    final frameSamples = _scrollSessionFrameTimings.length;
-    final avgFrameMs =
-        frameSamples == 0 ? 0.0 : (totalFrameMicros / frameSamples) / 1000.0;
-    final avgBuildMs =
-        frameSamples == 0 ? 0.0 : (totalBuildMicros / frameSamples) / 1000.0;
-    final avgRasterMs =
-        frameSamples == 0 ? 0.0 : (totalRasterMicros / frameSamples) / 1000.0;
 
     final cacheBaseline = _scrollSessionStartQuoteContentStats;
     final quoteContentStats = QuoteContent.debugCompactCacheStats(
@@ -335,9 +322,16 @@ extension _NoteListScrollExtension on NoteListViewState {
         'worst=${(_scrollSessionWorstItemLayoutMicros / 1000.0).toStringAsFixed(1)}ms';
     // 预热进度：滑动时 expandMiss+/planMiss+/Δimg+ 还高，就先看这一行是不是根本
     // 没跑起来（游标没走完、或宽度一直取不到）。
+    // `expand`/`plan` 是预热**自己**做掉的测量量，`items` 只数循环转了几圈 ——
+    // 键对不上、或者缓存被清空后没重暖时，`items` 照样很好看而这两个是 0。
+    // `gen` 跟着 [QuoteContent.cacheGeneration] 走，`rewarm` 数被清了几次。
     final warmupStats = 'items=$_idleWarmupWarmedItems,'
         'cursor=$_idleWarmupCursor/${_quotes.length},'
-        'img=$_idleWarmupPrecachedImages';
+        'img=$_idleWarmupPrecachedImages,'
+        'expand=$_idleWarmupExpandMisses,'
+        'plan=$_idleWarmupPlanMisses,'
+        'gen=${QuoteContent.cacheGeneration},'
+        'rewarm=$_idleWarmupRewarms';
     final itemMountStats = 'count=$_scrollSessionItemMountCount,'
         'workUs=$_scrollSessionItemMountMicros,'
         'worstUs=$_scrollSessionWorstItemMountMicros';
@@ -372,10 +366,7 @@ extension _NoteListScrollExtension on NoteListViewState {
       'elapsed=${elapsedMs.toStringAsFixed(0)}ms, updates=$intervalSamples, '
       'eventJank=$jankyIntervals, eventAvg=${avgIntervalMs.toStringAsFixed(1)}ms, '
       'eventWorst=${(worstIntervalMicros / 1000.0).toStringAsFixed(1)}ms, '
-      'frames=$frameSamples, frameJank=$jankyFrames, '
-      'avgFrame=${avgFrameMs.toStringAsFixed(1)}ms, worstFrame=${worstFrameMs.toStringAsFixed(1)}ms, '
-      'avgBuild=${avgBuildMs.toStringAsFixed(1)}ms, worstBuild=${worstBuildMs.toStringAsFixed(1)}ms, '
-      'avgRaster=${avgRasterMs.toStringAsFixed(1)}ms, worstRaster=${worstRasterMs.toStringAsFixed(1)}ms, '
+      '${frameStats.toCompactText()}, '
       'quotes={${_quoteMixStatsText()}}, quoteContent={$quoteContentStats}, '
       'quoteItem={$quoteItemStats}, imageCache={$imageStats}, '
       'imageEmbed={$imageEmbedStats}, '
@@ -394,10 +385,11 @@ extension _NoteListScrollExtension on NoteListViewState {
     _scrollSessionTracer?.instant(
         'ThoughtEcho.NoteListView.scrollSession.finalize',
         arguments: {
-          'frames': frameSamples,
-          'frameJank': jankyFrames,
-          'worstFrameMs': worstFrameMs.toStringAsFixed(1),
-          'avgFrameMs': avgFrameMs.toStringAsFixed(1),
+          'frames': frameStats.frames,
+          'frameJank': frameStats.jank,
+          'droppedFrames': frameStats.dropped,
+          'worstFrameMs': frameStats.worstFrameMs.toStringAsFixed(1),
+          'avgFrameMs': frameStats.avgFrameMs.toStringAsFixed(1),
         });
     _scrollSessionTracer?.finish();
     _scrollSessionTracer = null;
@@ -512,60 +504,23 @@ extension _NoteListScrollExtension on NoteListViewState {
     _releasePerfTimingsCallbackIfIdle();
 
     if (_firstOpenScrollFrameTimings.isNotEmpty) {
-      int jankyFrames = 0;
-      double worstFrameMs = 0;
-      double worstBuildMs = 0;
-      double worstRasterMs = 0;
-      int totalFrameMicros = 0;
-      int totalBuildMicros = 0;
-      int totalRasterMicros = 0;
-
-      for (final timing in _firstOpenScrollFrameTimings) {
-        final int buildMicros = timing.buildDuration.inMicroseconds;
-        final int rasterMicros = timing.rasterDuration.inMicroseconds;
-        final int totalMicros = buildMicros + rasterMicros;
-        totalFrameMicros += totalMicros;
-        totalBuildMicros += buildMicros;
-        totalRasterMicros += rasterMicros;
-
-        final frameMs = totalMicros / 1000.0;
-        final buildMs = buildMicros / 1000.0;
-        final rasterMs = rasterMicros / 1000.0;
-        if (frameMs > worstFrameMs) {
-          worstFrameMs = frameMs;
-        }
-        if (buildMs > worstBuildMs) {
-          worstBuildMs = buildMs;
-        }
-        if (rasterMs > worstRasterMs) {
-          worstRasterMs = rasterMs;
-        }
-
-        if (totalMicros > 16600) {
-          jankyFrames++;
-        }
-      }
-
-      final totalFrames = _firstOpenScrollFrameTimings.length;
-      final avgFrameMs = (totalFrameMicros / totalFrames) / 1000.0;
-      final avgBuildMs = (totalBuildMicros / totalFrames) / 1000.0;
-      final avgRasterMs = (totalRasterMicros / totalFrames) / 1000.0;
+      final frameStats = FrameTimingStats.of(
+        _firstOpenScrollFrameTimings,
+        budgetMicros: _frameBudgetMicros,
+      );
 
       logDebug(
-        '首次滑动性能结果(FrameTiming): total=$totalFrames, jank=$jankyFrames, '
-        'avg=${avgFrameMs.toStringAsFixed(1)}ms, '
-        'worst=${worstFrameMs.toStringAsFixed(1)}ms, '
-        'avgBuild=${avgBuildMs.toStringAsFixed(1)}ms, worstBuild=${worstBuildMs.toStringAsFixed(1)}ms, '
-        'avgRaster=${avgRasterMs.toStringAsFixed(1)}ms, worstRaster=${worstRasterMs.toStringAsFixed(1)}ms',
+        '首次滑动性能结果(FrameTiming): ${frameStats.toCompactText()}',
         source: 'NoteListView.Perf',
       );
       _firstOpenTracer?.instant(
           'ThoughtEcho.NoteListView.firstOpenScroll.finalize',
           arguments: {
-            'frames': totalFrames,
-            'frameJank': jankyFrames,
-            'worstFrameMs': worstFrameMs.toStringAsFixed(1),
-            'avgFrameMs': avgFrameMs.toStringAsFixed(1),
+            'frames': frameStats.frames,
+            'frameJank': frameStats.jank,
+            'droppedFrames': frameStats.dropped,
+            'worstFrameMs': frameStats.worstFrameMs.toStringAsFixed(1),
+            'avgFrameMs': frameStats.avgFrameMs.toStringAsFixed(1),
           });
     } else {
       if (_firstOpenScrollUpdateMicros.length < 2) {
@@ -701,55 +656,15 @@ extension _NoteListScrollExtension on NoteListViewState {
       _quotes.length,
     );
 
-    int jankyFrames = 0;
-    double worstFrameMs = 0;
-    double worstBuildMs = 0;
-    double worstRasterMs = 0;
-    int totalFrameMicros = 0;
-    int totalBuildMicros = 0;
-    int totalRasterMicros = 0;
-
-    for (final timing in _loadMorePerfFrameTimings) {
-      final int buildMicros = timing.buildDuration.inMicroseconds;
-      final int rasterMicros = timing.rasterDuration.inMicroseconds;
-      final int totalMicros = buildMicros + rasterMicros;
-      totalFrameMicros += totalMicros;
-      totalBuildMicros += buildMicros;
-      totalRasterMicros += rasterMicros;
-
-      final frameMs = totalMicros / 1000.0;
-      final buildMs = buildMicros / 1000.0;
-      final rasterMs = rasterMicros / 1000.0;
-      if (frameMs > worstFrameMs) {
-        worstFrameMs = frameMs;
-      }
-      if (buildMs > worstBuildMs) {
-        worstBuildMs = buildMs;
-      }
-      if (rasterMs > worstRasterMs) {
-        worstRasterMs = rasterMs;
-      }
-      if (totalMicros > 16600) {
-        jankyFrames++;
-      }
-    }
-
-    final totalFrames = _loadMorePerfFrameTimings.length;
-    final avgFrameMs =
-        totalFrames == 0 ? 0.0 : (totalFrameMicros / totalFrames) / 1000.0;
-    final avgBuildMs =
-        totalFrames == 0 ? 0.0 : (totalBuildMicros / totalFrames) / 1000.0;
-    final avgRasterMs =
-        totalFrames == 0 ? 0.0 : (totalRasterMicros / totalFrames) / 1000.0;
+    final frameStats = FrameTimingStats.of(
+      _loadMorePerfFrameTimings,
+      budgetMicros: _frameBudgetMicros,
+    );
 
     logDebug(
       '加载更多性能结果: start=$_loadMorePerfStartCount, '
       'current=${_quotes.length}, added=$addedCount, hasMore=$_hasMore, '
-      'elapsed=${elapsedMs}ms, frames=$totalFrames, jank=$jankyFrames, '
-      'avg=${avgFrameMs.toStringAsFixed(1)}ms, '
-      'worst=${worstFrameMs.toStringAsFixed(1)}ms, '
-      'avgBuild=${avgBuildMs.toStringAsFixed(1)}ms, worstBuild=${worstBuildMs.toStringAsFixed(1)}ms, '
-      'avgRaster=${avgRasterMs.toStringAsFixed(1)}ms, worstRaster=${worstRasterMs.toStringAsFixed(1)}ms',
+      'elapsed=${elapsedMs}ms, ${frameStats.toCompactText()}',
       source: 'NoteListView.Perf',
     );
     _logNoteListPerfSnapshot('加载更多缓存状态');

--- a/lib/widgets/note_list/note_list_warmup.dart
+++ b/lib/widgets/note_list/note_list_warmup.dart
@@ -66,12 +66,32 @@ extension _NoteListWarmupExtension on NoteListViewState {
     // 宽度或版式变了（旋屏、分屏、切换媒体版式）说明此前暖的键全作废，从头再来。
     // 图片的去重集合也要一起清：`imageProviderFor` 的解码尺寸就是按这两样算的，
     // 只按 source 记「暖过了」的话，换了尺寸的那张永远等不到预热。
-    if (_idleWarmupWidth != width || _idleWarmupMediaStyle != mediaStyle) {
+    //
+    // **缓存代号变了也一样要重来**。App 进后台时 `main.dart` 会把测量缓存整排清掉，
+    // 而游标停在列表末尾 —— 只看宽度和版式的话，回到前台后这一轮直接判定「暖完了」
+    // 然后去撑缓存区，缓存却是空的：接下来每张卡片滑进来都要现算折叠判定和折叠排版，
+    // 也就是「不是冷启动也卡」。Flutter 自己的 imageCache 在后台同样会被清，
+    // 所以 precache 的去重集合跟着一起清，否则那些图永远等不到第二次预解码。
+    final cacheGeneration = QuoteContent.cacheGeneration;
+    if (_idleWarmupWidth != width ||
+        _idleWarmupMediaStyle != mediaStyle ||
+        _idleWarmupCacheGeneration != cacheGeneration) {
+      if (_idleWarmupCacheGeneration != cacheGeneration &&
+          _idleWarmupCacheGeneration != null) {
+        _idleWarmupRewarms++;
+      }
       _idleWarmupWidth = width;
       _idleWarmupMediaStyle = mediaStyle;
+      _idleWarmupCacheGeneration = cacheGeneration;
       _idleWarmupCursor = 0;
       _idleWarmupPrecachedSources.clear();
     }
+
+    // 预热**自己**做掉了多少测量，按这一轮的未命中增量记账。`items` 只数循环转了
+    // 几圈，键对不上时它照样涨得很好看 —— 这两个增量才是「预热真的算过东西」的
+    // 证据，也是这一轮定位问题时最想要却没有的那个数。
+    final expandMissesBefore = QuoteContent.debugExpansionMissCount;
+    final planMissesBefore = CollapsedRichTextPlanCache.missCount;
 
     final stopwatch = Stopwatch()..start();
     while (_idleWarmupCursor < quotes.length &&
@@ -92,6 +112,11 @@ extension _NoteListWarmupExtension on NoteListViewState {
       );
       _idleWarmupWarmedItems++;
     }
+
+    _idleWarmupExpandMisses +=
+        QuoteContent.debugExpansionMissCount - expandMissesBefore;
+    _idleWarmupPlanMisses +=
+        CollapsedRichTextPlanCache.missCount - planMissesBefore;
 
     if (_idleWarmupCursor < quotes.length) {
       _scheduleIdleLayoutWarmup(

--- a/lib/widgets/note_list_view.dart
+++ b/lib/widgets/note_list_view.dart
@@ -17,10 +17,12 @@ import '../models/note_tag.dart';
 import '../services/database_service.dart';
 import '../utils/delta_media_extractor.dart';
 import '../utils/icon_utils.dart';
+import '../utils/frame_timing_stats.dart';
 import '../utils/jank_detector.dart';
 import '../utils/lottie_animation_manager.dart';
 import '../widgets/quote_item_widget.dart';
 import 'note_list/collapsed_media_banner.dart';
+import 'note_list/collapsed_rich_text.dart';
 import 'note_list/collapsed_media_thumbnail.dart';
 import '../widgets/quote_content_widget.dart';
 import '../widgets/app_loading_view.dart';
@@ -131,7 +133,8 @@ class NoteListView extends StatefulWidget {
   }
 }
 
-class NoteListViewState extends State<NoteListView> {
+class NoteListViewState extends State<NoteListView>
+    with WidgetsBindingObserver {
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode(); // 添加焦点节点管理
   final ScrollController _scrollController = ScrollController(); // 添加滚动控制器
@@ -259,8 +262,20 @@ class NoteListViewState extends State<NoteListView> {
   static const int _maxIdleWarmupDeferrals = 20;
   double? _idleWarmupWidth;
   String? _idleWarmupMediaStyle;
+
+  /// 上一轮预热是在哪一「代」测量缓存上跑的，见 [QuoteContent.cacheGeneration]。
+  int? _idleWarmupCacheGeneration;
+
+  /// 因为缓存被清空而重新暖过几轮。进后台再回来一次就 +1；一直是 0 说明
+  /// 缓存没被动过，滑动时还在 `planMiss+` 就得去别处找原因。
+  int _idleWarmupRewarms = 0;
   int _idleWarmupWarmedItems = 0;
   int _idleWarmupPrecachedImages = 0;
+
+  /// 预热**自己**做掉的测量量。这两个数是预热是否真的落地的唯一证据：
+  /// `items` 只说明循环转了多少圈，转空圈时它照样涨。
+  int _idleWarmupExpandMisses = 0;
+  int _idleWarmupPlanMisses = 0;
   final Set<String> _idleWarmupPrecachedSources = <String>{};
 
   /// 单轮预热的时间预算。一次暖满整张列表会在空闲帧里堆出一个上百毫秒的长任务，
@@ -514,6 +529,11 @@ class NoteListViewState extends State<NoteListView> {
     _isLoading = true; // 修复：保持为 true，避免闪现"无笔记"
     _isInitializing = true;
     _waitingForServices = true; // 初始等待服务初始化
+
+    // 进后台会把测量缓存整排清掉（见 main.dart 的 didChangeAppLifecycleState），
+    // 回前台得有人把空闲预热重新点着，否则缓存空着、游标满着，下一次滑动每张卡片
+    // 都要重算一遍。
+    WidgetsBinding.instance.addObserver(this);
 
     // 添加焦点节点监听器，用于Web平台的焦点管理
     _searchFocusNode.addListener(_onFocusChanged);
@@ -777,7 +797,17 @@ class NoteListViewState extends State<NoteListView> {
   // 移除重复的 _areListsEqual 定义
 
   @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state != AppLifecycleState.resumed) return;
+    // 缓存代号变没变由 `_runIdleWarmupTick` 自己比对：这里只负责排一轮，
+    // 没被清过的话那一轮查表全命中，几乎不花时间。
+    _scheduleIdleLayoutWarmup();
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     // 修复：安全清理所有资源
     try {
       _quotesSub?.cancel();

--- a/lib/widgets/quote_content_widget.dart
+++ b/lib/widgets/quote_content_widget.dart
@@ -241,7 +241,20 @@ class QuoteContent extends StatelessWidget {
   static const Key collapsedWrapperKey = ValueKey(
     'quote_content.collapsed_wrapper',
   );
+
+  /// 测量缓存的「代号」：[resetCaches] 每清一次自增一次。
+  ///
+  /// 空闲预热靠它知道自己暖出来的东西还在不在。App 进后台时 `main.dart` 会把下面
+  /// 这一整排缓存清空（省内存），而预热的游标停在列表末尾不动 —— 不比对代号的话，
+  /// 回到前台后预热永远不会重跑：缓存是空的、游标是满的，每张卡片滑进来都要重新
+  /// 算一遍折叠判定和折叠排版。日志里的表现是 `warmup={items=121,cursor=121/121}`
+  /// 看着很美，`expand=` 却恰好等于「一共建出来过几张卡」。
+  static int _cacheGeneration = 0;
+
+  static int get cacheGeneration => _cacheGeneration;
+
   static void resetCaches() {
+    _cacheGeneration++;
     _QuoteDocumentCache.clear();
     _QuoteHeightEstimateCache.clear();
     _QuotePlainTextLayoutExpansionCache.clear();
@@ -264,6 +277,10 @@ class QuoteContent extends StatelessWidget {
 
   @visibleForTesting
   static void clearCacheForTesting() => resetCaches();
+
+  /// 折叠判定的未命中次数。空闲预热拿它给自己记账，见 `note_list_warmup.dart`。
+  static int get debugExpansionMissCount =>
+      _QuotePlainTextLayoutExpansionCache._missCount;
 
   /// Returns lightweight cache counters for performance diagnostics.
   static Map<String, dynamic> debugCacheStats() => {

--- a/test/unit/utils/frame_timing_stats_test.dart
+++ b/test/unit/utils/frame_timing_stats_test.dart
@@ -1,0 +1,127 @@
+import 'dart:ui' show FrameTiming;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/frame_timing_stats.dart';
+
+/// 记录页的性能日志曾经把「一帧」写死成 60Hz 的 16.6ms，而且在三处各写一遍。
+/// 在 120Hz 屏上那等于「连丢两帧才算一次 jank」：日志里 `frameJank=0`，人明明
+/// 觉得卡。这个文件钉住两件事 —— 预算跟着刷新率走，以及「帧根本没产出」这件事
+/// 能从 vsync 间隔里被数出来（build/raster 时长永远看不见它）。
+FrameTiming _timing({
+  required int vsyncStart,
+  int vsyncOverheadMicros = 500,
+  int buildMicros = 2000,
+  int rasterMicros = 1000,
+}) {
+  final buildStart = vsyncStart + vsyncOverheadMicros;
+  final buildFinish = buildStart + buildMicros;
+  final rasterStart = buildFinish;
+  final rasterFinish = rasterStart + rasterMicros;
+  return FrameTiming(
+    vsyncStart: vsyncStart,
+    buildStart: buildStart,
+    buildFinish: buildFinish,
+    rasterStart: rasterStart,
+    rasterFinish: rasterFinish,
+    rasterFinishWallTime: rasterFinish,
+  );
+}
+
+void main() {
+  group('frameBudgetMicrosForRefreshRate', () {
+    test('按真实刷新率换算一帧的预算', () {
+      expect(frameBudgetMicrosForRefreshRate(120), 8333);
+      expect(frameBudgetMicrosForRefreshRate(90), 11111);
+      expect(frameBudgetMicrosForRefreshRate(60), 16667);
+    });
+
+    test('取不到刷新率时退回 60Hz，宁可漏报也不凭空造 jank', () {
+      expect(frameBudgetMicrosForRefreshRate(0), 16667);
+      expect(frameBudgetMicrosForRefreshRate(-1), 16667);
+      expect(frameBudgetMicrosForRefreshRate(double.nan), 16667);
+      expect(frameBudgetMicrosForRefreshRate(double.infinity), 16667);
+    });
+  });
+
+  group('FrameTimingStats', () {
+    test('每帧都踩在 vsync 上时既不算 jank 也不算丢帧', () {
+      const budget = 8333;
+      final stats = FrameTimingStats.of(
+        [
+          for (var i = 0; i < 5; i++) _timing(vsyncStart: i * budget),
+        ],
+        budgetMicros: budget,
+      );
+
+      expect(stats.frames, 5);
+      expect(stats.jank, 0);
+      expect(stats.dropped, 0);
+      expect(stats.avgFrameMs, closeTo(3.0, 0.01));
+    });
+
+    test('同一帧在 120Hz 上是 jank，在 60Hz 上不是', () {
+      final timings = [
+        _timing(vsyncStart: 0),
+        _timing(vsyncStart: 8333, buildMicros: 9000, rasterMicros: 3000),
+      ];
+
+      expect(FrameTimingStats.of(timings, budgetMicros: 8333).jank, 1);
+      expect(FrameTimingStats.of(timings, budgetMicros: 16667).jank, 0);
+    });
+
+    test('整帧被跳过时 build/raster 看不出来，vsync 间隔能数出来', () {
+      const budget = 8333;
+      // 第二帧和第三帧之间空了三个 vsync 周期，但每一帧自己都很快。
+      final stats = FrameTimingStats.of(
+        [
+          _timing(vsyncStart: 0),
+          _timing(vsyncStart: budget),
+          _timing(vsyncStart: budget + budget * 3),
+        ],
+        budgetMicros: budget,
+      );
+
+      expect(stats.jank, 0, reason: 'build+raster 都在预算内');
+      expect(stats.dropped, 2, reason: '中间空掉的两帧只有 vsync 间隔看得见');
+      expect(stats.worstGapMs, closeTo(budget * 3 / 1000.0, 0.01));
+    });
+
+    test('手指停住留下的长空档不算丢帧，但仍记进 worstGap', () {
+      const budget = 8333;
+      final stats = FrameTimingStats.of(
+        [
+          _timing(vsyncStart: 0),
+          _timing(vsyncStart: 3000000),
+        ],
+        budgetMicros: budget,
+      );
+
+      expect(stats.dropped, 0);
+      expect(stats.worstGapMs, closeTo(3000.0, 0.01));
+    });
+
+    test('vsync 到 build 之间的等待单独记账', () {
+      final stats = FrameTimingStats.of(
+        [
+          _timing(vsyncStart: 0, vsyncOverheadMicros: 400),
+          _timing(vsyncStart: 8333, vsyncOverheadMicros: 6200),
+        ],
+        budgetMicros: 8333,
+      );
+
+      expect(stats.worstVsyncOverheadMs, closeTo(6.2, 0.01));
+      expect(
+        stats.worstSpanMs,
+        closeTo(9.2, 0.01),
+        reason: 'totalSpan 要覆盖 build 之前的等待，否则这段时间无人认领',
+      );
+    });
+
+    test('空样本不炸', () {
+      final stats = FrameTimingStats.of(const [], budgetMicros: 8333);
+      expect(stats.frames, 0);
+      expect(stats.avgFrameMs, 0);
+      expect(stats.dropped, 0);
+    });
+  });
+}

--- a/test/unit/utils/jank_detector_test.dart
+++ b/test/unit/utils/jank_detector_test.dart
@@ -17,6 +17,18 @@ class FakeUnifiedLogService implements UnifiedLogService {
 }
 
 void main() {
+  testWidgets('卡顿阈值跟着屏幕刷新率走，而不是写死 60Hz', (WidgetTester tester) async {
+    // 原来写死 32ms 并注明「基于 60fps」。120Hz 屏一帧只有 8.3ms，那个阈值等于
+    // 连丢四帧才报一次 —— 日志里一片安静，人却明显觉得卡。
+    addTearDown(tester.view.display.resetRefreshRate);
+
+    tester.view.display.refreshRate = 60;
+    expect(JankDetector.jankThresholdMicros, 33334);
+
+    tester.view.display.refreshRate = 120;
+    expect(JankDetector.jankThresholdMicros, 16666);
+  });
+
   testWidgets('JankDetector normal, jank, throttle and session tests',
       (WidgetTester tester) async {
     final fakeLogService = FakeUnifiedLogService();
@@ -27,7 +39,7 @@ void main() {
     // init 再次调用，应该直接返回 (由于 _initialized)
     JankDetector.init();
 
-    // Normal frame: build 16ms, raster 16ms (under 32ms)
+    // Normal frame: build 16ms, raster 16ms（60Hz 下一帧 16.7ms，两帧 33.3ms）
     tester.binding.platformDispatcher.onReportTimings?.call([
       FrameTiming(
         vsyncStart: 0,
@@ -42,7 +54,7 @@ void main() {
     expect(fakeLogService.warnings.isEmpty, isTrue,
         reason: 'Normal frame should not trigger log');
 
-    // Jank frame: build 40ms, raster 10ms (build > 32ms)
+    // Jank frame: build 40ms, raster 10ms（超过两帧）
     tester.binding.platformDispatcher.onReportTimings?.call([
       FrameTiming(
         vsyncStart: 0,
@@ -111,13 +123,15 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 2100));
     });
 
-    // Jank frame again, should log with session 456
+    // Jank frame again, should log with session 456。
+    // 用 36ms 而不是 33ms：阈值现在按屏幕刷新率算（60Hz 下是两帧 33.3ms），
+    // 33ms 在 60Hz 上本来就不到两帧，那个取值只对旧的写死 32ms 成立。
     tester.binding.platformDispatcher.onReportTimings?.call([
       FrameTiming(
         vsyncStart: 0,
         buildStart: 0,
-        buildFinish: 33000,
-        rasterStart: 33000,
+        buildFinish: 36000,
+        rasterStart: 36000,
         rasterFinish: 40000,
         rasterFinishWallTime: 40000,
       )

--- a/test/widget/widgets/note_list/note_list_warmup_test.dart
+++ b/test/widget/widgets/note_list/note_list_warmup_test.dart
@@ -95,6 +95,9 @@ int _planMisses() => (QuoteContent.debugCacheStats()['plan']
 int _expansionMisses() => (QuoteContent.debugCacheStats()['expansion']
     as Map<String, dynamic>)['missCount'] as int;
 
+int _expansionCacheSize() => (QuoteContent.debugCacheStats()['expansion']
+    as Map<String, dynamic>)['cacheSize'] as int;
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -203,6 +206,79 @@ void main() {
       );
     });
   }
+
+  testWidgets('测量缓存被清空后，回到前台必须重新预热', (tester) async {
+    // App 进后台时 `main.dart` 会把 QuoteContent 的测量缓存整排清掉（省内存）。
+    // 预热的游标停在列表末尾不动，只比对宽度和版式的话，回到前台后这一轮直接判定
+    // 「暖完了」—— 缓存是空的、游标是满的，接下来每张卡片滑进来都要现算一遍折叠
+    // 判定和折叠排版。线上日志里这条路径长这样：`warmup={items=121,cursor=121/121}`
+    // 看着很美，`expand=` 却恰好等于「一共建出来过几张卡」。
+    final databaseService = _StreamingFakeDatabaseService();
+    final quotes = [
+      for (var i = 0; i < 120; i++)
+        Quote(
+          id: 'rewarm-$i',
+          content: '缓存清空后重新预热测试笔记 $i',
+          date: DateTime(2026, 8, 22, 9)
+              .subtract(Duration(minutes: i))
+              .toIso8601String(),
+          editSource: 'inline',
+          dayPeriod: 'morning',
+        ),
+    ];
+
+    await tester.pumpWidget(
+      _TestApp(
+        databaseService: databaseService,
+        settingsService: _FakeSettingsService(),
+      ),
+    );
+    await tester.pump();
+    databaseService.emit(quotes, hasMore: false);
+    await tester.pump();
+
+    Future<void> settleIdleWork() async {
+      for (var i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+      }
+    }
+
+    int builtCards() =>
+        find.byType(QuoteItemWidget, skipOffstage: false).evaluate().length;
+
+    await settleIdleWork();
+
+    expect(
+      _expansionCacheSize(),
+      greaterThanOrEqualTo(quotes.length),
+      reason: '静止期预热应当把整张列表的折叠判定都暖好',
+    );
+    // 缓存里的量必须是预热做的，不能是「卡片全建出来了」这种平凡解，
+    // 否则下面那条断言换成什么实现都能过。
+    expect(
+      builtCards(),
+      lessThan(quotes.length),
+      reason: '这个用例要证明的是预热覆盖了没建出来的条目',
+    );
+
+    // 模拟 main.dart 在 AppLifecycleState.paused 里做的事。
+    QuoteContent.resetCaches();
+    expect(_expansionCacheSize(), 0);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await settleIdleWork();
+
+    expect(
+      _expansionCacheSize(),
+      greaterThanOrEqualTo(quotes.length),
+      reason: '缓存被清空后预热没有重跑：游标停在列表末尾，'
+          '下一次滑动每张卡片都要重算一遍折叠判定',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(seconds: 2));
+    await databaseService.disposeStream();
+  });
 
   testWidgets('静止期把缓存区一级一级撑大，提前建出下一屏的卡片', (tester) async {
     final databaseService = _StreamingFakeDatabaseService();


### PR DESCRIPTION
接着 #487（空闲预热 + 缓存区预建）。用户反馈「不是冷启动也卡，虽然好了很多」，从 2026-08-22 的 release 日志查到两件同时成立的事。

## 一、空闲预热一直在空转

`warmup=` 说预热跑完了 121 条、发了 31 次 precache，可同一行里的缓存尺寸全部对不上：

| 指标 | 日志值 | 预热真跑过的话 |
|---|---|---|
| `expand`（折叠判定缓存） | 59 | ≥121 |
| `ir`（DeltaRichTextCache） | 20 | 40（`rich=40`） |
| `plan`（折叠排版缓存） | 36 | ≥40 |
| `imageCache.img` | 15 | ~31 |

`expand=59` 恰好等于 `tracked=59`（`_expandedItems.length`，「一共建出来过几张卡」），上一段是 `44/44`。缓存里没有一条是预热的份，全是卡片自己现算的；三个缓存的上限 300/200/300 都远没到，不是被挤掉的。

原因在 `lib/main.dart:719`：进后台 `QuoteContent.resetCaches()` 把七个测量缓存整排清掉（Android 侧后台还会清 Flutter 自己的 imageCache，正好解释 31 → 15），而 `_resetIdleLayoutWarmup()` 只在**列表内容变化**时才调用 —— 宽度和版式都没变，游标就停在 `121/121`：回前台后 tick 一进去直接判定「暖完了」，转头去撑缓存区，缓存却是空的。

改法：

- `QuoteContent.cacheGeneration`，`resetCaches()` 每清一次自增一次；预热 tick 拿它和宽度、版式一起比对，代号变了就把游标拨回 0 并清掉 precache 去重集合。走 generation 而不是直接挂生命周期，是为了让将来任何清缓存的路径都自动触发重暖。
- `NoteListViewState` 监听 `AppLifecycleState.resumed`，回前台排一轮预热；没被清过的话那一轮全是查表命中，几乎不花时间。

## 二、日志自己看不见这件事

报告问题的设备是 120Hz（一帧 8.3ms），而帧的 jank 阈值在三处各写死了一遍 `16600`（60Hz 的一帧）—— 那等于「连丢两帧才算一次」。于是 `frameJank=0` 和「明显觉得卡」可以同时成立：

| session | eventJank | eventWorst | frameJank | avgFrame |
|---|---|---|---|---|
| scroll-8 | 15/106 | 25.2ms | **0** | 3.0ms |
| scroll-6 | 14/141 | 82.8ms | 2 | 4.4ms |

而且 `frameJank` 只统计 `buildDuration + rasterDuration`：vsync 到 build 之间的等待不进账，**整帧被跳过更不会留下任何 FrameTiming**。

改法：

- 新增 `lib/utils/frame_timing_stats.dart`，一帧的预算按 `display.refreshRate` 算（120Hz → 8333µs），首滑 / 加载更多 / 滚动会话三处共用同一份换算和同一个汇总，`16600` 从此只此一处且不再是常量。`JankDetector` 的 32ms 同样改成「两帧」，并改用微秒比较（`inMilliseconds` 会把 33.9ms 截成 33）。
- 日志新增 `dropped=`（按相邻两帧 vsync 间隔折算出的、根本没产出的帧数）、`worstGap=`、`avgSpan=`/`worstSpan=`（`totalSpan`，含 build 之前的等待）、`worstVsync=`（`vsyncOverhead`）。
- `warmup={}` 新增 `expand=`/`plan=`（预热**自己**做掉的测量量）、`gen=`、`rewarm=`。`items` 只数循环转了几圈，转空圈时它照样很好看；这两个增量才是预热落地的证据 —— 也正是这一轮定位时最想要却没有的那个数。

## 验证

- `flutter analyze --no-fatal-infos`：干净（只剩两条既有的 `cacheExtent` deprecation）。
- 相关测试 **171 passed**（`test/widget/widgets/note_list/`、`test/unit/widgets/`、`test/unit/utils/`、`quote_content_widget_test`、四个 `note_list_*` widget 测试）。
- 新增 `test/unit/utils/frame_timing_stats_test.dart`（8 例：预算随刷新率、同一帧在 120Hz 是 jank 而 60Hz 不是、跳帧只有 vsync 间隔看得见、长空档不算丢帧）。
- 新增「测量缓存被清空后，回到前台必须重新预热」：跑完预热 → `resetCaches()` → `handleAppLifecycleStateChanged(resumed)` → 缓存必须重新填满。把 generation 比对拆掉重跑确认它会失败，否则这条断言证明不了任何东西。
- `jank_detector_test` 补一条阈值随刷新率的用例；原用例里 33ms 那一帧改成 36ms —— 33ms 在 60Hz 上本来就不到两帧，那个取值只对旧的写死 32ms 成立。

诊断过程记在 `docs/note-list-warmup-invalidation-2026-08-22.md`，含下一轮该看哪几个数。

## 还没做（按优先级）

1. **排版量封顶**：`planWorstUs=15486`（单条笔记一次 plan 15.5ms）、首个 rich-image 卡片 `itemLayout 18.3ms`。`_computePlan` 和渲染侧的 `Text.rich` 都把整块正文交给引擎，`maxLines` 只限制保留几行、断行仍然跑全文 —— 折叠盒只有 160px，成本却随笔记长度线性增长。
2. **分页别落在惯性里**：scroll-6 是唯一真掉帧的一段，也正是 `loadMoreStartΔ=1` 那段（15 次挂载、9 次解码）。
3. **iOS 的 Sentry profiling**：`profilesSampleRate` 目前是 null（仅 iOS/macOS 支持），且 profiling 只在有活跃 transaction 时采样，滑动本身不产生 transaction。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uothjCj8DFsmTVb5uUMgc