### PR TITLE
⚡ Bolt: 消除 GetNoteDetailTool 中标签查询的 N+1 问题

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -93,3 +93,7 @@
 ## 2025-01-20 - [Optimize String splitting to avoid memory allocation]
 **Learning:** Frequent `String.split` generates intermediate lists and strings which puts pressure on GC. Instead manual parsing using `String.indexOf` and `String.substring` minimizes allocations.
 **Action:** Replace `String.split` with manual parsing in high-frequency methods like when parsing `tagIdsString` in `DatabaseBackupService`.
+
+## 2026-08-15 - 消除 GetNoteDetailTool 中获取标签的 N+1 查询问题
+**Learning:** 在获取单篇笔记详情或关联数据时，循环调用 `getTagById(id)` 查询数据库会导致典型的 N+1 查询瓶颈。使用 SQLite 的 `IN (...)` 子句一次性批量传入参数（配合 SQL 绑定变参），可以将原本与标签数量成正比的数次数据库 I/O 压缩为单次高效查询，在大幅减少 SQLite 数据库/平台 Channel 跨进程通信开销的同时保持相同的类型与功能边界。
+**Action:** 在 `DatabaseService` 中定义并实装 `getTagsByIds(Iterable<String> ids)`，在 `GetNoteDetailTool.execute` 中改用 `_db.getTagsByIds(idsToFetch)` 批量获取分类和标签名称映射，消除标签详情读取中的 N+1 查询，并在单元测试中验证其单次调用行为。

--- a/lib/services/agent_tools/get_note_detail_tool.dart
+++ b/lib/services/agent_tools/get_note_detail_tool.dart
@@ -64,19 +64,14 @@ class GetNoteDetailTool extends AgentTool {
         );
       }
 
-      // 批量收集所有需要查询的分类ID和标签ID
+      // 批量收集所有需要查询的分类ID和标签ID，单次批量获取
       final idsToFetch = <String>{
         if (q.categoryId != null && q.categoryId!.isNotEmpty) q.categoryId!,
         ...q.tagIds,
       };
 
-      final nameMap = <String, String>{};
-      for (final id in idsToFetch) {
-        final cat = await _db.getTagById(id);
-        if (cat != null) {
-          nameMap[id] = cat.name;
-        }
-      }
+      final tagsMap = await _db.getTagsByIds(idsToFetch);
+      final nameMap = tagsMap.map((id, tag) => MapEntry(id, tag.name));
 
       final response = <String, Object?>{
         'id': q.id,

--- a/lib/services/database/database_tag_mixin.dart
+++ b/lib/services/database/database_tag_mixin.dart
@@ -508,17 +508,25 @@ mixin _DatabaseTagMixin on _DatabaseServiceBase {
 
     try {
       final db = database;
-      final placeholders = List.filled(idList.length, '?').join(',');
-      final maps = await db.query(
-        'categories',
-        where: 'id IN ($placeholders)',
-        whereArgs: idList,
-      );
-
       final result = <String, NoteTag>{};
-      for (final map in maps) {
-        final tag = NoteTag.fromMap(map);
-        result[tag.id] = tag;
+
+      const batchSize = 900;
+      for (int i = 0; i < idList.length; i += batchSize) {
+        final chunk = idList.sublist(
+          i,
+          i + batchSize > idList.length ? idList.length : i + batchSize,
+        );
+        final placeholders = List.filled(chunk.length, '?').join(',');
+        final maps = await db.query(
+          'categories',
+          where: 'id IN ($placeholders)',
+          whereArgs: chunk,
+        );
+
+        for (final map in maps) {
+          final tag = NoteTag.fromMap(map);
+          result[tag.id] = tag;
+        }
       }
       return result;
     } catch (e) {

--- a/lib/services/database/database_tag_mixin.dart
+++ b/lib/services/database/database_tag_mixin.dart
@@ -486,4 +486,44 @@ mixin _DatabaseTagMixin on _DatabaseServiceBase {
       return null;
     }
   }
+
+  /// 根据一组 ID 批量获取标签
+  @override
+  Future<Map<String, NoteTag>> getTagsByIds(Iterable<String> ids) async {
+    final idList = ids.where((id) => id.isNotEmpty).toSet().toList();
+    if (idList.isEmpty) {
+      return {};
+    }
+
+    if (kIsWeb) {
+      final result = <String, NoteTag>{};
+      final idSet = idList.toSet();
+      for (final tag in _tagStore) {
+        if (idSet.contains(tag.id)) {
+          result[tag.id] = tag;
+        }
+      }
+      return result;
+    }
+
+    try {
+      final db = database;
+      final placeholders = List.filled(idList.length, '?').join(',');
+      final maps = await db.query(
+        'categories',
+        where: 'id IN ($placeholders)',
+        whereArgs: idList,
+      );
+
+      final result = <String, NoteTag>{};
+      for (final map in maps) {
+        final tag = NoteTag.fromMap(map);
+        result[tag.id] = tag;
+      }
+      return result;
+    } catch (e) {
+      logDebug('批量根据 ID 获取标签失败: $e');
+      return {};
+    }
+  }
 }

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -166,6 +166,7 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
   Future<void> deleteTag(String id);
   Future<void> updateTag(String id, String name, {String? iconName});
   Future<NoteTag?> getTagById(String id);
+  Future<Map<String, NoteTag>> getTagsByIds(Iterable<String> ids);
 
   Future<void> initDefaultHitokotoTags();
   Future<NoteTag?> getOrCreateHiddenTag();

--- a/test/unit/services/database_multi_tag_filter_test.dart
+++ b/test/unit/services/database_multi_tag_filter_test.dart
@@ -364,5 +364,21 @@ void main() {
         expect(list.first.content, equals('matching both'));
       });
     });
