### PR TITLE
📥 黑匣: [完善 AddNoteController 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -50,3 +50,6 @@
 ## 2025-10-25 - 🗃️ 黑匣: [完善 ThoughtEchoDiscoveryService 模块的结构化日志]
 **异常:** [ThoughtEchoDiscoveryService 模块在启动服务、绑定UDP组播套接字、发送公告、解析组播消息等多个环节发生错误时，仅使用了 `debugPrint` 或者缺少统一标准地使用了不带完整参数的 `logError` / `logDebug` 进行异常捕获和打印。这不仅隐藏了关键错误堆栈信息 (stackTrace)，还使得跨端协同中设备发现相关的网络异常溯源变得困难。]
 **拦截:** [已将上述所有流程中的相关 `catch (e)` 升级为 `catch (e, stack)`，并统一替换为带有 `error: e`, `stackTrace: stack`, `source: 'ThoughtEchoDiscoveryService'` 参数的 `logError` (部分预期内的底层网络报错使用了 `logWarning`)。确认新的 logError 调用不会有意记录明文形式的用户交互数据。]
+## 2024-05-24 - [完善 AddNoteController 中的结构化日志]
+**异常:** [在 `lib/controllers/add_note_controller.dart` 中，发现了多处使用 `catch (e)` 的空捕获或粗糙的 `logDebug('xxx失败: $e')` 打印，这些异常捕获不仅吞噬了关键的异常堆栈（StackTrace），并且严重依赖字符串拼接，未能利用已有的结构化日志系统，使得定位位置获取、天气抓取及标签创建等关键业务失败原因变得困难。]
+**拦截:** [将 `catch (e)` 改写为 `catch (e, stackTrace)`，并引入全局的 `logError`，传入 error、stackTrace，并指明 source: 'AddNoteController'，将原有的粗糙拼接替换为带有上下文的规范日志上报。]

--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -324,8 +324,13 @@ class AddNoteController extends ChangeNotifier {
         notifyListeners();
         onLocationFetchEmpty?.call();
       }
-    } catch (e) {
-      logDebug('获取位置失败: $e');
+    } catch (e, stackTrace) {
+      logError(
+        '获取位置失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'AddNoteController',
+      );
       if (_isDisposed) return;
       includeLocation = false;
       _clearNewLocation();
@@ -380,8 +385,13 @@ class AddNoteController extends ChangeNotifier {
 
       isFetchingWeather = false;
       notifyListeners();
-    } catch (e) {
-      logDebug('获取天气失败: $e');
+    } catch (e, stackTrace) {
+      logError(
+        '获取天气失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'AddNoteController',
+      );
       if (_isDisposed) return;
       includeWeather = false;
       isFetchingWeather = false;
@@ -488,8 +498,13 @@ class AddNoteController extends ChangeNotifier {
         selectedCategory = category;
         onCategoryUpdated(category);
       }
-    } catch (e) {
-      logDebug('添加默认标签失败: $e');
+    } catch (e, stackTrace) {
+      logError(
+        '添加默认标签失败',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'AddNoteController',
+      );
     } finally {
       if (!_isDisposed) {
         isLoadingHitokotoTags = false;
@@ -543,8 +558,13 @@ class AddNoteController extends ChangeNotifier {
           if (_isDisposed) return null;
           allCategoriesCache = null;
           return fixedId;
-        } catch (e) {
-          logDebug('使用固定ID创建标签失败: $e');
+        } catch (e, stackTrace) {
+          logError(
+            '使用固定ID创建标签失败',
+            error: e,
+            stackTrace: stackTrace,
+            source: 'AddNoteController',
+          );
           if (_isDisposed) return null;
           await db.addTag(name, iconName: iconName);
           if (_isDisposed) return null;
@@ -563,8 +583,13 @@ class AddNoteController extends ChangeNotifier {
       );
 
       return newTag.id.isNotEmpty ? newTag.id : null;
-    } catch (e) {
-      logDebug('确保标签"$name"存在时出错: $e');
+    } catch (e, stackTrace) {
+      logError(
+        '确保标签"$name"存在时出错',
+        error: e,
+        stackTrace: stackTrace,
+        source: 'AddNoteController',
+      );
       return null;
     }
   }


### PR DESCRIPTION
📥 黑匣: [完善 AddNoteController 模块的结构化日志]

**异常:** [在 `lib/controllers/add_note_controller.dart` 中，发现了多处使用 `catch (e)` 的空捕获或粗糙的 `logDebug('xxx失败: $e')` 打印，这些异常捕获不仅吞噬了关键的异常堆栈（StackTrace），并且严重依赖字符串拼接，未能利用已有的结构化日志系统，使得定位位置获取、天气抓取及标签创建等关键业务失败原因变得困难。]
**拦截:** [将 `catch (e)` 改写为 `catch (e, stackTrace)`，并引入全局的 `logError`，传入 error、stackTrace，并指明 source: 'AddNoteController'，将原有的粗糙拼接替换为带有上下文的规范日志上报。]

💡 变更核心:
- 针对位置获取失败、新建笔记天气获取失败、默认标签及固定ID标签创建失败等场景，替换了 `catch (e)` 的简易捕获逻辑。
- 引入了 `logError` 代替原有的 `logDebug`，通过传递完整的 `error` 对象和 `stackTrace` 对象，保护了完整的异常调用堆栈。
- 为上报添加了 `source: 'AddNoteController'`，提供更清晰的上下文。

📖 规范执行:
- 添加的修改不超过 50 行，符合微调规范。
- 验证日志修改前后均不包含如笔记文本或账号密码等用户隐私数据。
- 完善了 `.jules/blackbox.md` 中对应的记录。
- 格式化了代码，验证了静态分析和 AddNoteController 相关的测试用例均通过。

---
*PR created automatically by Jules for task [5140641791746612556](https://jules.google.com/task/5140641791746612556) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `AddNoteController` 中的异常捕获从粗糙的 `logDebug('xxx失败: $e')` 替换为结构化 `logError`，保留完整堆栈便于定位位置获取、天气抓取及标签创建等失败原因。

- 将 `catch (e)` 改为 `catch (e, stackTrace)`，并通过 `logError` 上报 `error` 和 `stackTrace`。
- 所有结构化日志均指定 `source: 'AddNoteController'` 提供上下文。
- 更新了 `.jules/blackbox.md` 中的对应记录，确认日志不包含用户隐私数据。

<sup>Written for commit 3e820119b439515bc4d729da30ba7a366cf13549. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进添加笔记流程中的异常日志记录。
  - 位置获取、天气获取、默认标签及标签创建失败时，现会记录错误详情、堆栈信息和来源，便于问题排查。
  - 保持异常后的状态清理、回退处理和页面返回逻辑不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->