### PR TITLE
更新官网文案、下载页UI与导航链接

### DIFF
--- a/res/dl.html
+++ b/res/dl.html
@@ -103,45 +103,46 @@
         font-family:
           -apple-system, BlinkMacSystemFont, "PingFang SC", "Hiragino Sans GB",
           "Microsoft YaHei", "Noto Sans SC", "Segoe UI", sans-serif;
-        line-height: 1.7;
+        line-height: 1.6;
         -webkit-font-smoothing: antialiased;
-        padding: 0 1rem 4rem;
+        padding: 0 1rem 3rem;
       }
 
       /* Top Navigation Bar */
       .top-nav {
-        max-width: 680px;
-        margin: 0 auto;
-        padding: 1.25rem 0.5rem;
+        max-width: 600px;
+        margin: 0 auto 1.5rem;
+        padding: 1rem 0.25rem;
         display: flex;
         align-items: center;
         justify-content: space-between;
         border-bottom: 1px solid var(--line);
-        margin-bottom: 2rem;
+        flex-wrap: wrap;
+        gap: 0.75rem;
       }
 
       .nav-brand {
         display: flex;
         align-items: center;
-        gap: 0.6rem;
+        gap: 0.5rem;
         text-decoration: none;
         color: var(--ink);
         font-weight: 700;
-        font-size: 1.1rem;
+        font-size: 1.05rem;
       }
 
       .nav-brand img {
-        width: 32px;
-        height: 32px;
+        width: 30px;
+        height: 30px;
         border-radius: 8px;
       }
 
       .nav-links {
         display: flex;
         align-items: center;
-        gap: 1rem;
+        gap: 0.85rem;
         list-style: none;
-        font-size: 0.88rem;
+        font-size: 0.85rem;
       }
 
       .nav-links a {
@@ -156,51 +157,51 @@
 
       /* Main Content Container */
       main {
-        max-width: 580px;
+        max-width: 560px;
         margin: 0 auto;
       }
 
       /* Hero Header */
       .hero-header {
         text-align: center;
-        margin-bottom: 2rem;
+        margin-bottom: 1.75rem;
       }
 
       .app-logo {
-        width: 76px;
-        height: 76px;
-        margin: 0 auto 1rem;
-        border-radius: 20px;
-        box-shadow: 0 6px 18px var(--shadow-medium);
+        width: 64px;
+        height: 64px;
+        margin: 0 auto 0.75rem;
+        border-radius: 16px;
+        box-shadow: 0 4px 14px var(--shadow-medium);
         display: block;
       }
 
       h1 {
-        font-size: 1.75rem;
+        font-size: 1.5rem;
         font-weight: 700;
         letter-spacing: -0.01em;
-        margin-bottom: 0.4rem;
+        margin-bottom: 0.3rem;
         color: var(--ink);
       }
 
       .tagline {
-        font-size: 1.02rem;
+        font-size: 0.95rem;
         color: var(--ink-mid);
-        margin-bottom: 1rem;
+        margin-bottom: 0.85rem;
       }
 
       .pill-group {
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
-        gap: 0.45rem;
-        margin-bottom: 1.5rem;
+        gap: 0.35rem;
+        margin-bottom: 1.25rem;
       }
 
       .pill {
-        font-size: 0.76rem;
+        font-size: 0.72rem;
         font-weight: 500;
-        padding: 0.2rem 0.65rem;
+        padding: 0.15rem 0.55rem;
         border-radius: 999px;
         background: var(--card);
         border: 1px solid var(--line);
@@ -211,17 +212,18 @@
       .platform-filter {
         display: flex;
         justify-content: center;
-        gap: 0.5rem;
-        margin-bottom: 1.5rem;
+        gap: 0.4rem;
+        margin-bottom: 1.25rem;
+        flex-wrap: wrap;
       }
 
       .filter-btn {
         background: transparent;
         border: 1px solid var(--line);
         color: var(--ink-mid);
-        padding: 0.4rem 0.85rem;
+        padding: 0.35rem 0.75rem;
         border-radius: 8px;
-        font-size: 0.85rem;
+        font-size: 0.82rem;
         cursor: pointer;
         transition: all 0.2s ease;
       }
@@ -241,18 +243,18 @@
       /* Download Cards */
       .download-card {
         background: var(--card);
-        border: 1.5px solid var(--line);
-        border-radius: 16px;
-        padding: 1.5rem;
-        margin-bottom: 1.25rem;
-        box-shadow: 0 4px 16px var(--shadow-soft);
-        transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 1.25rem;
+        margin-bottom: 1rem;
+        box-shadow: 0 2px 10px var(--shadow-soft);
+        transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
         position: relative;
       }
 
       .download-card:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 24px var(--shadow-medium);
+        box-shadow: 0 6px 18px var(--shadow-medium);
         border-color: var(--accent);
       }
 
@@ -265,22 +267,24 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
-        margin-bottom: 0.6rem;
+        margin-bottom: 0.5rem;
+        flex-wrap: wrap;
+        gap: 0.4rem;
       }
 
       .card-title {
-        font-size: 1.2rem;
+        font-size: 1.1rem;
         font-weight: 700;
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: 0.4rem;
         color: var(--ink);
       }
 
       .badge {
-        font-size: 0.72rem;
+        font-size: 0.7rem;
         font-weight: 600;
-        padding: 0.15rem 0.55rem;
+        padding: 0.12rem 0.5rem;
         border-radius: 999px;
         background: rgba(166, 124, 82, 0.12);
         color: var(--accent);
@@ -300,36 +304,36 @@
       }
 
       .card-desc {
-        font-size: 0.9rem;
+        font-size: 0.86rem;
         color: var(--ink-mid);
-        margin-bottom: 1.15rem;
-        line-height: 1.6;
+        margin-bottom: 1rem;
+        line-height: 1.55;
       }
 
       .btn-download {
         display: flex;
         align-items: center;
         justify-content: center;
-        gap: 0.5rem;
+        gap: 0.4rem;
         width: 100%;
-        padding: 0.85rem 1.25rem;
-        border-radius: 12px;
+        padding: 0.75rem 1rem;
+        border-radius: 10px;
         background: var(--accent);
         color: #ffffff !important;
         text-align: center;
         text-decoration: none;
         font-weight: 600;
-        font-size: 1rem;
+        font-size: 0.95rem;
         border: none;
         cursor: pointer;
-        box-shadow: 0 4px 12px rgba(166, 124, 82, 0.25);
+        box-shadow: 0 3px 10px rgba(166, 124, 82, 0.22);
         transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
       }
 
       .btn-download:hover {
         background: var(--accent-hover);
         transform: translateY(-1px);
-        box-shadow: 0 6px 16px rgba(166, 124, 82, 0.35);
+        box-shadow: 0 5px 14px rgba(166, 124, 82, 0.32);
       }
 
       .btn-download.ghost {
@@ -344,13 +348,13 @@
       }
 
       .card-sublinks {
-        margin-top: 0.85rem;
+        margin-top: 0.75rem;
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
         align-items: center;
-        gap: 0.75rem;
-        font-size: 0.82rem;
+        gap: 0.5rem 0.75rem;
+        font-size: 0.8rem;
         color: var(--ink-light);
       }
 
