### PR TITLE
⚡ Bolt: 优化 escapeUntrustedText 正则表达式编译性能

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,5 @@
 ## 2024-05-18 - 优化 Web 平台标签筛选性能，减少 List.contains 的 N+1 查询
+
 **Learning:**
 在列表的循环（如 `where` 和 `any`）中调用 `List.contains` 进行条件判断，会导致 $O(N \times M)$ 的时间复杂度。当被筛选列表较大或者条件数组较长时，这是一个典型的性能热点。对于 Dart 和大多数语言而言，将条件数组预先转换为 `Set`，可以利用 Hash 查找特性将单词检索的时间复杂度降为 $O(1)$，进而将整体时间复杂度从 $O(N \times M)$ 降低至 $O(N)$。在本次通过基准测试发现，在 10,000 条数据、5 个关联标签以及 100 个筛选条件的场景下，替换为 Set 后执行耗时降低了一半左右（约 1.8 倍性能提升）。
 
@@ -6,101 +7,153 @@
 修改了 `lib/services/database/database_query_mixin.dart` 与 `lib/services/database/database_query_helpers_mixin.dart` 中 Web 平台的数据内存过滤逻辑。预先使用 `final tagIdSet = tagIds.toSet();`，并在之后的 `.any((tag) => tagIdSet.contains(tag))` 中使用该 Set 替代原有的 `tagIds.contains(tag)`，彻底消除了 N+1 的隐藏复杂度。验证通过了相关多标签过滤的测试。
 
 ## 2024-05-30 - 优化 RegExp 编译性能
+
 **Learning:** 在高频调用的方法（如字符串过滤、格式化）中，如果使用字面量正则表达式，Dart 在每次执行到该行时都会调用 `RegExp` 构造函数。由于正则表达式的编译过程（即使带有缓存或者简单匹配）本身具有一定开销，尤其是在长循环或大列表过滤中会被不断放大，应当将其提取为静态只读成员（`static final`）来仅在类加载时编译一次。
 **Action:** 在 `lib/services/location_service.dart` 中，将 `_containsLatinOrDigit` 方法里的 `RegExp(r'[A-Za-z0-9]')` 提取为 `static final _latinOrDigitRegex` 并复用。
+
 ## 2024-05-30 - 优化 database_backup_service 中的降级插入性能
+
 **Learning:** The fallback block for database record insertion was incorrectly using sequential `await txn.insert()` for every tag of every quote. Although the initial quote array batch failed forcing this fallback, making another N+1 sequential request inside the fallback loop compounded the performance issue significantly.
 **Action:** Removed the sequential `txn.insert` call inside the tag resolution loop. Appended the records to `tagRelations` which is eventually processed by an existing, outer batched `txn.batch()` execution.
+
 ## 2024-05-30 - 优化 ContentSanitizer 正则表达式编译性能
+
 **Learning:**
 在处理基于字符串分析的操作时（如 `injectCsp` 等方法），如果内联声明 `RegExp(...)`，Dart 会在每次调用方法时重新解析和编译正则表达式对象。尽管内部有一定缓存，但对于存在多次替换操作（如连续调用 `replaceAll` 和 `replaceFirstMapped`），频繁的对象分配和匹配查找依然会构成性能开销。
 **Action:**
 将 `injectCsp` 方法体内的所有用于 CSP 标签过滤、 `<script>` 标签清除以及 `<head>` 和 `<html>` 标签查找的正则表达式提取为类的 `static final RegExp` 字段。这种模式确保它们只会在类第一次被加载时进行编译（单次分配），避免了每次执行清理操作时重复实例化对象的问题，并更新了受影响的单元测试。
 
 ## 2024-06-03 - 优化 StringUtils 正则表达式编译性能
