### PR TITLE
📏 标尺: [补充 dio_network_utils 重试逻辑的测试]

### DIFF
--- a/.jules/caliper.md
+++ b/.jules/caliper.md
@@ -59,3 +59,6 @@
 ## 2026-08-18 - [补充 StringUtils.forEachLine 测试]
 **盲点:** `StringUtils.forEachLine` 作为核心底层工具方法之一，用于替代 `split('\n')` 以减少 GC 压力，但缺乏相应的测试覆盖，可能在某些边界条件（如末尾换行、连续换行、空字符串）下存在断裂风险。
 **对策:** 在 `test/unit/utils/string_utils_test.dart` 中增加 `forEachLine` 组，补充了空字符串、单行、多行、末尾带换行符、连续换行等场景用例，以确保该纯函数边界严谨，不引入隐患。
+## 2026-08-25 - [补充 dio_network_utils 重试逻辑的测试]
+**盲点:** `dio_network_utils.dart` 中的 `RetryInterceptor` 包含了对特定网络错误和服务器响应 (`_shouldRetry`) 的重试判断逻辑，这一纯逻辑处理长期缺乏测试覆盖，在调整重试条件时极易引入回归问题。
+**对策:** 通过编写针对 `RetryInterceptor` 处理流程 (`onError`) 的单元测试，利用伪造的 `Dio` 和 `ErrorInterceptorHandler`，验证其针对各种 HTTP 状态码（500、502）以及“model not found”等具体错误负载的决策是否准确，确保其不会阻拦正常的客户端错误返回。

--- a/test/unit/utils/dio_network_utils_test.dart
+++ b/test/unit/utils/dio_network_utils_test.dart
@@ -1,0 +1,105 @@
+import "package:dio/dio.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:thoughtecho/utils/dio_network_utils.dart";
+
+class FakeErrorInterceptorHandler extends ErrorInterceptorHandler {
+  final List<DioException> nextCalled = [];
+  final List<Response> resolveCalled = [];
+  final List<DioException> rejectCalled = [];
+
+  @override
+  void next(DioException err) {
+    nextCalled.add(err);
+  }
+
+  @override
+  void resolve(Response response) {
+    resolveCalled.add(response);
+  }
+
+  @override
+  void reject(DioException error) {
+    rejectCalled.add(error);
+  }
+}
+
+class FakeDio extends Fake implements Dio {
+  final Response? fetchResponse;
+  final DioException? fetchError;
+
+  FakeDio({this.fetchResponse, this.fetchError});
+
+  @override
+  Future<Response<T>> fetch<T>(RequestOptions requestOptions) async {
+    if (fetchError != null) {
+      throw fetchError!;
+    }
+    if (fetchResponse != null) {
+      return fetchResponse as Response<T>;
+    }
+    return Response<T>(requestOptions: requestOptions);
+  }
+}
+
+void main() {
+  group("RetryInterceptor", () {
+    test("shouldRetry evaluates true for 502 and next is NOT called immediately (triggers retry)", () async {
+      final dio = FakeDio(fetchResponse: Response(requestOptions: RequestOptions(path: "/")));
+      final interceptor = RetryInterceptor(
+        dio: dio,
+        retries: 1,
+        retryDelays: [const Duration(milliseconds: 1)],
+      );
+
+      final handler = FakeErrorInterceptorHandler();
+      final options = RequestOptions(path: "/", extra: {});
+      final error = DioException(
+        requestOptions: options,
+        response: Response(requestOptions: options, statusCode: 502),
+      );
+
+      interceptor.onError(error, handler);
+
+      // Verify that next was not called immediately, meaning a retry is scheduled
+      expect(handler.nextCalled, isEmpty);
+
+      // wait for the delay and fetch
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(handler.resolveCalled.length, 1);
+    });
+
+    test("shouldRetry evaluates false for 400 and next is called", () async {
+      final dio = FakeDio();
+      final interceptor = RetryInterceptor(dio: dio, retries: 1);
+      final handler = FakeErrorInterceptorHandler();
+      final options = RequestOptions(path: "/", extra: {});
+      final error = DioException(
+        requestOptions: options,
+        response: Response(requestOptions: options, statusCode: 400),
+      );
+
+      interceptor.onError(error, handler);
+
+      expect(handler.nextCalled.length, 1);
+    });
+
+    test("shouldRetry evaluates false for 500 with 'model not found' and next is called", () async {
+      final dio = FakeDio();
+      final interceptor = RetryInterceptor(dio: dio, retries: 1);
+      final handler = FakeErrorInterceptorHandler();
+      final options = RequestOptions(path: "/", extra: {});
+      final error = DioException(
+        requestOptions: options,
+        response: Response(
+          requestOptions: options,
+          statusCode: 500,
+          data: '{"error": "model not found"}',
+        ),
+      );
+
+      interceptor.onError(error, handler);
+
+      expect(handler.nextCalled.length, 1);
+    });
+  });
+}

