### PR TITLE
fix: resolve static analysis warnings in theme and tests

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1076,7 +1076,6 @@ class AppTheme with ChangeNotifier {
 
       // 配置进度指示器颜色与 M3 新版造型
       progressIndicatorTheme: ProgressIndicatorThemeData(
-        year2023: false,
         color: colorScheme.primary,
         circularTrackColor: colorScheme.primary.withValues(alpha: 0.2),
         linearTrackColor: colorScheme.primary.withValues(alpha: 0.2),
@@ -1312,7 +1311,6 @@ class AppTheme with ChangeNotifier {
       ),
       // 配置进度指示器颜色与 M3 新版造型
       progressIndicatorTheme: ProgressIndicatorThemeData(
-        year2023: false,
         color: colorScheme.primary,
         circularTrackColor: colorScheme.primary.withValues(alpha: 0.2),
         linearTrackColor: colorScheme.primary.withValues(alpha: 0.2),

--- a/test/widget/pages/thoughter_page_test.dart
+++ b/test/widget/pages/thoughter_page_test.dart
@@ -33,7 +33,7 @@ Quote _buildQuote() => Quote(
       date: DateTime(2026, 4, 5).toIso8601String(),
     );
 
-/// 结果卡片的 key 绑定了消息 ID（ai_workflow_result_smart_result_<id>），
+/// 结果卡片的 key 绑定了消息 ID（ai_workflow_result_smart_result_{id}），
 /// 用前缀匹配定位，避免测试依赖具体消息 ID。
 Finder _smartResultCardKey() => find.byWidgetPredicate(
       (widget) =>
@@ -43,7 +43,7 @@ Finder _smartResultCardKey() => find.byWidgetPredicate(
               .startsWith('ai_workflow_result_smart_result'),
     );
 
-/// 提案卡片同理（ai_workflow_result_note_proposal_<id>）。
+/// 提案卡片同理（ai_workflow_result_note_proposal_{id}）。
 Finder _noteProposalCardKey() => find.byWidgetPredicate(
       (widget) =>
           widget.key is ValueKey<String> &&


### PR DESCRIPTION
Fix deprecated year2023 parameter in ProgressIndicatorThemeData and HTML angle bracket warnings in test doc comments.

---
*PR created automatically by Jules for task [9144009439046884148](https://jules.google.com/task/9144009439046884148) started by @Shangjin-Xiao*

## Sourcery 总结

增强功能：
- 移除已弃用的进度指示器主题配置，并更新测试注释，以避免因尖括号表示法触发静态分析警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove the deprecated progress indicator theme configuration and update test comments to avoid static-analysis warnings from angle-bracket notation.

</details>