+
 **Learning:**
 在工具类高频调用的方法中，如果内联声明 `RegExp` 对象，Dart 每次调用都会重新分配和编译正则表达式，即使它们是纯字符串常量。虽然有内部缓存，依然存在分配开销。特别是在 `StringUtils` 等纯函数或解析工具中，频繁调用会被放大性能损耗。
 **Action:**
 将 `lib/utils/string_utils.dart` 中的相关正则表达式（如提取作者和作品的模式）提取为类的 `static final RegExp` 字段。这样在类首次加载时只需编译一次，提高了反复解析文本时的性能。
+
 ## 2026-06-14 - Optimize N+1 Query in quote_tags
+
 **Learning:** The correct optimization for chunked SQLite `IN` queries (to bypass the 900 parameter limit) in `sqflite` is to accumulate the chunk queries using `db.batch()` and execute them in a single IPC call with `await batch.commit()`, rather than sequentially awaiting each or using `Future.wait`.
 **Action:** Replaced `for` loops sequentially awaiting `rawQuery` or using `Future.wait` with `db.batch()` in `database_query_helpers_mixin.dart`, `database_query_mixin.dart`, `database_quote_crud_mixin.dart`, and `database_trash_mixin.dart`.
+
 ## 2026-06-14 - [优化回收站彻底删除记录的性能]
+
 **Learning:** Sequential `await` in loops over batch operations limits performance significantly by performing I/O sequentially. However, replacing it with `Future.wait` requires a `try/catch` inside the closure returning a fallback value (like an empty list) to prevent a single failure from failing the entire batch.
 **Action:** Replaced a sequential `for` loop awaiting `MediaReferenceService.extractMediaPathsFromQuote` with `Future.wait` for concurrent processing, cutting processing time significantly in tests.
 
 ## 2026-06-14 - Optimize Media Reference Checking Loop
+
 **Learning:** Sequential asynchronous checks (using `await` in a loop) over large arrays (like 50k items) severely block execution due to event loop scheduling overhead.
 **Action:** Chunked the execution into batches of 1000 items processed concurrently with `Future.wait()`, and maintained a small yield (`await Future<void>.delayed(Duration.zero)`) between batches to keep the main thread responsive.
+
 ## 2024-05-24 - Optimize MediaCleanupService verifyMediaIntegrity
+
 **Learning:** The verifyMediaIntegrity method processed quotes sequentially and awaited extractMediaPathsFromQuote on each, causing significant I/O blocking when iterating over hundreds or thousands of quotes. Redundant directory lookups per extraction further exacerbated the overhead.
 **Action:** Replaced the sequential `for (final quote in quotes)` loop with a chunked `Future.wait` implementation that processes quotes in batches of 50. Passed down the pre-calculated `appPath` via `cachedAppPath` to eliminate repeated platform IPC calls. This reduced execution time by over 80%.
+
 ## 2024-06-26 - Optimize N+1 Query in database fallback insert
+
 **Learning:** In database batch insert operations, when a bulk `commit` fails, falling back to a loop that sequentially performs `await txn.insert()` is a severe performance bottleneck (N+1 I/O problem) in degraded/fallback execution paths.
 **Action:** Replaced sequential `await txn.insert()` in the fallback loops for `categories`, `quotes`, `quote_tags`, and `quote_tombstones` with `txn.batch()` and used `batch.commit(continueOnError: true, noResult: true)` in `lib/services/database_backup_service.dart`.
+
 ## 2024-06-28 - Fallback retry logic data integrity issue
+
 **Learning:** During database backup restoration, re-parsing original JSON payloads and randomly generating missing IDs (e.g., `_uuid.v4()`) directly inside a fallback insertion loop (e.g. after a batch `commit` failure) creates a critical data integrity flaw. If an initial pass already generated UUIDs and collected relational data (like `tagRelations`), regenerating new UUIDs in the fallback will decouple the records from those previously built relationships, causing orphan relationships and duplicated entities.
 **Action:** Modified `lib/services/database_backup_service.dart` to store processed, normalized map representations (including generated UUIDs) into lists (`processedCategories`, `processedQuotes`) during the primary loop. The fallback `batch.commit(continueOnError: true)` now iterates over these pre-processed objects instead of the raw parsed JSON, ensuring ID consistency and perfectly retaining existing relational mappings.