--- a/test/unit/utils/dio_network_utils_test.dart
+++ b/test/unit/utils/dio_network_utils_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import "package:dio/dio.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:thoughtecho/utils/dio_network_utils.dart";
@@ -6,6 +7,7 @@ class FakeErrorInterceptorHandler extends ErrorInterceptorHandler {
   final List<DioException> nextCalled = [];
   final List<Response> resolveCalled = [];
   final List<DioException> rejectCalled = [];
+  final Completer<Response> resolveCompleter = Completer<Response>();
 
   @override
   void next(DioException err) {
@@ -15,6 +17,9 @@ class FakeErrorInterceptorHandler extends ErrorInterceptorHandler {
   @override
   void resolve(Response response) {
     resolveCalled.add(response);
+    if (!resolveCompleter.isCompleted) {
+      resolveCompleter.complete(response);
+    }
   }
 
   @override
@@ -24,18 +29,29 @@ class FakeErrorInterceptorHandler extends ErrorInterceptorHandler {
 }
 
 class FakeDio extends Fake implements Dio {
-  final Response? fetchResponse;
+  final Response<dynamic>? fetchResponse;
   final DioException? fetchError;
+  int fetchCalledCount = 0;
 
   FakeDio({this.fetchResponse, this.fetchError});
 
   @override
   Future<Response<T>> fetch<T>(RequestOptions requestOptions) async {
+    fetchCalledCount++;
     if (fetchError != null) {
       throw fetchError!;
     }
     if (fetchResponse != null) {
-      return fetchResponse as Response<T>;
+      return Response<T>(
+        requestOptions: fetchResponse!.requestOptions,
+        data: fetchResponse!.data as T?,
+        statusCode: fetchResponse!.statusCode,
+        statusMessage: fetchResponse!.statusMessage,
+        isRedirect: fetchResponse!.isRedirect,
+        redirects: fetchResponse!.redirects,
+        extra: fetchResponse!.extra,
+        headers: fetchResponse!.headers,
+      );
     }
     return Response<T>(requestOptions: requestOptions);
   }
@@ -66,8 +82,8 @@ void main() {
       // Verify that next was not called immediately, meaning a retry is scheduled
       expect(handler.nextCalled, isEmpty);
 
-      // wait for the delay and fetch
-      await Future.delayed(const Duration(milliseconds: 10));
+      // wait for the delay and fetch via completer
+      await handler.resolveCompleter.future;
       expect(handler.resolveCalled.length, 1);
     });
 
@@ -84,6 +100,7 @@ void main() {
       interceptor.onError(error, handler);
 
       expect(handler.nextCalled.length, 1);
+      expect(dio.fetchCalledCount, 0);
     });
 
     test(

--- a/test/unit/utils/dio_network_utils_test.dart
+++ b/test/unit/utils/dio_network_utils_test.dart
@@ -43,8 +43,11 @@ class FakeDio extends Fake implements Dio {
 
 void main() {
   group("RetryInterceptor", () {
-    test("shouldRetry evaluates true for 502 and next is NOT called immediately (triggers retry)", () async {
-      final dio = FakeDio(fetchResponse: Response(requestOptions: RequestOptions(path: "/")));
+    test(
+        "shouldRetry evaluates true for 502 and next is NOT called immediately (triggers retry)",
+        () async {
+      final dio = FakeDio(
+          fetchResponse: Response(requestOptions: RequestOptions(path: "/")));
       final interceptor = RetryInterceptor(
         dio: dio,
         retries: 1,
@@ -83,7 +86,9 @@ void main() {
       expect(handler.nextCalled.length, 1);
     });
 
-    test("shouldRetry evaluates false for 500 with 'model not found' and next is called", () async {
+    test(
+        "shouldRetry evaluates false for 500 with 'model not found' and next is called",
+        () async {
       final dio = FakeDio();
       final interceptor = RetryInterceptor(dio: dio, retries: 1);
       final handler = FakeErrorInterceptorHandler();


### PR DESCRIPTION
💡 **测试覆盖内容:**
本 PR 针对 `lib/utils/dio_network_utils.dart` 中长期缺乏测试覆盖的 `RetryInterceptor` 进行了单元测试补充。核心聚焦于其私有重试判定逻辑（通过触发 `onError` 执行），确保该拦截器能精准应对各类网络异常。

🎯 **测试边界与场景:**
1. **瞬时服务端错误 (502 等):** 模拟返回 502 状态码，断言拦截器不会立即调用 `next`，而是触发延迟重试（`resolve`）。
2. **明确的客户端错误 (400):** 模拟 400 状态码，断言 `shouldRetry` 返回 `false` 且立即调用 `next` 透传错误。
3. **特定 Payload 的 500 错误 (Model Not Found):** 模拟携带 "model not found" 信息的 500 错误，断言拦截器识别到该持久性错误并拦截重试，直接抛出。

这降低了后续修改 AI 服务提供商通信重试逻辑时的回归风险。已同步在 `.jules/caliper.md` 中记录了盲点与对策。

---
*PR created automatically by Jules for task [2544447508865086481](https://jules.google.com/task/2544447508865086481) started by @Shangjin-Xiao*

## Sourcery 摘要

添加网络请求重试决策的回归测试，以防止未来的更改影响错误处理行为。

测试：
- 为 RetryInterceptor 处理可重试的服务器错误、不可重试的客户端错误以及模型未找到响应添加单元测试覆盖。

杂务：
- 在项目校准日志中记录 RetryInterceptor 的测试缺口及缓解措施。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

添加回归测试，以验证网络请求的重试决策和错误传播。

测试：
- 为 RetryInterceptor 处理可重试的服务器错误、不可重试的客户端错误以及模型未找到响应添加单元测试覆盖。

杂项：
- 在校准日志中记录 RetryInterceptor 的测试缺口及缓解措施。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为网络请求重试决策和错误传播添加回归测试覆盖。

测试：
- 添加单元测试，覆盖 RetryInterceptor 对可重试服务器错误、不可重试客户端错误以及模型未找到响应的处理决策。

杂项：
- 在校准日志中记录 RetryInterceptor 测试覆盖缺口及其缓解措施。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add regression coverage for network request retry decisions and error propagation.

Tests:
- Add unit tests covering RetryInterceptor decisions for retryable server errors, non-retryable client errors, and model-not-found responses.

Chores:
- Record the RetryInterceptor test coverage gap and mitigation in the calibration log.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 新增重试错误处理测试，覆盖 HTTP 500、HTTP 502 触发重试的场景。
  * 验证包含“model not found”信息的 HTTP 500 错误会直接返回。
  * 验证 HTTP 400 等普通客户端错误不会触发请求重试。
  * 改进异步测试等待与请求调用次数校验，提升测试稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->