### PR TITLE
🩺 Guardian: 修复 RetryInterceptor 中 retryCount 非安全强转隐患

### DIFF
--- a/lib/services/network_service.dart
+++ b/lib/services/network_service.dart
@@ -457,11 +457,9 @@ class RetryInterceptor extends Interceptor {
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
-    if (err.requestOptions.extra['retryCount'] == null) {
-      err.requestOptions.extra['retryCount'] = 0;
-    }
-
-    final retryCount = err.requestOptions.extra['retryCount'] as int;
+    final rawCount = err.requestOptions.extra['retryCount'];
+    final retryCount = (rawCount is num) ? rawCount.toInt() : 0;
+    err.requestOptions.extra['retryCount'] = retryCount;
 
     if (retryCount < retries && _shouldRetry(err)) {
       err.requestOptions.extra['retryCount'] = retryCount + 1;

--- a/test/unit/services/network_service_test.dart
+++ b/test/unit/services/network_service_test.dart
@@ -1,9 +1,81 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/services/network_service.dart';
 import 'package:thoughtecho/models/ai_provider_settings.dart';
 import 'package:thoughtecho/models/ai_settings.dart';
 
+class MockErrorInterceptorHandler extends ErrorInterceptorHandler {
+  DioException? passedError;
+
+  @override
+  void next(DioException err) {
+    passedError = err;
+  }
+}
+
 void main() {
+  group('RetryInterceptor Tests', () {
+    test(
+        'should handle null or missing retryCount safely without throwing TypeError',
+        () async {
+      final dio = Dio();
+      final interceptor = RetryInterceptor(dio: dio, retries: 0);
+
+      final requestOptions = RequestOptions(path: 'https://example.com');
+      // extra['retryCount'] is null / omitted intentionally
+      final err = DioException(
+        requestOptions: requestOptions,
+        type: DioExceptionType.connectionTimeout,
+      );
+      final handler = MockErrorInterceptorHandler();
+
+      interceptor.onError(err, handler);
+
+      expect(requestOptions.extra['retryCount'], 0);
+      expect(handler.passedError, equals(err));
+    });
+
+    test('should handle non-int numeric retryCount safely', () async {
+      final dio = Dio();
+      final interceptor = RetryInterceptor(dio: dio, retries: 0);
+
+      final requestOptions = RequestOptions(
+        path: 'https://example.com',
+        extra: {'retryCount': 1.0},
+      );
+      final err = DioException(
+        requestOptions: requestOptions,
+        type: DioExceptionType.connectionTimeout,
+      );
+      final handler = MockErrorInterceptorHandler();
+
+      interceptor.onError(err, handler);
+
+      expect(requestOptions.extra['retryCount'], 1);
+      expect(handler.passedError, equals(err));
+    });
+
+    test('should handle unexpected type in retryCount safely as 0', () async {
+      final dio = Dio();
+      final interceptor = RetryInterceptor(dio: dio, retries: 0);
+
+      final requestOptions = RequestOptions(
+        path: 'https://example.com',
+        extra: {'retryCount': 'invalid_string'},
+      );
+      final err = DioException(
+        requestOptions: requestOptions,
+        type: DioExceptionType.connectionTimeout,
+      );
+      final handler = MockErrorInterceptorHandler();
+
+      interceptor.onError(err, handler);
+
+      expect(requestOptions.extra['retryCount'], 0);
+      expect(handler.passedError, equals(err));
+    });
+  });
+
   group('NetworkService AI Headers Tests', () {
     late NetworkService networkService;
 


### PR DESCRIPTION
🏷️ 问题类别: 🩺 Stability & Availability (稳定性与可用性)
💡 隐患剖析: 在 `RetryInterceptor.onError` 中，原逻辑通过 `err.requestOptions.extra['retryCount'] as int` 对重试次数进行强制类型转换。当 `retryCount` 缺失、为 `null`、为 `double` 类型或非数值类型时，会导致运行时抛出 `TypeError` 崩溃，中断网络异常处理链。
🎯 解决方案: 使用 safe type check `(rawCount is num) ? rawCount.toInt() : 0` 提取重试次数，确保 null 或非数值类型能够安全降级为 0，避免类型强转异常。
📊 收益影响: 提升网络请求重试模块的鲁棒性，消除因数据类型不匹配导致的运行时崩溃风险。
🔬 验证方式: 补充针对 `RetryInterceptor` 各种边界值（null、double、invalid string）的单元测试并全部通过，运行 `flutter analyze --no-fatal-infos` 静态检查无报错。

---
*PR created automatically by Jules for task [14239653073743129840](https://jules.google.com/task/14239653073743129840) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 RetryInterceptor 中对 retryCount 的非安全强转。旧行为：直接 `as int`，在缺失、null、double 或非数值时抛出 TypeError。新行为：对 num 安全取整，否则降级为 0，并回写到 extra，避免中断错误处理链。

**评审与验证**
- 仅调整 `onError` 中 retryCount 的读取与回写，不影响重试判定与流程。
- 新增单元测试覆盖 null、double、非法字符串三种边界，均通过。
- 无需迁移；调用方无需保证整型，任何数值类型会被安全处理。

<sup>Written for commit 5bbecf76778147d22bb0bef8ee70583cfa93f952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