+
 ## 2026-06-26 - [优化 QuillAiApplyUtils 正则表达式编译性能]
+
 **Learning:**
 在处理文档内容的高频工具方法（如 `stripMediaMarkersForDisplay`）中，内联调用 `RegExp` 构造函数会导致每次方法执行时重新分配和编译正则表达式。在连续使用链式 `replaceAll` 操作时，这种性能损耗会被进一步放大。
 **Action:**
 将 `QuillAiApplyUtils` 中的空白字符和换行符匹配模式提取为类的 `static final RegExp` 静态成员，使其仅在类加载时编译一次。测试执行通过且时间未受影响，有效降低了高频字符串处理时的资源消耗。
 
 ## 2026-06-26 - Optimize Database Schema Migration
+
 **Learning:** For database schema migrations involving dictionary mapping (e.g., legacy string labels to string keys), fetching all records into Dart memory and iterating through them to perform row-by-row `batch.update()` calls introduces severe N+1 overhead across the SQLite FFI boundary.
 **Action:** Replaced the row-by-row iteration with a loop that directly executes `txn.rawUpdate('UPDATE quotes SET field = ? WHERE field = ?', [key, label])` for each dictionary entry. This pushes the update logic entirely into the SQLite engine, saving ~35-60% of migration time on large datasets by eliminating unnecessary read queries and FFI data transfers.
+
 ## 2026-06-28 - Optimize String Splitting in SmartPushAnalytics
+
 **Learning:** Nested .split() in frequently called loops allocates unnecessary temporary arrays causing GC pressure.
 **Action:** Replaced nested split with indexOf and substring to reduce memory allocations.
+
 ## 2026-06-28 - 优化同步冲突隔离备份中的 N+1 查询问题
+
 **Learning:** 在处理可能包含大量数据循环处理的 SQLite 数据库查询时，不要在循环内部使用 `await db.query()` 引起 N+1 查询性能问题。
 **Action:** 利用 `IN` 语句配合 `db.batch()` 根据 SQLite 的 900 参数上限进行分块聚合查询，大大降低 IPC 边界开销，将时间从 920 ms 降低至 77 ms。
+
 ## 2024-06-25 - 优化媒体文件清理服务大小计算
+
 **Learning:** Sequential `await entity.length()` queries block execution and create excessive microtask scheduling overhead in large directories, drastically slowing down directory size calculation.
 **Action:** Transformed the directory size calculation in `MediaCleanupService._calculateMediaFilesSizes` to aggregate file lists and chunk `entity.length()` requests using `Future.wait` combined with event loop yielding `await Future<void>.delayed(Duration.zero)`. This removes sequential blockage and significantly speeds up directory traversing.
+
 ## 2024-05-18 - [Batched Database Inserts for sqflite]
