### PR TITLE
style(theme): 信笺元信息退回黑体 w400，纸纹横线收淡

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -143,9 +143,9 @@ class AppTheme with ChangeNotifier {
   ///
   /// - `display*` / `headline*`（24–57sp）：只换字体族。这个尺寸上衬线的横画怎么都
   ///   落在整像素以上，不需要补偿，再加重反而笨。
-  /// - `title*` / `body*`（11–23sp）：换字体族 + 按 [ThemeStyleForm.readingFontScale]
-  ///   放大 + 抬字重。横画掉进半像素是「衬线读起来比黑体虚」的物理原因，
-  ///   字号和字重是两个直接的补偿手段。
+  /// - `title*` / `bodyLarge` / `bodyMedium`（14–23sp）：换字体族 + 按
+  ///   [ThemeStyleForm.readingFontScale] 放大 + 抬字重。横画掉进半像素是
+  ///   「衬线读起来比黑体虚」的物理原因，字号和字重是两个直接的补偿手段。
   ///
   ///   **两档下限不是重复：[ThemeStyleForm.titleWeightFloor] 比
   ///   [ThemeStyleForm.bodyWeightFloor] 高一档，标题和正文的层级全靠这一档。**
@@ -153,21 +153,33 @@ class AppTheme with ChangeNotifier {
   ///   （几何要到 build 时才补），一个下限会把六级一起钉成同一个字重——
   ///   小节标题和列表正文就分不出主次了。
   ///
-  ///   `body*` 另外还吃行高缩放；标题的行高交给几何。
+  ///   这两级正文另外还吃行高缩放；标题的行高交给几何。
   ///
   ///   **这里刻意只写 `fontWeight`，不写 `fontVariations`。** 随包衬线是可变字体，
   ///   直接指定 wght 轴看着更「精确」，但 `fontVariations` 会盖过 `fontWeight`——
   ///   下游任何一处 `style.copyWith(fontWeight: FontWeight.bold)`（全项目上百处，
   ///   包括富文本的加粗）都会静默失效。交给引擎按 `fontWeight` 映射 wght 轴，
   ///   现有代码一行不用改。
-  /// - `label*`：**什么都不改，保持系统黑体**。按钮、胶囊、导航栏标签是 11–14sp
-  ///   的功能性文字，中文衬线在这个尺寸下糊成一团，而它们又不承担任何风格识别——
-  ///   没有人从一个按钮标签上看出「这是纸墨风格」。这是全局排版规则，
+  /// - `label*` 和 `bodySmall`：**什么都不改，保持系统黑体**。按钮、胶囊、导航栏标签
+  ///   是 11–14sp 的功能性文字，中文衬线在这个尺寸下糊成一团，而它们又不承担任何
+  ///   风格识别——没有人从一个按钮标签上看出「这是纸墨风格」。这是全局排版规则，
   ///   不是某套风格的选择，所以直接写在这里而不是做成令牌。
   ///
-  /// 行高只改 `body*` 三级——标题用的是紧排，跟着放松会显得散。
-  /// `bodyLarge` 直接取 [ThemeStyleForm.bodyLineHeight]，另外两级按同一比例缩放
-  /// 各自的 M3 默认值，避免三级正文被压成同一个行高。
+  ///   **`bodySmall`（12sp）和 `label*` 是同一档光学尺寸，判据也该是同一条。**
+  ///   它过去被算进「阅读级」，代价有两层：一是 12×1.0625≈12.75sp 的中文衬线，
+  ///   横画只有半个多像素，抗锯齿完是一层灰绒；二是它跟着吃
+  ///   [ThemeStyleForm.bodyWeightFloor] 抬到 w500，和正文一样重——而 `bodySmall`
+  ///   在这个应用里几乎全是元信息（笔记卡的日期/位置/天气、设置项说明、日志、
+  ///   时间戳），它们本来要靠「小一档 + 淡一档 + **轻一档**」退到背景里。字重那一档
+  ///   被抹平之后，一张笔记卡上四段衬线全是 w500，眼睛找不到落点——首页只有一句话
+  ///   所以显得有分量，记录页一张卡五段文字就成了没有主次。
+  ///
+  ///   所以这一级回到系统黑体、回到 M3 原生 w400：**元信息退后，正文不用动一个像素
+  ///   就浮出来了**。这也是 `36a78da`「小字不再用宋体」那条规则漏掉的一级。
+  ///
+  /// 行高只改 `bodyLarge` / `bodyMedium`——标题用的是紧排，跟着放松会显得散。
+  /// `bodyLarge` 直接取 [ThemeStyleForm.bodyLineHeight]，`bodyMedium` 按同一比例缩放
+  /// 自己的 M3 默认值，避免两级正文被压成同一个行高。
   ///
   /// material 风格四项全是恒等取值（`fontFamily` 为 null、字号/行高比例为 1、
   /// 字重下限为 0），像素不变。
@@ -247,8 +259,8 @@ class AppTheme with ChangeNotifier {
       titleSmall: reading(base.titleSmall, titleFloor, 14),
       bodyLarge: reading(base.bodyLarge, bodyFloor, 16, 24 / 16),
       bodyMedium: reading(base.bodyMedium, bodyFloor, 14, 20 / 14),
-      bodySmall: reading(base.bodySmall, bodyFloor, 12, 16 / 12),
-      // label* 刻意不动，见方法注释。
+      // bodySmall 和 label* 一样刻意不动，见方法注释：12sp 是功能性小字的光学
+      // 尺寸，换衬线会糊，抬字重会把元信息和正文拉平。
     );
   }
 

--- a/lib/theme/theme_style.dart
+++ b/lib/theme/theme_style.dart
@@ -529,7 +529,12 @@ class ThemeStyleForm {
     // 0.55 是横线只画在正文块之前的取值。那时横线铺满整张卡（穿过日期行、图片、
     // 标签胶囊和按钮行），画得淡一点也压不住乱；现在横线只画在正文那一块里，
     // 反而要收着画——它是纸的底纹，不是表格线。
-    ruleOpacity: 0.4,
+    //
+    // 0.4 仍然太实：`outlineVariant`(#DFD3C2) 按 0.4 混到卡片色上约等于 #F2ECE4，
+    // 和页面底色 #F3EEE4 几乎同一个明度——也就是每一行字底下都垫着一道「和背景
+    // 一样重」的横线。底纹不该有这个分量，它在和文字抢横向注意力，扫读列表时
+    // 尤其明显。0.24 混出来约 #F7F3ED，还看得出格子纸，但不再压着字。
+    ruleOpacity: 0.24,
     fontFamily: bundledSerif,
     fontFamilyFallback: _systemSerifFallback,
     bodyLineHeight: _paperLineHeight,

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -1222,9 +1222,9 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
           color: secondaryTextColor,
         ) ??
         TextStyle(color: secondaryTextColor);
-    // 和上面的日期同一级：写死 12 会让它比同一行的日期小半档——衬线风格给 body*
-    // 加了 6% 的字号补偿（ThemeStyleForm.readingFontScale），日期跟上了，
-    // 写死的这项没有。同一行两个字号，看着就是没对齐。
+    // 和上面的日期同一级，必须取同一个 token：写死 12 就等于把这一项从排版体系里
+    // 摘出去，风格一旦动了 bodySmall（曾经加过 6% 字号补偿，现在改成整级不动），
+    // 日期跟着走而它不跟，同一行两个字号，看着就是没对齐。
     final TextStyle headerMetaStyle = theme.textTheme.bodySmall?.copyWith(
           color: secondaryTextColor,
         ) ??

--- a/test/unit/theme/theme_style_contrast_test.dart
+++ b/test/unit/theme/theme_style_contrast_test.dart
@@ -496,7 +496,11 @@ void main() {
       // 横线曾经铺满整张笔记卡（穿过日期行、图片、标签胶囊和按钮行），
       // 那时 0.55 的浓度看着就是一张糊在卡片上的格子图。现在它只画在正文块里
       // （见 quote_item_widget 的 _buildQuoteContentSection），要收着画。
-      expect(ThemeStyleForm.paper.ruleOpacity, lessThanOrEqualTo(0.45));
+      //
+      // 上限从 0.45 收到 0.3：0.4 混到卡片色上约 #F2ECE4，和页面底色 #F3EEE4
+      // 几乎同一个明度，等于每行字底下都垫着一道和背景一样重的线，在和文字抢
+      // 横向注意力。底纹要看得见，不能有分量。
+      expect(ThemeStyleForm.paper.ruleOpacity, lessThanOrEqualTo(0.3));
     });
 
     test('纹理开关是令牌取值，只有纸与墨画横线', () {

--- a/test/unit/theme/theme_style_typography_test.dart
+++ b/test/unit/theme/theme_style_typography_test.dart
@@ -68,10 +68,10 @@ void main() {
         final text = (await themeFor(style)).textTheme;
 
         // M3 的字号/行高：几何里给的值，风格在它上面做缩放。
+        // bodySmall 不在这里：12sp 归功能性小字，见下面那条 label* 的用例。
         final levels = <String, (TextStyle?, double, double)>{
           'bodyLarge': (text.bodyLarge, 16, 24 / 16),
           'bodyMedium': (text.bodyMedium, 14, 20 / 14),
-          'bodySmall': (text.bodySmall, 12, 16 / 12),
         };
         levels.forEach((name, spec) {
           final (resolved, m3Size, m3Height) = spec;
@@ -146,14 +146,20 @@ void main() {
         expect(text.displaySmall?.fontWeight, isNull);
       });
 
-      test('label* 一项都不改，保持系统黑体', () async {
+      test('label* 和 bodySmall 一项都不改，保持系统黑体', () async {
         final text = (await themeFor(style)).textTheme;
         // 按钮、胶囊、导航栏标签是 11–14sp 的功能性文字，中文衬线在这个尺寸下
         // 糊成一团，又不承担任何风格识别。换了才是 bug。
+        //
+        // bodySmall（12sp）同一档光学尺寸，判据也是同一条：它在这个应用里几乎全是
+        // 元信息（笔记卡的日期/位置/天气、设置项说明、时间戳）。它一旦被算进阅读级，
+        // 就会跟着抬到 bodyWeightFloor，和正文一样重——一张笔记卡上四段衬线全是
+        // w500，主次就没了。这一级回黑体、回 w400 才是元信息该有的样子。
         for (final entry in {
           'labelLarge': text.labelLarge,
           'labelMedium': text.labelMedium,
           'labelSmall': text.labelSmall,
+          'bodySmall': text.bodySmall,
         }.entries) {
           expect(entry.value?.fontFamily, 'Roboto',
               reason: '${entry.key} 被换成衬线了');
@@ -161,6 +167,15 @@ void main() {
           expect(entry.value?.fontWeight, isNull,
               reason: '${entry.key} 字重被钉住了');
         }
+        // 行高也不该被钉——bodySmall 曾经跟着 bodyLineHeight 放松，那是阅读级
+        // 才需要的呼吸感，元信息跟着放松只会把卡片撑高。
+        expect(text.bodySmall?.height, isNull, reason: 'bodySmall 行高被钉住了');
+        // 层级的硬关系：元信息必须比正文轻一档，否则「小一档 + 淡一档 + 轻一档」
+        // 三重退后只剩两重，卡片上所有文字一样重。
+        expect(
+          (text.bodySmall?.fontWeight ?? FontWeight.w400).value,
+          lessThan(text.bodyLarge!.fontWeight!.value),
+        );
       });
 
       test('AppBar 标题跟上字体族和字重', () async {


### PR DESCRIPTION
> **说明**：本正文已编辑，移除了示例表格中误引用的个人数据（署名与区级位置）。本 PR 的代码差异不含个人数据。

## 问题

信笺风格下，首页那张卡看着舒服，记录页的笔记卡说不上来哪里累。翻了一下两张卡实际落地的字号字重，结构完全不同：

**首页**（`daily_quote_view.dart:373`）

| 元素 | 样式 | 字体 | 字号 | 字重 |
|---|---|---|---|---|
| 一言正文 | titleLarge | 衬线 | ~23–26 | **w600** |
| 来源 | bodyMedium | 衬线 | 12 | w500 |

两段，一大一小，主次一眼分明。

**记录页**（`quote_item_widget.dart`）

| 元素 | 样式 | 字体 | 字号 | 字重 |
|---|---|---|---|---|
| 日期 + 时段 | bodySmall | 衬线 | 12.75 | **w500** |
| 位置 + 天气温度 | bodySmall | 衬线 | 12.75 | **w500** |
| 正文 | bodyLarge | 衬线 | 17 | **w500** |
| 来源行 | bodyMedium | 衬线 | 14.875 | **w500** |
| 标签胶囊 | labelSmall | 黑体 | 11 | w500 |

四段衬线，全是 w500。`bodyWeightFloor: 500` 是给 `body*` 三级一起抬的，所以日期、位置、天气、正文、来源拿到同一个字重。整张卡的墨量上去了，但没有重新分配——元信息不退后，正文不突出。首页只有一句话谈不上主次，所以显得有分量；记录页一张卡五段文字就成了没有落点。

第二层：`36a78da`「小字不再用宋体」修的是 `label*`，**`bodySmall` 漏了**，而记录页顶上那行日期/位置/天气用的正是 bodySmall（`quote_item_widget.dart:1221`、`1228`）。12.75px 中文衬线的横画只有半个多像素，抗锯齿完是一层灰绒。

## 改动

**1. `bodySmall` 归入 `label*` 那一档「功能性小字」**（`lib/theme/app_theme.dart`）

保持系统黑体、M3 原生 w400，不吃 `readingFontScale` 和 `bodyLineHeight` 缩放。判据和 `label*` 是同一条——光学尺寸，不是风格身份。抽样看过 116 处 `bodySmall` 调用点，几乎全是元信息（设置项说明、日志、时间戳、状态），没有承担阅读的段落；首页「今日思考」的正文用的是 `bodyMedium`，不受影响。

**2. `paper.ruleOpacity` 0.4 → 0.24**（`lib/theme/theme_style.dart`）

`outlineVariant`(#DFD3C2) 按 0.4 混到卡片色上约等于 `#F2ECE4`，和页面底色 `#F3EEE4` 几乎同一个明度——每行字底下都垫着一道和背景一样重的横线，在和文字抢横向注意力。0.24 混出来约 `#F7F3ED`，还看得出格子纸，但不再压着字。

**正文一个像素没动**：它已经是全卡最重的了，该做的是把元信息放轻。色板同样没动。

## 测试

- `theme_style_typography_test`：把 `bodySmall` 从「阅读级」那组挪到 `label*` 一组，另外钉死一条硬关系——元信息字重必须低于正文。
- `theme_style_contrast_test`：`ruleOpacity` 上限从 0.45 收到 0.3。