### PR TITLE
fix(ai): 本地模型端点不再被 HTTPS 强制判死；今日思考主次正过来

### DIFF
--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -324,14 +324,30 @@ class AddNoteController extends ChangeNotifier {
         notifyListeners();
         onLocationFetchEmpty?.call();
       }
-    } catch (e) {
-      // 定位/天气在正常使用中本来就会失败：没给权限、离线、超时。
-      // 记成 error 会把日志页刷满预期内的失败，真正的异常反而淹掉。
-      // 也不用带 stackTrace：这一档失败看的是「为什么没拿到」，不是调用栈。
-      logWarning(
-        '获取位置失败: $e',
-        source: 'AddNoteController',
-      );
+    } catch (e, stackTrace) {
+      // 定位/天气在正常使用中本来就会失败：没给权限、离线、超时。这一档记成
+      // error 会把日志页刷满预期内的失败，真正的异常反而被淹掉——所以降 warning，
+      // 也不需要调用栈：要看的是「为什么没拿到」，不是栈。
+      //
+      // **但 `Error` 不在这一档里。** 这两个 catch 罩着的范围不小（权限检查、
+      // 服务调用、状态改写），`NoSuchMethodError` / `TypeError` / `StateError`
+      // 这类编程错误一旦落进来，降成 warning 又丢掉调用栈就等于把 bug 藏起来。
+      // Dart 的 `Error` / `Exception` 之分正好是「程序写错了」和「预期内失败」，
+      // 比按消息串匹配可靠——这两个服务抛的都是泛型 `Exception('…')`，
+      // 按消息分类必然脆。
+      if (e is Error) {
+        logError(
+          '获取位置失败（非预期错误）',
+          error: e,
+          stackTrace: stackTrace,
+          source: 'AddNoteController',
+        );
+      } else {
+        logWarning(
+          '获取位置失败: $e',
+          source: 'AddNoteController',
+        );
+      }
       if (_isDisposed) return;
       includeLocation = false;
       _clearNewLocation();
@@ -386,14 +402,30 @@ class AddNoteController extends ChangeNotifier {
 
       isFetchingWeather = false;
       notifyListeners();
-    } catch (e) {
-      // 定位/天气在正常使用中本来就会失败：没给权限、离线、超时。
-      // 记成 error 会把日志页刷满预期内的失败，真正的异常反而淹掉。
-      // 也不用带 stackTrace：这一档失败看的是「为什么没拿到」，不是调用栈。
-      logWarning(
-        '获取天气失败: $e',
-        source: 'AddNoteController',
-      );
+    } catch (e, stackTrace) {
+      // 定位/天气在正常使用中本来就会失败：没给权限、离线、超时。这一档记成
+      // error 会把日志页刷满预期内的失败，真正的异常反而被淹掉——所以降 warning，
+      // 也不需要调用栈：要看的是「为什么没拿到」，不是栈。
+      //
+      // **但 `Error` 不在这一档里。** 这两个 catch 罩着的范围不小（权限检查、
+      // 服务调用、状态改写），`NoSuchMethodError` / `TypeError` / `StateError`
+      // 这类编程错误一旦落进来，降成 warning 又丢掉调用栈就等于把 bug 藏起来。
+      // Dart 的 `Error` / `Exception` 之分正好是「程序写错了」和「预期内失败」，
+      // 比按消息串匹配可靠——这两个服务抛的都是泛型 `Exception('…')`，
+      // 按消息分类必然脆。
+      if (e is Error) {
+        logError(
+          '获取天气失败（非预期错误）',
+          error: e,
+          stackTrace: stackTrace,
+          source: 'AddNoteController',
+        );
+      } else {
+        logWarning(
+          '获取天气失败: $e',
+          source: 'AddNoteController',
+        );
+      }
       if (_isDisposed) return;
       includeWeather = false;
       isFetchingWeather = false;

--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -324,11 +324,12 @@ class AddNoteController extends ChangeNotifier {
         notifyListeners();
         onLocationFetchEmpty?.call();
       }
-    } catch (e, stackTrace) {
-      logError(
-        '获取位置失败',
-        error: e,
-        stackTrace: stackTrace,
+    } catch (e) {
+      // 定位/天气在正常使用中本来就会失败：没给权限、离线、超时。
+      // 记成 error 会把日志页刷满预期内的失败，真正的异常反而淹掉。
+      // 也不用带 stackTrace：这一档失败看的是「为什么没拿到」，不是调用栈。
+      logWarning(
+        '获取位置失败: $e',
         source: 'AddNoteController',
       );
       if (_isDisposed) return;
@@ -385,11 +386,12 @@ class AddNoteController extends ChangeNotifier {
 
       isFetchingWeather = false;
       notifyListeners();
-    } catch (e, stackTrace) {
-      logError(
-        '获取天气失败',
-        error: e,
-        stackTrace: stackTrace,
+    } catch (e) {
+      // 定位/天气在正常使用中本来就会失败：没给权限、离线、超时。
+      // 记成 error 会把日志页刷满预期内的失败，真正的异常反而淹掉。
+      // 也不用带 stackTrace：这一档失败看的是「为什么没拿到」，不是调用栈。
+      logWarning(
+        '获取天气失败: $e',
         source: 'AddNoteController',
       );
       if (_isDisposed) return;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1491,7 +1491,7 @@
   "todayThoughtsUseAi": "Use AI for Today's Thoughts",
   "todayThoughtsUseAiDesc": "When enabled, AI will be used to generate prompts for Today's Thoughts. If disabled, local generation will be used.",
   "apiUrlRequired": "API URL cannot be empty",
-  "invalidUrl": "Please enter a valid HTTP/HTTPS URL",
+  "invalidUrl": "Enter an HTTPS URL, or an HTTP address on localhost or your local network",
   "fieldRequired": "This field is required",
   "mediaManagementTitle": "Media File Management",
   "loadStatsError": "Failed to load statistics: {error}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1395,7 +1395,7 @@
   "todayThoughtsUseAi": "Utiliser l'IA pour les Pensées du jour",
   "todayThoughtsUseAiDesc": "Si activé, l'IA sera utilisée pour générer des invites pour les Pensées du jour. Si désactivé, la génération locale sera utilisée.",
   "apiUrlRequired": "L'URL de l'API ne peut pas être vide",
-  "invalidUrl": "Veuillez saisir une URL HTTP/HTTPS valide",
+  "invalidUrl": "Saisissez une URL HTTPS, ou une adresse HTTP sur localhost ou votre réseau local",
   "fieldRequired": "Ce champ est obligatoire",
   "mediaManagementTitle": "Gestion des fichiers multimédias",
   "loadStatsError": "Échec du chargement des statistiques : {error}",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1375,7 +1375,7 @@
   },
   "apiUrlField": "URL de l'API",
   "apiUrlHint": "par ex., https://api.xxx.com/v1/chat/completions",
-  "apiUrlHelper": "Doit être une URL http/https",
+  "apiUrlHelper": "URL HTTPS, ou HTTP uniquement pour localhost ou le réseau local",
   "apiKeyField": "Clé API",
   "apiKeyHint": "La clé requise pour le service (peut être laissée vide)",
   "show": "Afficher",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1402,7 +1402,7 @@
   "todayThoughtsUseAi": "今日の思考でAIを使用",
   "todayThoughtsUseAiDesc": "プロンプト生成にAIを使用します",
   "apiUrlRequired": "API URLは必須です",
-  "invalidUrl": "有効なURLを入力してください",
+  "invalidUrl": "HTTPS の URL、または localhost・ローカルネットワーク上の HTTP アドレスを入力してください",
   "fieldRequired": "この項目は必須です",
   "mediaManagementTitle": "メディア管理",
   "loadStatsError": "統計読み込み失敗: {error}",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1382,7 +1382,7 @@
   },
   "apiUrlField": "API URL",
   "apiUrlHint": "例: https://api.xxx.com/v1/chat/completions",
-  "apiUrlHelper": "http/https URL",
+  "apiUrlHelper": "HTTPS の URL。localhost やローカルネットワークに限り HTTP も可",
   "apiKeyField": "APIキー",
   "apiKeyHint": "必要な場合（空欄可）",
   "show": "表示",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1402,7 +1402,7 @@
   "todayThoughtsUseAi": "오늘의 생각에 AI 사용",
   "todayThoughtsUseAiDesc": "활성화하면 AI를 사용하여 오늘의 생각 프롬프트를 생성합니다. 비활성화하면 로컬 생성을 사용합니다.",
   "apiUrlRequired": "API URL은 비워둘 수 없습니다",
-  "invalidUrl": "유효한 HTTP/HTTPS URL을 입력해 주세요",
+  "invalidUrl": "HTTPS URL 또는 localhost·로컬 네트워크의 HTTP 주소를 입력해 주세요",
   "fieldRequired": "이 필드는 필수입니다",
   "mediaManagementTitle": "미디어 파일 관리",
   "loadStatsError": "통계 로드 실패: {error}",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1382,7 +1382,7 @@
   },
   "apiUrlField": "API URL",
   "apiUrlHint": "예: https://api.xxx.com/v1/chat/completions",
-  "apiUrlHelper": "http/https URL이어야 합니다",
+  "apiUrlHelper": "HTTPS URL이어야 합니다. localhost나 로컬 네트워크는 HTTP도 가능합니다",
   "apiKeyField": "API Key",
   "apiKeyHint": "서비스에 필요한 키 (공란일 수 있음)",
   "show": "표시",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1491,7 +1491,7 @@
   "todayThoughtsUseAi": "今日思考使用AI",
   "todayThoughtsUseAiDesc": "打开后将使用AI生成今日思考提示，关闭则使用本地生成",
   "apiUrlRequired": "API URL不能为空",
-  "invalidUrl": "请输入有效的HTTP/HTTPS URL",
+  "invalidUrl": "请填写 HTTPS 地址；本机或局域网的 HTTP 地址也可以",
   "fieldRequired": "此字段不能为空",
   "mediaManagementTitle": "媒体文件管理",
   "loadStatsError": "加载统计信息失败: {error}",

--- a/lib/pages/ai_provider_edit_page.dart
+++ b/lib/pages/ai_provider_edit_page.dart
@@ -8,6 +8,7 @@ import '../models/ai_provider_settings.dart';
 import '../models/ai_settings.dart';
 import '../services/api_key_manager.dart';
 import '../services/settings_service.dart';
+import '../utils/ai_endpoint_security.dart';
 import '../utils/ai_network_manager.dart';
 import '../utils/app_logger.dart';
 import '../widgets/app_snackbar.dart';
@@ -121,7 +122,12 @@ class _AIProviderEditPageState extends State<AIProviderEditPage> {
     final l10n = AppLocalizations.of(context);
     if (value == null || value.trim().isEmpty) return l10n.apiUrlRequired;
     final uri = Uri.tryParse(value.trim());
-    if (uri == null || !uri.hasScheme || !uri.scheme.startsWith('http')) {
+    // 判据和运行时那三处**必须是同一条**（[isSecureAiEndpoint]），否则又会出现
+    // 「表单放行、发请求时才炸、报错还指不回是哪个设置项」的裂缝——原来这里写的
+    // 是 `startsWith('http')`，对 `http` 和 `https` 都成立，正是那道裂缝。
+    //
+    // 校验属于输入这一层：在能解释、能指着输入框说话的地方拦住它。
+    if (uri == null || !uri.hasScheme || !isSecureAiEndpoint(uri)) {
       return l10n.invalidUrl;
     }
     return null;

--- a/lib/pages/home/daily_prompt_panel.dart
+++ b/lib/pages/home/daily_prompt_panel.dart
@@ -310,11 +310,17 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
                         l10n.todayThoughts,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleMedium?.copyWith(
+                        // 「今日思考」是这张卡的**标签**，不是它的标题——真正的
+                        // 内容是下面那句提问。用 `titleMedium` 会让它吃到标题
+                        // 字重下限（衬线风格下 w700），再叠上强调色和比正文还大
+                        // 的字号，chrome 就压过了 content：眼睛先读到这四个字，
+                        // 而不是那个问题。`labelLarge` 才是它的角色——和按钮、
+                        // 胶囊、导航栏标签同一档功能性文字。
+                        //
+                        // 顺带去掉写死的字号：写死等于把这张卡从
+                        // `ThemeStyleForm.readingFontScale` 体系里摘出去。
+                        style: theme.textTheme.labelLarge?.copyWith(
                           color: theme.colorScheme.primary,
-                          fontSize: widget.screenWidth > 600
-                              ? 16
-                              : (widget.isVerySmallScreen ? 13 : 15),
                         ),
                       ),
                     ),
@@ -345,13 +351,21 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
                   : (isAiConfigured
                       ? l10n.waitingForTodayThoughts
                       : l10n.noTodayThoughts),
-              style: theme.textTheme.bodyMedium?.copyWith(
+              // 提问是这张卡的正文，就该用正文那一级：`bodyLarge` 拿到的是
+              // 正文字重（衬线风格 w600）和跟随风格缩放的字号，标签退到
+              // `labelLarge` 之后，主次才正过来。
+              //
+              // 极小屏退回 `bodyMedium` 而不是写死一个 12：**降级也走类型级别**，
+              // 这样它照样跟着风格缩放，不会又变成一处脱离体系的硬编码。
+              style: (widget.isVerySmallScreen
+                      ? theme.textTheme.bodyMedium
+                      : theme.textTheme.bodyLarge)
+                  ?.copyWith(
+                // 这张卡是紧排的两三行居中提问，不跟正文行高（纸墨 1.75）走，
+                // 否则卡片会显著变高、把上面那张一言卡挤扁。
                 height: 1.4,
-                fontSize: widget.screenWidth > 600
-                    ? 15
-                    : (widget.isVerySmallScreen ? 12 : 14),
                 color: _accumulatedPromptText.isNotEmpty
-                    ? theme.textTheme.bodyMedium?.color
+                    ? theme.textTheme.bodyLarge?.color
                     : theme.colorScheme.onSurface.withAlpha(120),
               ),
               textAlign: TextAlign.center,

--- a/lib/pages/home/daily_prompt_panel.dart
+++ b/lib/pages/home/daily_prompt_panel.dart
@@ -240,6 +240,13 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
     final theme = Theme.of(context);
     final shape = AppShapeTokens.of(context);
     final l10n = AppLocalizations.of(context);
+    // 提问是这张卡的正文，就该用正文那一级。极小屏退回 `bodyMedium` 而不是写死
+    // 一个字号：**降级也走类型级别**，这样它照样跟着 `readingFontScale` 缩放。
+    // 取成局部变量是为了让下面的 `color` 也读到**同一级**——分别写两次的话，
+    // 极小屏会出现「样式取 bodyMedium、颜色取 bodyLarge」的错配。
+    final promptStyle = widget.isVerySmallScreen
+        ? theme.textTheme.bodyMedium
+        : theme.textTheme.bodyLarge;
     final aiService = context.watch<AIService>();
     final settingsService = context.watch<SettingsService>();
     // 以多 provider 设置为准：生成链路读的是 multiAISettings.currentProvider，
@@ -351,21 +358,14 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
                   : (isAiConfigured
                       ? l10n.waitingForTodayThoughts
                       : l10n.noTodayThoughts),
-              // 提问是这张卡的正文，就该用正文那一级：`bodyLarge` 拿到的是
-              // 正文字重（衬线风格 w600）和跟随风格缩放的字号，标签退到
-              // `labelLarge` 之后，主次才正过来。
-              //
-              // 极小屏退回 `bodyMedium` 而不是写死一个 12：**降级也走类型级别**，
-              // 这样它照样跟着风格缩放，不会又变成一处脱离体系的硬编码。
-              style: (widget.isVerySmallScreen
-                      ? theme.textTheme.bodyMedium
-                      : theme.textTheme.bodyLarge)
-                  ?.copyWith(
+              style: promptStyle?.copyWith(
                 // 这张卡是紧排的两三行居中提问，不跟正文行高（纸墨 1.75）走，
                 // 否则卡片会显著变高、把上面那张一言卡挤扁。
                 height: 1.4,
+                // 颜色要读**实际选中的那一级**：极小屏用的是 bodyMedium，
+                // 却去取 bodyLarge 的颜色，一旦主题给两级配了不同颜色就会错。
                 color: _accumulatedPromptText.isNotEmpty
-                    ? theme.textTheme.bodyLarge?.color
+                    ? promptStyle.color
                     : theme.colorScheme.onSurface.withAlpha(120),
               ),
               textAlign: TextAlign.center,

--- a/lib/services/network_service.dart
+++ b/lib/services/network_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import '../utils/ai_endpoint_security.dart';
 import '../utils/http_response.dart';
 import '../models/ai_settings.dart';
 import '../models/ai_provider_settings.dart';
@@ -182,9 +183,12 @@ class NetworkService {
     _ensureInitialized();
 
     try {
+      // 判据见 [isSecureAiEndpoint]：公网必须 https，环回/私有网段的明文放行。
+      // 一刀切 https-only 会把本地模型（Ollama / LM Studio，只监听
+      // `http://127.0.0.1:<port>`）整个功能判死。
       final uri = Uri.parse(url);
-      if (uri.scheme.toLowerCase() != 'https') {
-        throw Exception('非安全URL: 所有请求必须使用HTTPS');
+      if (!isSecureAiEndpoint(uri)) {
+        throw Exception('非安全URL: 公网请求必须使用 HTTPS');
       }
 
       final headers = _buildAIHeaders(provider, legacySettings);
@@ -227,9 +231,12 @@ class NetworkService {
     _ensureInitialized();
 
     try {
+      // 判据见 [isSecureAiEndpoint]：公网必须 https，环回/私有网段的明文放行。
+      // 一刀切 https-only 会把本地模型（Ollama / LM Studio，只监听
+      // `http://127.0.0.1:<port>`）整个功能判死。
       final uri = Uri.parse(url);
-      if (uri.scheme.toLowerCase() != 'https') {
-        throw Exception('非安全URL: 所有请求必须使用HTTPS');
+      if (!isSecureAiEndpoint(uri)) {
+        throw Exception('非安全URL: 公网请求必须使用 HTTPS');
       }
 
       final headers = _buildAIHeaders(provider, legacySettings);

--- a/lib/utils/ai_endpoint_security.dart
+++ b/lib/utils/ai_endpoint_security.dart
@@ -17,7 +17,13 @@ import 'dart:io' show InternetAddress, InternetAddressType;
 /// - `https` → 永远安全。
 /// - `http` → 只有目标在**环回或私有网段**时才安全（包没有离开本机或本地网络）。
 /// - 其它 scheme（含拼错的、空的）→ 一律不安全。
+/// - 主机为空（`https:foo`、`https:///`）→ 一律不安全，scheme 对也不行。
 bool isSecureAiEndpoint(Uri uri) {
+  // **没有主机的绝对 URI 一律不安全**，哪怕 scheme 写着 https：
+  // `Uri.parse('https:foo')` 和 `https:///` 的 `host` 都是空串，它们 scheme 对
+  // 但根本不是一个端点。放行等于把「这地址无效」推迟到发请求时才由 Dio 报错，
+  // 而这个判据存在的理由正是「在输入这一层拦住、在能解释的地方说话」。
+  if (uri.host.isEmpty) return false;
   final scheme = uri.scheme.toLowerCase();
   if (scheme == 'https') return true;
   if (scheme != 'http') return false;

--- a/lib/utils/ai_endpoint_security.dart
+++ b/lib/utils/ai_endpoint_security.dart
@@ -1,0 +1,62 @@
+/// AI 服务端点的传输安全判据。
+///
+/// **判据是「密钥会不会以明文跨过一段我们不控制的网络」，不是「scheme 是不是
+/// https」。** 这两件事在公网上等价，在环回和私有网段上不等价，而后者正是
+/// 本地模型（Ollama / LM Studio / vLLM / llama.cpp）唯一的部署形态——它们
+/// 基本都只监听 `http://127.0.0.1:<port>`，装不了也不需要证书。
+///
+/// 一刀切成 https-only 的代价是把「本地模型」整个功能判死：
+/// `ai_settings_page_test` 里那条 `id: 'local'` / 名字「本机模型」 /
+/// `http://localhost:1234/v1/chat/completions` 的夹具就是这个用法的证据。
+library;
+
+import 'dart:io' show InternetAddress, InternetAddressType;
+
+/// 这个端点发请求时是否安全。
+///
+/// - `https` → 永远安全。
+/// - `http` → 只有目标在**环回或私有网段**时才安全（包没有离开本机或本地网络）。
+/// - 其它 scheme（含拼错的、空的）→ 一律不安全。
+bool isSecureAiEndpoint(Uri uri) {
+  final scheme = uri.scheme.toLowerCase();
+  if (scheme == 'https') return true;
+  if (scheme != 'http') return false;
+  return _isLocalHost(uri.host);
+}
+
+/// 字符串版，解析不了就是不安全。
+bool isSecureAiEndpointUrl(String url) {
+  final uri = Uri.tryParse(url.trim());
+  if (uri == null || !uri.hasScheme) return false;
+  return isSecureAiEndpoint(uri);
+}
+
+/// 主机名/地址是否落在「包不出本机或本地网络」的范围里。
+bool _isLocalHost(String host) {
+  if (host.isEmpty) return false;
+  final name = host.toLowerCase();
+
+  // 主机名形式。`.local` 是 mDNS，只在本地链路解析。
+  if (name == 'localhost' ||
+      name.endsWith('.localhost') ||
+      name.endsWith('.local')) {
+    return true;
+  }
+
+  // 字面量地址。`Uri.host` 会把 IPv6 的方括号去掉，可以直接喂给 tryParse。
+  final address = InternetAddress.tryParse(name);
+  if (address == null) return false;
+  if (address.isLoopback || address.isLinkLocal) return true;
+
+  final raw = address.rawAddress;
+  if (address.type == InternetAddressType.IPv4) {
+    // 10/8、172.16/12、192.168/16 —— RFC 1918。
+    if (raw[0] == 10) return true;
+    if (raw[0] == 172 && raw[1] >= 16 && raw[1] <= 31) return true;
+    if (raw[0] == 192 && raw[1] == 168) return true;
+    return false;
+  }
+
+  // IPv6 唯一本地地址 fc00::/7（fc.. 和 fd..）。
+  return (raw[0] & 0xFE) == 0xFC;
+}

--- a/lib/utils/ai_network_manager.dart
+++ b/lib/utils/ai_network_manager.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:thoughtecho/utils/dio_performance_interceptor.dart';
 import 'package:flutter/foundation.dart';
+import 'ai_endpoint_security.dart';
 import '../models/ai_settings.dart';
 import '../models/ai_provider_settings.dart';
 import '../models/multi_ai_settings.dart' as multi_ai;
@@ -123,9 +124,10 @@ class AINetworkManager {
         throw Exception('请求数据JSON编码失败: $e');
       }
 
+      // 判据见 [isSecureAiEndpoint]，和设置页的校验器、NetworkService 同一条。
       final uri = Uri.parse(finalUrl);
-      if (uri.scheme.toLowerCase() != 'https') {
-        throw Exception('非安全URL: 所有请求必须使用HTTPS');
+      if (!isSecureAiEndpoint(uri)) {
+        throw Exception('非安全URL: 公网请求必须使用 HTTPS');
       }
 
       final response = await _dio.post(

--- a/test/unit/services/network_service_test.dart
+++ b/test/unit/services/network_service_test.dart
@@ -202,10 +202,15 @@ void main() {
         throwsA(isA<Exception>().having(
           (e) => e.toString(),
           'description',
-          contains('非安全URL: 所有请求必须使用HTTPS'),
+          contains('非安全URL'),
         )),
       );
     });
+
+    // 「本地明文端点要放行」不在这里断言：判据一旦放行，`aiRequest` 就会真的去连
+    // http://127.0.0.1:1234，撞上重试退避直接把用例拖超时。那条规则由
+    // `test/unit/utils/ai_endpoint_security_test.dart` 覆盖（纯函数，不碰网络），
+    // 接线由下面这条「公网明文被拦」和设置页那条 localhost 夹具用例共同证明。
 
     test('aiRequest should allow uppercase HTTPS URL scheme', () async {
       try {
@@ -214,7 +219,7 @@ void main() {
           data: {},
         );
       } catch (e) {
-        expect(e.toString(), isNot(contains('非安全URL: 所有请求必须使用HTTPS')));
+        expect(e.toString(), isNot(contains('非安全URL')));
       }
     });
 
@@ -233,7 +238,7 @@ void main() {
       expect(capturedError, isNotNull);
       expect(
         capturedError.toString(),
-        contains('非安全URL: 所有请求必须使用HTTPS'),
+        contains('非安全URL'),
       );
     });
   });

--- a/test/unit/utils/ai_endpoint_security_test.dart
+++ b/test/unit/utils/ai_endpoint_security_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/utils/ai_endpoint_security.dart';
+
+void main() {
+  group('isSecureAiEndpointUrl', () {
+    test('https 一律放行，大小写不敏感', () {
+      expect(isSecureAiEndpointUrl('https://api.openai.com/v1/x'), isTrue);
+      expect(isSecureAiEndpointUrl('HTTPS://api.openai.com/v1/x'), isTrue);
+    });
+
+    test('公网明文一律拦下', () {
+      expect(isSecureAiEndpointUrl('http://api.openai.com/v1/x'), isFalse);
+      expect(isSecureAiEndpointUrl('http://8.8.8.8:11434/v1'), isFalse);
+      // 172.15 / 172.32 在 RFC1918 的 172.16/12 之外，别把边界放宽了。
+      expect(isSecureAiEndpointUrl('http://172.15.0.1:1234/v1'), isFalse);
+      expect(isSecureAiEndpointUrl('http://172.32.0.1:1234/v1'), isFalse);
+    });
+
+    test('本地模型的明文端点放行——这是 Ollama / LM Studio 唯一的部署形态', () {
+      expect(isSecureAiEndpointUrl('http://localhost:1234/v1'), isTrue);
+      expect(isSecureAiEndpointUrl('http://127.0.0.1:11434/v1'), isTrue);
+      expect(isSecureAiEndpointUrl('http://[::1]:11434/v1'), isTrue);
+      expect(isSecureAiEndpointUrl('http://mac-mini.local:1234/v1'), isTrue);
+    });
+
+    test('私有网段的明文端点放行：包没有离开本地网络', () {
+      expect(isSecureAiEndpointUrl('http://192.168.1.10:11434/v1'), isTrue);
+      expect(isSecureAiEndpointUrl('http://10.0.0.5:11434/v1'), isTrue);
+      expect(isSecureAiEndpointUrl('http://172.16.0.1:11434/v1'), isTrue);
+      expect(isSecureAiEndpointUrl('http://172.31.255.254:1234/v1'), isTrue);
+      expect(isSecureAiEndpointUrl('http://[fd00::1]:11434/v1'), isTrue);
+    });
+
+    test('其它 scheme 和解析不了的一律不安全', () {
+      expect(isSecureAiEndpointUrl('ftp://example.com/x'), isFalse);
+      expect(isSecureAiEndpointUrl('ws://localhost:1234'), isFalse);
+      expect(isSecureAiEndpointUrl('api.openai.com/v1'), isFalse);
+      expect(isSecureAiEndpointUrl(''), isFalse);
+    });
+  });
+}

--- a/test/unit/utils/ai_endpoint_security_test.dart
+++ b/test/unit/utils/ai_endpoint_security_test.dart
@@ -31,6 +31,16 @@ void main() {
       expect(isSecureAiEndpointUrl('http://[fd00::1]:11434/v1'), isTrue);
     });
 
+    test('scheme 对但没有主机的一律不安全', () {
+      // `Uri.parse` 对这些照样给出 scheme=https、host=''：scheme 判对了不等于
+      // 这是个端点。放行的话，用户在设置页填 `https:foo` 会一路保存成功，
+      // 直到发请求时才由 Dio 报「无效地址」。
+      expect(isSecureAiEndpointUrl('https:foo'), isFalse);
+      expect(isSecureAiEndpointUrl('https:///'), isFalse);
+      expect(isSecureAiEndpointUrl('https://'), isFalse);
+      expect(isSecureAiEndpointUrl('http:///v1'), isFalse);
+    });
+
     test('其它 scheme 和解析不了的一律不安全', () {
       expect(isSecureAiEndpointUrl('ftp://example.com/x'), isFalse);
       expect(isSecureAiEndpointUrl('ws://localhost:1234'), isFalse);


### PR DESCRIPTION
## 1. #525 的 HTTPS 强制打断了本地模型（主要问题）

`NetworkService.aiRequest` / `aiStreamRequest` / `AINetworkManager` 一刀切要求 `scheme == 'https'`。但本地模型（Ollama / LM Studio / vLLM / llama.cpp）基本只监听 `http://127.0.0.1:<port>` —— 装不了也不需要证书。这条规则等于**把「本地模型」整个功能判死**。

不是推测，仓库自己的测试就写着这个用法：

```dart
// test/widget/pages/ai_settings_page_test.dart
AIProviderSettings(
  id: 'local',
  name: '本机模型',
  apiUrl: 'http://localhost:1234/v1/chat/completions',
  model: 'old-model',
),
```

我最初按「https-only」去修校验缺口，跑测试时这条挂了 —— 等于把 bug 焊死。

**改法**：判据换成「密钥会不会以明文跨过一段我们不控制的网络」，而不是 scheme 本身。新增 `isSecureAiEndpoint`（`lib/utils/ai_endpoint_security.dart`）：

| 情况 | 结果 |
|---|---|
| `https://…` | 放行 |
| `http://` + 环回（`localhost` / `127.0.0.1` / `::1` / `*.localhost`） | 放行 |
| `http://` + `*.local`（mDNS，只在本地链路解析） | 放行 |
| `http://` + RFC1918（`10/8`、`172.16/12`、`192.168/16`）、链路本地、IPv6 `fc00::/7` | 放行 |
| `http://` + 其它（公网） | **拦下** |
| 其它 scheme / 解析失败 | **拦下** |

公网明文照样拦，本地部署照样能用。

## 2. 同一条判据前移到输入层

`ai_provider_edit_page._validateUrl` 原来是：

```dart
if (uri == null || !uri.hasScheme || !uri.scheme.startsWith('http')) {
```

`startsWith('http')` 对 `http` 和 `https` **都成立**。于是用户填 `http://api.example.com` → 表单放行、保存成功 → 之后每次 AI 请求在运行时才炸，报错里没有任何线索指回是哪个设置项。

现在校验器和运行时三处**共用同一个** `isSecureAiEndpoint`，裂缝消失。`invalidUrl` 文案同步改成说明白「HTTPS，或者本机 / 局域网的 HTTP」，覆盖 en / fr / ja / ko / zh。

## 3. 今日思考的主次是反的

| 元素 | 原来 | 落地效果 |
|---|---|---|
| 标签「今日思考」 | `titleMedium` + 强调色 + 写死 15px | 衬线 **w700** 赭石色 |
| 提问（内容） | `bodyMedium` + 写死 14px | 衬线 w500 灰 |

标签比内容更大、更重、更艳 —— 眼睛先读到那四个字，而不是问题本身。而且这个反差是 **#521 把标题下限抬到 w700 之后放大的**（原本差一档，变成差两档）。

标签降到 `labelLarge`（它就是功能性标签，和按钮、胶囊同一档），提问升到 `bodyLarge`。两处写死的 `fontSize` 一并去掉 —— 写死等于把这张卡从 `ThemeStyleForm.readingFontScale` 体系里摘出去。极小屏退回 `bodyMedium` 而不是写死一个 12，**降级也走类型级别**。

## 4. #527 顺带：预期内的失败降回 warning

定位 / 天气获取失败在正常使用中本来就会发生（没给权限、离线、超时）。记成 `logError` 会把日志页刷满预期内的失败，把真正的异常淹掉 —— 改回 `logWarning`。

## 讨论过但**没做**的两项

- **首页顶栏天气改衬线**：出图比过。衬线要好看就得放大，一放大那个 chip 就从配角变成主角（外面套着 `FittedBox(scaleDown)`，放大后整条被缩放）；不放大就得接受 12px 宋体 w400 那层灰绒。收益小于代价，保持黑体。
- **按钮 / 胶囊改衬线**：同样是 11–14sp 功能性文字，糊的程度和上面一样，而且不承担任何风格识别。`36a78da` 当初排除 `label*` 的判断是对的。

## 测试

- 新增 `test/unit/utils/ai_endpoint_security_test.dart`：纯函数，覆盖环回 / `.local` / RFC1918 / IPv6 ULA / 公网 / **边界（`172.15` 与 `172.32` 必须被拦）** / 其它 scheme。
- `network_service_test` 保留「公网明文被拦」；**本地放行不在那里断言** —— 判据一放行 `aiRequest` 就会真的去连 `127.0.0.1`，撞上重试退避把用例拖到超时。理由写在原处。
- 原先挂掉的 `ai_settings_page_test`「本机模型」用例恢复通过。
- 全量 `test/unit` + `test/widget` **2102 项通过**，`dart format` 与 `flutter analyze` 干净（只剩仓库既有的 2 条 deprecated info）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoY4B7pKH7dwiXBJevF8Qn)_

## Sourcery 总结

允许安全的本地 AI 部署，同时对公共端点强制使用 HTTPS；使验证逻辑与运行时检查保持一致；优化每日思绪层级；并降低预期环境故障的日志严重级别。

新功能：
- 允许环回、mDNS 本地、链路本地和私有网络主机使用 HTTP AI 端点，同时继续要求公共端点使用 HTTPS。

错误修复：
- 在提供商验证和请求期间应用一致的 AI 端点安全策略，防止保存不安全的公共 HTTP 配置，并恢复对本地模型提供商的支持。
- 将预期的位置和天气获取失败从错误降级为警告，以减少嘈杂日志。
- 重新平衡每日思绪面板的排版，使提示内容在视觉上更突出，并遵循已配置的字体缩放设置。

测试：
- 增加针对 HTTPS、本地和私有地址、公共地址、边界范围及不支持协议的安全端点判定的单元测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持安全的本地 AI 部署，使端点验证与运行时执行规则保持一致，优化每日箴言的排版，并减少预期环境故障带来的干扰。

新功能：
- 允许环回、本地域名、链路本地和私有网络主机使用 HTTP AI 端点，同时继续要求公共端点使用 HTTPS。

错误修复：
- 在提供商验证和请求过程中应用统一的 AI 端点安全策略，防止不安全的公共 HTTP 配置，同时恢复对本地模型的支持。
- 将预期的位置和天气获取失败从错误降级为警告，同时保留对编程错误的错误日志记录。

改进：
- 重新平衡每日箴言面板的排版，使提示文本在视觉上更加突出，并让两个元素都遵循配置的文本缩放比例。

测试：
- 为安全、本地、私有、公共、边界、格式错误和不受支持的 AI 端点 URL 添加单元测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow secure local AI deployments, align endpoint validation with runtime enforcement, improve daily thought typography, and reduce noise from expected environmental failures.

New Features:
- Allow HTTP AI endpoints for loopback, local-domain, link-local, and private-network hosts while continuing to require HTTPS for public endpoints.

Bug Fixes:
- Apply one shared AI endpoint security policy during provider validation and requests, preventing unsafe public HTTP configurations while restoring local model support.
- Reduce expected location and weather acquisition failures from errors to warnings while retaining error logging for programming failures.

Enhancements:
- Rebalance the daily thought panel typography so the prompt is visually primary and both elements follow configured text scaling.

Tests:
- Add unit coverage for secure, local, private, public, boundary, malformed, and unsupported AI endpoint URLs.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
本地模型端点不再被一刀切的 HTTPS 校验判死：http 请求按目标位置放行，环回、`.local` 和私有网段可用，公网明文仍被拦截（#525）。今日思考卡的标签/正文层级互换，定位与天气失败日志降回 warning（#527）。

- 新增 `isSecureAiEndpoint`（`lib/utils/ai_endpoint_security.dart`）统一判据：https 放行；http 仅环回、`*.localhost`、`*.local`、RFC1918 私有网段、链路本地与 IPv6 ULA（`fc00::/7`）放行，其余拦下；scheme 是 https 但没有主机（如 `https:foo`）也一律拦下。
- 设置页表单原来用 `scheme.startsWith('http')`，会放行公网明文并在请求时才抛错；现在与 `NetworkService` / `AINetworkManager` 共用同一判据，`invalidUrl` 文案同步更新五种语言，fr/ja/ko 的输入框帮助文案也一并对齐。
- 标签「今日思考」从 `titleMedium` 降到 `labelLarge`，提问从 `bodyMedium` 升到 `bodyLarge`，写死的 `fontSize` 移除，极小屏退回 `bodyMedium`，修掉 #521 放大后的层级差；样式提到 build 顶部存成局部变量，颜色读同一变量避免极小屏错配。
- 定位/天气获取失败从 `logError` 改回 `logWarning`；但 `Error` 类编程错误仍保留 `logError` 和调用栈，只有预期内的 `Exception` 降级。

<sup>Written for commit 2de6a368dd37d586b2ff35b226a037bcbb14b06b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化 AI 服务地址安全校验：公网请求必须使用 HTTPS，本机及局域网地址可使用 HTTP。
  - 更新 URL 输入提示，明确说明允许的地址类型，并同步完善多语言文案。

- **界面优化**
  - 调整“今日思考”面板文字样式，使字号更好地适配主题与不同屏幕尺寸。

- **改进**
  - 降低非关键位置错误日志的严重级别，减少不必要的调用栈记录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->