+
+    group('getTagsByIds oversized batch test', () {
+      test('should retrieve all tags when id list exceeds SQLite batch limit (> 900 items)', () async {
+        const totalTags = 1050;
+        for (int i = 0; i < totalTags; i++) {
+          await service.addTagWithId('tag-id-$i', 'Tag Name $i');
+        }
+
+        final allIds = List.generate(totalTags, (i) => 'tag-id-$i');
+        final tagMap = await service.getTagsByIds(allIds);
+
+        expect(tagMap.length, equals(totalTags));
+        expect(tagMap['tag-id-0']?.name, equals('Tag Name 0'));
+        expect(tagMap['tag-id-1049']?.name, equals('Tag Name 1049'));
+      });
+    });
   });
 }

--- a/test/unit/services/database_multi_tag_filter_test.dart
+++ b/test/unit/services/database_multi_tag_filter_test.dart
@@ -366,7 +366,9 @@ void main() {
     });
 
     group('getTagsByIds oversized batch test', () {
-      test('should retrieve all tags when id list exceeds SQLite batch limit (> 900 items)', () async {
+      test(
+          'should retrieve all tags when id list exceeds SQLite batch limit (> 900 items)',
+          () async {
         const totalTags = 1050;
         for (int i = 0; i < totalTags; i++) {
           await service.addTagWithId('tag-id-$i', 'Tag Name $i');

--- a/test/unit/services/get_note_detail_tool_test.dart
+++ b/test/unit/services/get_note_detail_tool_test.dart
@@ -13,6 +13,7 @@ class _TestDatabaseService extends DatabaseService {
   _TestDatabaseService(this._quotes) : super.forTesting();
 
   final List<Quote> _quotes;
+  int getTagsByIdsCallCount = 0;
 
   @override
   Future<Quote?> getQuoteById(String id, {bool includeDeleted = false}) async {
@@ -32,7 +33,23 @@ class _TestDatabaseService extends DatabaseService {
     if (id == 'tag_idea') {
       return NoteTag(id: 'tag_idea', name: '灵感', isDefault: false);
     }
+    if (id == 'tag_life') {
+      return NoteTag(id: 'tag_life', name: '生活', isDefault: false);
+    }
     return null;
+  }
+
+  @override
+  Future<Map<String, NoteTag>> getTagsByIds(Iterable<String> ids) async {
+    getTagsByIdsCallCount++;
+    final result = <String, NoteTag>{};
+    for (final id in ids) {
+      final tag = await getTagById(id);
+      if (tag != null) {
+        result[id] = tag;
+      }
+    }
+    return result;
   }
 }
 
@@ -153,6 +170,36 @@ void main() {
 
       expect(result.isError, isTrue);
       expect(result.content, contains('未找到ID为non_existent_id的笔记'));
+    });
+
+    test('fetches category and multiple tags in a single batch query call',
+        () async {
+      final testDb = _TestDatabaseService(<Quote>[
+        Quote(
+          id: 'note_multi_tags',
+          content: 'Note with multiple tags',
+          date: '2026-06-06T12:00:00Z',
+          categoryId: 'cat_work',
+          tagIds: const ['tag_idea', 'tag_life'],
+        ),
+      ]);
+      final multiTool = GetNoteDetailTool(testDb);
+
+      final result = await multiTool.execute(
+        ToolCall(
+          id: 'call_multi',
+          name: 'get_note_detail',
+          arguments: const {
+            'note_id': 'note_multi_tags',
+          },
+        ),
+      );
+
+      expect(result.isError, isFalse);
+      expect(testDb.getTagsByIdsCallCount, 1);
+      final data = jsonDecode(result.content);
+      expect(data['category'], '工作');
+      expect(data['tags'], containsAll(['灵感', '生活']));
     });
   });
 }


### PR DESCRIPTION
💡 **What:** 在 `DatabaseService` 中新增 `getTagsByIds` 批量查询方法，并将 `GetNoteDetailTool` 中循环逐个查询分类和标签名称的逻辑重构为一次性批量查询。
🎯 **Why:** 消除 `GetNoteDetailTool.execute` 中多次触发 `getTagById` 查询数据库导致的 N+1 查询耗时与平台 Channel/SQLite I/O 开销。
📊 **Impact:** 将多标签笔记详情获取时的标签数据库查询操作由 O(N) 次 SQL 执行优化为 O(1) 次批量 `IN (...)` 查询，移除了数据库进程间通信开销。
🔬 **Measurement:** 增加了针对 `getTagsByIds` 调用的单元测试，断言验证单次批量查询行为及元数据映射正确性，并通过了全量单元测试与静态分析。

---
*PR created automatically by Jules for task [10601787133019462598](https://jules.google.com/task/10601787133019462598) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `GetNoteDetailTool` 的分类与标签查询从逐个调用改为一次性 `getTagsByIds` 批量查询，消除 N+1；旧行为为对每个 ID 单独查询，新行为为单次（按 900 参数分块）`IN (...)` 查询；结果不变但延迟与 I/O 显著降低。新增单测覆盖单次批量调用与 >900 ID 分块路径。

**审阅要点**
- 在 `DatabaseService` 增加 `getTagsByIds(Iterable<String>)`；SQLite 实现按批 900 参数分块；`kIsWeb` 走内存 `_tagStore`；自动过滤空 ID 并去重。
- `GetNoteDetailTool.execute` 改为一次批量获取并构建 `id -> name` 映射；新增测试验证单次调用与映射正确性。

**迁移**
- 所有 `DatabaseService` 子类及相关 mock/stub 必须实现 `getTagsByIds`。

<sup>Written for commit ee8f5e8cdf7137839bade8a92fb681e1fa178d40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化笔记详情加载，分类和多个标签信息现可通过一次批量查询获取。
  * 减少标签较多时的数据库访问次数，提升详情展示效率。

* **Bug 修复**
  * 改进标签 ID 的处理，自动过滤空值并去重，确保批量查询结果稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->