@@ -366,9 +370,9 @@
       }
 
       .card-note {
-        font-size: 0.78rem;
+        font-size: 0.75rem;
         color: var(--ink-light);
-        margin-top: 0.65rem;
+        margin-top: 0.5rem;
         text-align: center;
       }
 
@@ -376,25 +380,25 @@
       .faq-card {
         background: var(--card);
         border: 1px solid var(--line);
-        border-radius: 14px;
-        padding: 1.25rem 1.5rem;
-        margin-top: 1.75rem;
+        border-radius: 12px;
+        padding: 1.1rem 1.25rem;
+        margin-top: 1.5rem;
       }
 
       .faq-title {
-        font-size: 1rem;
+        font-size: 0.95rem;
         font-weight: 700;
-        margin-bottom: 0.85rem;
+        margin-bottom: 0.75rem;
         color: var(--ink);
         display: flex;
         align-items: center;
-        gap: 0.4rem;
+        gap: 0.35rem;
       }
 
       details {
         border-bottom: 1px dashed var(--line);
-        padding: 0.65rem 0;
-        font-size: 0.88rem;
+        padding: 0.55rem 0;
+        font-size: 0.85rem;
       }
 
       details:last-child {
@@ -414,10 +418,10 @@
       }
 
       details p {
-        margin-top: 0.5rem;
+        margin-top: 0.4rem;
         color: var(--ink-mid);
-        line-height: 1.65;
-        font-size: 0.85rem;
+        line-height: 1.6;
+        font-size: 0.82rem;
       }
 
       details a {
@@ -427,9 +431,9 @@
 
       /* Footer */
       footer {
-        margin-top: 3rem;
+        margin-top: 2.5rem;
         text-align: center;
-        font-size: 0.84rem;
+        font-size: 0.8rem;
         color: var(--ink-light);
         line-height: 1.8;
       }
@@ -446,8 +450,48 @@
       }
 
       .footer-divider {
-        margin: 0 0.35rem;
+        margin: 0 0.25rem;
         color: var(--line);
+      }
+
+      /* Responsive Adjustments for Mobile */
+      @media (max-width: 480px) {
+        body {
+          padding: 0 0.75rem 2rem;
+        }
+
+        .top-nav {
+          padding: 0.85rem 0;
+          margin-bottom: 1.25rem;
+        }
+
+        .hero-header {
+          margin-bottom: 1.25rem;
+        }
+
+        .app-logo {
+          width: 56px;
+          height: 56px;
+          margin-bottom: 0.5rem;
+        }
+
+        h1 {
+          font-size: 1.35rem;
+        }
+
+        .tagline {
+          font-size: 0.88rem;
+        }
+
+        .download-card {
+          padding: 1rem;
+          margin-bottom: 0.85rem;
+        }
+
+        .btn-download {
+          padding: 0.68rem 0.85rem;
+          font-size: 0.9rem;
+        }
       }
 
       /* Hidden utility */