+
 **Learning:** Sequential `await txn.insert()` calls inside a loop in `sqflite` cause massive N+1 IPC overhead because each insert requires traversing the Dart-to-Native channel.
 **Action:** Always accumulate `insert` or `update` operations using `txn.batch()` (e.g., `batch.insert()`) and execute them together with a single `await batch.commit(noResult: true)` (if results aren't needed) to minimize platform channel serialization costs during migrations or bulk processing.
+
 ## 2024-05-14 - 避免使用 split('').length 计算字符串长度
+
 **Learning:** 在 Dart 中，使用 `str.split('').length` 来计算字符串长度会导致 O(N) 的时间和空间开销，因为系统会分配一个包含每个字符的临时列表，这会引发频繁的内存分配和垃圾回收，影响性能。
 **Action:** 在计算字数等场景，应当直接使用 O(1) 的 `str.length`，或者在需要过滤不可见字符时，使用 `str.characters.length` 配合正则等更高效的方式。
 
 ## 2026-07-14 - Batch Querying with IN clause to eliminate N+1 in data sync
+
 **Learning:** SQLite has a parameter limit (usually 999) per query. When fetching data using `IN` clauses to prevent N+1 issues in loops, chunk the array into batches (e.g., 500), queue the queries in one `Batch`, and call `commit()` once to reduce IPC overhead. Collect results by iterating the returned `List<Object?>`.
 **Action:** Replaced `await txn.query` inside `tombstones` sync loop with a pre-loop chunked batch query mechanism to load existing quotes and references into memory maps, achieving O(1) lookups and cutting execution time by >90%.
 
 ## 2026-07-24 - 优化笔记多选操作的时间复杂度
+
 **Learning:** 在 UI 交互中，如果有针对 `Set` 中多个 ID 进行全量查找的操作（例如在 `List` 中循环使用 `firstWhere` 或者 `firstWhereOrNull`），这会导致 O(M*N) 的时间复杂度（N 是列表长度，M 是选中的 ID 数量）。当列表较大且选中大量项目时，会导致 UI 线程阻塞。
 **Action:** 在 `lib/widgets/note_list/note_list_items.dart` 的 `_selectSameMonthNotes` 和 `_selectSameCategoryNotes` 方法中，将 `for (final id in _selectedExportNoteIds)` 内部的 `_quotes.firstWhereOrNull` 查找逻辑，替换为先遍历 `_quotes` 并使用 `_selectedExportNoteIds.contains(quote.id)` 收集月份/分类，再遍历 `_quotes` 按收集结果筛选；通过常数次遍历避免 O(M*N) 的嵌套线性查找，分类筛选还会遍历每条笔记的 `tagIds`。
 
 ## 2026-07-25 - [避免 O(M*N) 的嵌套循环查找]
-**Learning:** 在 Flutter UI 渲染循环中，对 `List<T>` 数组调用 `.map()` 并内部嵌套 `List.firstWhere()` 查找对象时，会导致 O(M*N) 复杂度。在涉及重绘动画的地方，这种隐式的线性查找会积少成多，进而带来不必要的卡顿和 GC。
+
+**Learning:** 在 Flutter UI 渲染循环中，对 `List<T>` 数组调用 `.map()` 并内部嵌套 `List.firstWhere()` 查找对象时，会导致 O(M\*N) 复杂度。在涉及重绘动画的地方，这种隐式的线性查找会积少成多，进而带来不必要的卡顿和 GC。
 **Action:** 在执行对一组 ID 进行列表元素的映射操作之前，提前将 `List` 转化为基于 ID 为键的哈希映射表（即 `final map = { for(var item in list) item.id: item };`），然后在循环体中使用 `map[id]` 进行 O(1) 取值。
+
 ## 2026-08-07 - [String splitting memory optimization in SSE parsers]
+
 **Learning:** Dart's `String.split('\n')` creates numerous intermediate string lists and string objects, putting significant pressure on the Garbage Collector, especially during real-time Server-Sent Events (SSE) processing where partial chunks are frequently accumulated and parsed.
 **Action:** Replace `String.split` with manual `String.indexOf('\n')` and `String.substring` in high-frequency string parsing paths like AI stream parsers and network managers to reduce memory allocations and GC pauses.
+
 ## 2024-05-24 - [优化流式响应解析性能]
+
 **Learning:** 在高频流式数据处理（如大语言模型流式输出）中，使用 `String.split('\n')` 会产生大量短生命周期的列表和字符串对象，从而显著增加垃圾回收（GC）压力并导致可能的性能卡顿。
 **Action:** 在此类场景中，应始终采用手动寻找分隔符（如 `String.indexOf` 和 `String.substring`）的方法来遍历文本。
+
 ## 2026-08-14 - Optimize hitokoto tag category ID lookup
+
 **Learning:** O(N) linear lookups in loops can be efficiently replaced with O(1) direct dictionary mapping when the key-value mappings are constant/static.
 **Action:** Replaced loop-based ID retrieval in `ensureTagExists` by generating `hitokotoTagNameToCategoryIdMap`.
 
 ## 2026-08-14 - [Replace String.split with indexOf and substring to reduce GC pressure]
+
 **Learning:** `String.split` generates intermediate lists and string tokens, creating high GC pressure when parsing large strings frequently. When rewriting a `for-in` loop with `split` to a `while` loop with `indexOf`, extracting a shared `StringUtils.forEachLine` helper avoids boilerplate while maintaining zero-allocation scanning.
 **Action:** Replace `split('\n')` with `StringUtils.forEachLine` in line-by-line parsers like `DeltaRichTextParser` and `DeltaBuilder` to eliminate temporary list allocations and standardize line scanning across the codebase.
+
 ## 2025-01-20 - [Optimize String splitting to avoid memory allocation]
+
 **Learning:** Frequent `String.split` generates intermediate lists and strings which puts pressure on GC. Instead manual parsing using `String.indexOf` and `String.substring` minimizes allocations.
 **Action:** Replace `String.split` with manual parsing in high-frequency methods like when parsing `tagIdsString` in `DatabaseBackupService`.
 
 ## 2026-08-15 - 消除 GetNoteDetailTool 中获取标签的 N+1 查询问题
+
 **Learning:** 在获取单篇笔记详情或关联数据时，循环调用 `getTagById(id)` 查询数据库会导致典型的 N+1 查询瓶颈。使用 SQLite 的 `IN (...)` 子句一次性批量传入参数（配合 SQL 绑定变参），可以将原本与标签数量成正比的数次数据库 I/O 压缩为单次高效查询，在大幅减少 SQLite 数据库/平台 Channel 跨进程通信开销的同时保持相同的类型与功能边界。
 **Action:** 在 `DatabaseService` 中定义并实装 `getTagsByIds(Iterable<String> ids)`，在 `GetNoteDetailTool.execute` 中改用 `_db.getTagsByIds(idsToFetch)` 批量获取分类和标签名称映射，消除标签详情读取中的 N+1 查询，并在单元测试中验证其单次调用行为。
 
 ## 2026-08-16 - [Optimize Batch Inserts in Database Backup Service]
+
 **Learning:**
 In `sqflite`, calling `batch.insert` repeatedly inside loops adds individual SQL statement maps to the `Batch` queue sent over the Flutter-to-Native method channel IPC boundary. For bulk relation tables (such as `quote_tags`), using chunked multi-row raw insert queries (`INSERT OR IGNORE INTO table (col1, col2) VALUES (?, ?), (?, ?)...`) reduces the total number of IPC commands queued and executed across the FFI/MethodChannel boundary, significantly lowering serialization and processing overhead.
 
 **Action:**
 Updated `importDataFromMap` and `_mergeQuotes` in `lib/services/database_backup_service.dart` to process `tagRelations` and `remappedTagIds` using chunked `batch.rawInsert` statements (bounded by a chunk size of 400 parameter pairs).
+
+## 2026-08-17 - 优化 escapeUntrustedText 正则表达式编译性能
+
+**Learning:**
+在提示词过滤和防注入转义等高频文本处理工具（如 `escapeUntrustedText`）中，内联调用 `RegExp(..., caseSensitive: false)` 会导致每次转义时重新分配和编译多个正则表达式。将正则表达式提取为静态/模块级只读对象可使正则表达式仅在首次加载时编译一次，消除频繁转义时的对象分配与正则编译开销。
+
+**Action:**
+将 `lib/utils/untrusted_text.dart` 中的转义正则表达式（`[SYSTEM]`, `[ASSISTANT]`, `[USER]`, `<|im_start|>`, `<|im_end|>` 以及多换行匹配）提取为模块级 `final RegExp` 静态成员进行复用。

--- a/lib/utils/untrusted_text.dart
+++ b/lib/utils/untrusted_text.dart
@@ -6,6 +6,15 @@
 /// 对单个自由文本字段调用 [escapeUntrustedText]。
 library;
 
+// 预编译正则表达式以优化高频转义时的性能
+final RegExp _systemTagRegex = RegExp(r'\[SYSTEM\]', caseSensitive: false);
+final RegExp _assistantTagRegex =
+    RegExp(r'\[ASSISTANT\]', caseSensitive: false);
+final RegExp _userTagRegex = RegExp(r'\[USER\]', caseSensitive: false);
+final RegExp _imStartRegex = RegExp(r'<\|im_start\|>', caseSensitive: false);
+final RegExp _imEndRegex = RegExp(r'<\|im_end\|>', caseSensitive: false);
+final RegExp _multipleNewlinesRegex = RegExp(r'\n{3,}');
+
 /// 转义不可信的外部内容，防止提示注入攻击。
 ///
 /// 处理策略：
@@ -19,19 +28,14 @@ String escapeUntrustedText(String content) {
   escaped = escaped.replaceAll('```', '\\`\\`\\`');
 
   // 移除可能被解析为角色切换的标记
-  escaped = escaped.replaceAll(
-      RegExp(r'\[SYSTEM\]', caseSensitive: false), '[SYS_TEM]');
-  escaped = escaped.replaceAll(
-      RegExp(r'\[ASSISTANT\]', caseSensitive: false), '[ASSIS_TANT]');
-  escaped =
-      escaped.replaceAll(RegExp(r'\[USER\]', caseSensitive: false), '[US_ER]');
-  escaped = escaped.replaceAll(
-      RegExp(r'<\|im_start\|>', caseSensitive: false), '<|im\\_start|>');
-  escaped = escaped.replaceAll(
-      RegExp(r'<\|im_end\|>', caseSensitive: false), '<|im\\_end|>');
+  escaped = escaped.replaceAll(_systemTagRegex, '[SYS_TEM]');
+  escaped = escaped.replaceAll(_assistantTagRegex, '[ASSIS_TANT]');
+  escaped = escaped.replaceAll(_userTagRegex, '[US_ER]');
+  escaped = escaped.replaceAll(_imStartRegex, '<|im\\_start|>');
+  escaped = escaped.replaceAll(_imEndRegex, '<|im\\_end|>');
 
   // 限制连续换行（最多 2 个）
-  escaped = escaped.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+  escaped = escaped.replaceAll(_multipleNewlinesRegex, '\n\n');
 
   return escaped;
 }


### PR DESCRIPTION
⚡ Bolt: 优化 escapeUntrustedText 正则表达式编译性能

💡 What:
将 `lib/utils/untrusted_text.dart` 中的 `escapeUntrustedText` 方法内部的高频内联 `RegExp` 提取为模块级 `final RegExp` 静态成员，使其在模块加载时仅编译一次并全程复用。

🎯 Why:
`escapeUntrustedText` 是系统在处理不可信外部输入（如笔记正文、网页搜索结果等）时的核心转义函数。原实现每次调用该函数都会内联构造并编译 6 个带有 `caseSensitive: false` 等配置的 `RegExp` 对象，在大批量或高频处理文本时带来不必要的对象分配与正则解析开销。

📊 Impact:
彻底消除了 `escapeUntrustedText` 在反复调用时的正则表达式重复编译与 GC 分配开销，提升高频文本防注入处理性能。

🔬 Measurement:
通过 `flutter test test/unit/utils/untrusted_text_test.dart` 与 `flutter analyze --no-fatal-infos` 验证功能正确性与代码规范。

---
*PR created automatically by Jules for task [13010155194392054961](https://jules.google.com/task/13010155194392054961) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化 `escapeUntrustedText` 的正则表达式编译性能，将方法内联的 6 个 `RegExp` 提取为模块级 `final` 成员，避免每次调用重复编译和对象分配，行为不变。

<sup>Written for commit fea286424c97e86e0ee92c885a0ea6d38e91a67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化不可信文本处理的正则表达式复用机制，减少重复编译开销。
  * 保持现有文本转义、标签处理及连续换行压缩行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->