--- a/res/index.html
+++ b/res/index.html
@@ -257,9 +257,9 @@
             </div>
 
             <h1>
-              <span class="content-zh">你的专属<br />灵感摘录本 & 笔记APP</span>
+              <span class="content-zh">你的专属<br />灵感摘录本</span>
               <span class="content-en"
-                >Your Personal<br />Inspiration Notebook & Notes</span
+                >Your Personal<br />Inspiration Notebook</span
               >
             </h1>
 

--- a/res/thoughter/index.html
+++ b/res/thoughter/index.html
@@ -1068,11 +1068,6 @@
   <!-- Hero Section -->
   <section class="hero-section">
     <div class="container">
-      <div class="hero-eyebrow">
-        <span class="hero-eyebrow-dot"></span>
-        THOUGHTECHO · AI INSPIRATION COMPANION
-      </div>
-
       <div class="typewriter-stage">
         <h1 class="hero-title"><span id="typewriterText">翻阅旧日片羽，聊聊当下所想。</span><span class="cursor"></span></h1>
       </div>

--- a/res/user-guide.html
+++ b/res/user-guide.html
@@ -412,10 +412,6 @@
                     <span class="lang-en">Contents</span>
                 </button>
                 <button id="langToggle">EN/中文</button>
-                <button onclick="location.href='thoughter/index.html'">
-                    <span class="lang-zh">Thoughter 伴写</span>
-                    <span class="lang-en">Thoughter</span>
-                </button>
                 <button onclick="location.href='dl.html'">
                     <span class="lang-zh">下载心迹</span>
                     <span class="lang-en">Download</span>


### PR DESCRIPTION
根据需求调整官网首页标题为“你的专属灵感摘录本”（保持 SEO 关键词不变），重构并优化下载页移动端排版与体验，移除用户指南导航中的 Thoughter 链接以及 Thoughter 顶部的标识文本。

---
*PR created automatically by Jules for task [12688389654847070490](https://jules.google.com/task/12688389654847070490) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
更新首页标题为“你的专属灵感摘录本”，重构下载页移动端布局与交互，并移除用户指南中的 Thoughter 导航与 Thoughter 页头标识。统一产品定位并提升小屏体验，不改动 SEO 关键词与下载链接行为。

- 评审要点
  - 首页 H1（中英）移除“& 笔记APP/Notes”；确认 meta 关键词未变。
  - 下载页样式重构：更紧凑的间距、卡片与按钮尺寸调整、hover 阴影优化、导航与筛选支持换行、新增 ≤480px 媒体查询；请在常见移动设备上验证各平台下载按钮与锚点可用、无布局溢出。
  - 导航与 Thoughter：用户指南不再展示 Thoughter 链接；Thoughter 页面移除顶部标识文案；确认不存在死链或残留引用。
  - 发布建议：刷新站点/CDN 缓存以确保新样式与文案生效。

<sup>Written for commit ba2ea0923be965dab64ecb2151dc624da424f99d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

