### PR TITLE
style(ui): 今日思考的提问收回 bodyMedium；占位符全局降一档

### DIFF
--- a/lib/pages/home/daily_prompt_panel.dart
+++ b/lib/pages/home/daily_prompt_panel.dart
@@ -247,8 +247,11 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
     // 顶高，跟上面那张一言卡抢分量。真正起作用的是降标签那一半：标签一旦是黑体
     // `labelLarge`，提问只要还是衬线、还比它深，主次就已经正过来了，不需要再放大。
     //
-    // 取成局部变量是为了让下面的 `color` 也读到**同一级**，避免样式和颜色分别写
-    // 两次时读到不同的级别。
+    // 所有屏幕尺寸都用这一级，不再按屏分档；随屏变的只剩 `maxLines`。
+    //
+    // 仍然取成局部变量而不是两处各写一遍 `theme.textTheme.bodyMedium`：样式和
+    // 颜色必须读同一级，写成两处就等着将来改了一处漏另一处——#529 那版正是
+    // 样式取 `bodyMedium`、颜色却取 `bodyLarge`，在极小屏上错配。
     final promptStyle = theme.textTheme.bodyMedium;
     final aiService = context.watch<AIService>();
     final settingsService = context.watch<SettingsService>();

--- a/lib/pages/home/daily_prompt_panel.dart
+++ b/lib/pages/home/daily_prompt_panel.dart
@@ -240,13 +240,16 @@ class HomeDailyPromptPanelState extends State<HomeDailyPromptPanel> {
     final theme = Theme.of(context);
     final shape = AppShapeTokens.of(context);
     final l10n = AppLocalizations.of(context);
-    // 提问是这张卡的正文，就该用正文那一级。极小屏退回 `bodyMedium` 而不是写死
-    // 一个字号：**降级也走类型级别**，这样它照样跟着 `readingFontScale` 缩放。
-    // 取成局部变量是为了让下面的 `color` 也读到**同一级**——分别写两次的话，
-    // 极小屏会出现「样式取 bodyMedium、颜色取 bodyLarge」的错配。
-    final promptStyle = widget.isVerySmallScreen
-        ? theme.textTheme.bodyMedium
-        : theme.textTheme.bodyLarge;
+    // 提问用 `bodyMedium`，不是 `bodyLarge`。
+    //
+    // 上一轮为了把标签压下去，两头都动了：标签降到 `labelLarge`，提问抬到
+    // `bodyLarge`。**抬过头了**——衬线 17px w600 在这张卡里会撑成两行、把整张卡
+    // 顶高，跟上面那张一言卡抢分量。真正起作用的是降标签那一半：标签一旦是黑体
+    // `labelLarge`，提问只要还是衬线、还比它深，主次就已经正过来了，不需要再放大。
+    //
+    // 取成局部变量是为了让下面的 `color` 也读到**同一级**，避免样式和颜色分别写
+    // 两次时读到不同的级别。
+    final promptStyle = theme.textTheme.bodyMedium;
     final aiService = context.watch<AIService>();
     final settingsService = context.watch<SettingsService>();
     // 以多 provider 设置为准：生成链路读的是 multiAISettings.currentProvider，

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1098,6 +1098,13 @@ class AppTheme with ChangeNotifier {
       ),
 
       // 浮动操作按钮使用主题色系
+      // 占位符降一档，理由见暗色那份同名注释。
+      //
+      // **亮色这条原本整个没有 `inputDecorationTheme`**（只有暗色有），
+      // 所以这里是新加的一整项，不是 copyWith 追加。两条路径本来就不对称，
+      // 加的时候别只改一边。
+      inputDecorationTheme: baseTheme.inputDecorationTheme
+          .copyWith(hintStyle: textTheme.bodyMedium),
       floatingActionButtonTheme: baseTheme.floatingActionButtonTheme.copyWith(
         backgroundColor: colorScheme.primary,
         foregroundColor: colorScheme.onPrimary,
@@ -1189,6 +1196,9 @@ class AppTheme with ChangeNotifier {
     );
 
     // 返回主题，确保使用原始的colorScheme，并额外配置控件主题
+    // 和亮色那条对齐：排版加工只做一次，`textTheme` 和 `hintStyle` 读同一份，
+    // 免得两处各算一次、将来改了一处漏另一处。
+    final darkTextTheme = _styledTextTheme(form, baseTheme.textTheme);
     return _cachedDarkThemeData = baseTheme.copyWith(
       colorScheme: colorScheme, // 重新应用原始colorScheme，确保自定义颜色不被修改
       // 显式配置 Switch 主题，确保使用自定义主题色
@@ -1346,6 +1356,15 @@ class AppTheme with ChangeNotifier {
       ),
       // 配置输入框装饰主题
       inputDecorationTheme: baseTheme.inputDecorationTheme.copyWith(
+        // **占位符降一档，全局一处。**
+        //
+        // `TextField` 的 hint 默认跟输入文字同一级（`bodyLarge`），衬线风格下就是
+        // 17px w600——和笔记正文一模一样的分量。可占位符是 chrome，不是内容：
+        // 记录页那个「搜索笔记…」看着和它下面的笔记正文一样重，读起来像标题。
+        //
+        // 写在主题里而不是逐个 `hintStyle:`：全仓库有二十多处 `hintText` 没给样式，
+        // 逐点改既漏又会漂。输入文字本身不动——那是用户敲进去的内容，该有内容的分量。
+        hintStyle: darkTextTheme.bodyMedium,
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(inputRadius),
           borderSide: BorderSide(color: colorScheme.primary, width: 2),
@@ -1372,7 +1391,7 @@ class AppTheme with ChangeNotifier {
       extensions: _extensionsFor(form, colorScheme, Brightness.dark),
 
       // Windows 平台字体优化
-      textTheme: _styledTextTheme(form, baseTheme.textTheme),
+      textTheme: darkTextTheme,
       primaryTextTheme: _styledTextTheme(form, baseTheme.primaryTextTheme),
     );
   }

--- a/test/preview/page_preview_test.dart
+++ b/test/preview/page_preview_test.dart
@@ -271,6 +271,10 @@ void main() {
     /// null 表示留在默认的首页——首页那个 destination 已经是选中态，
     /// 未选中图标 `home_outlined` 根本不在树里，点不到。
     required IconData? navIcon,
+
+    /// 亮暗两套都要出图：手工风格的字重/字号在暗色下压在深底上，观感和亮色
+    /// 不是一回事，只渲亮色等于半边没看。
+    Brightness brightness = Brightness.light,
     required String name,
   }) async {
     tester.view.physicalSize = const Size(786, 1746);
@@ -324,7 +328,9 @@ void main() {
             locale: const Locale('zh'),
             theme: appTheme.createLightThemeData(),
             darkTheme: appTheme.createDarkThemeData(),
-            themeMode: ThemeMode.light,
+            themeMode: brightness == Brightness.dark
+                ? ThemeMode.dark
+                : ThemeMode.light,
             home: const HomePage(),
           ),
         ),
@@ -358,7 +364,8 @@ void main() {
       final png = await image.toByteData(format: ui.ImageByteFormat.png);
       image.dispose();
       final dir = Directory(outDir)..createSync(recursive: true);
-      File('${dir.path}/${tag}_$name.png')
+      final suffix = brightness == Brightness.dark ? '_dark' : '';
+      File('${dir.path}/${tag}_$name$suffix.png')
           .writeAsBytesSync(png!.buffer.asUint8List());
     });
   }
@@ -394,6 +401,28 @@ void main() {
         accent: accent,
         navIcon: null,
         name: 'home_$styleName',
+      );
+    }, skip: fontDir == null);
+
+    testWidgets('记录页 · $styleName · 暗色', (tester) async {
+      await renderTab(
+        tester,
+        style: style,
+        accent: accent,
+        navIcon: Icons.book_outlined,
+        name: 'notes_$styleName',
+        brightness: Brightness.dark,
+      );
+    }, skip: fontDir == null);
+
+    testWidgets('首页 · $styleName · 暗色', (tester) async {
+      await renderTab(
+        tester,
+        style: style,
+        accent: accent,
+        navIcon: null,
+        name: 'home_$styleName',
+        brightness: Brightness.dark,
       );
     }, skip: fontDir == null);
   }


### PR DESCRIPTION
## 1. 今日思考的提问抬过头了

#529 为了把标签压下去**两头都动了**：标签降到 `labelLarge`，提问抬到 `bodyLarge`。提问那一半是过的 —— 衬线 17px w600 在这张卡里会撑成两行、把卡片顶高，跟上面那张一言卡抢分量。

真正起作用的是**降标签那一半**：标签一旦是黑体 `labelLarge`，提问只要还是衬线、还比它深，主次就已经正过来了，不需要再放大。

提问收回 `bodyMedium`，顺带去掉极小屏的分支 —— 一个级别就够，不用再判屏。

## 2. 输入框占位符跟输入文字同重

`TextField` 的 hint 默认跟输入文字同一级（`bodyLarge`），衬线风格下就是 **17px w600** —— 和笔记正文一模一样的分量。记录页那个「搜索笔记…」看着和它下面的笔记正文一样重，读起来像标题，可它是 chrome 不是内容。

和「今日思考」标签是同一类问题：**chrome 占了内容的字级**。

**写在主题里而不是逐个 `hintStyle:`** —— 全仓库有二十多处 `hintText` 没给样式，逐点改既漏又会漂。输入文字本身不动：那是用户敲进去的内容，该有内容的分量。

顺带查出两条路径不对称：**亮色主题原本整个没有 `inputDecorationTheme`**，只有暗色有。亮色这次是新加一整项，注释里写明了别只改一边。暗色那边把 `_styledTextTheme` 的结果提成局部变量，`textTheme` 和 `hintStyle` 读同一份，不再各算一次。

## 3. 出图脚手架补上暗色

之前整轮排查**只渲了亮色，等于半边没看** —— 手工风格的字重压在深底上，观感和亮色不是一回事。`renderTab` 加 `brightness` 参数，记录页和首页各多一组暗色图，文件名带 `_dark` 后缀。这次两处改动在暗色下也复核过。

## 排查过但**没动**的地方

- **笔记正文 `bodyLarge` w600** —— 出图确认仍然合适，这是上一轮真正解决问题的那一刀，不动。
- **设置项标题 / 小节标题**（`bodyLarge` w600 / `titleMedium` w700）—— 同字号差一档字重，正是 M3 的层级手法，配上图标和分隔线读得清楚。
- **来源行、元信息、标签胶囊** —— 三档阶梯（w600 / w500 / 黑体 w400）成立，亮暗都复核过。

## 测试

全量 `test/unit` + `test/widget` **2103 项通过**，`[E]` 计数 0，`dart format` 与 `flutter analyze` 干净（只剩仓库既有的 2 条 deprecated info）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoY4B7pKH7dwiXBJevF8Qn)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
今日思考的提问从 `bodyLarge` 收回 `bodyMedium`，输入框占位符全局降一档——两处都是把界面 chrome 抬到了和内容同重，读起来像标题，改回主次分明。顺带把出图脚手架补上暗色渲染，之前只渲亮色等于半边没看。

**调整**
- 提问统一用 `bodyMedium`，极小屏分支删掉；局部变量保留，防止将来样式和颜色读成不同级别。
- 占位符在主题里统一设 `hintStyle`，不逐个 `hintStyle:` 改，输入文字本身不动。
- 亮色主题原来整个没有 `inputDecorationTheme`，这次新加；暗色把排版结果提成局部变量，`textTheme` 和 `hintStyle` 读同一份。

**出图与测试**
- `renderTab` 加 `brightness` 参数，记录页和首页各渲一组暗色图（文件名带 `_dark` 后缀），两处改动在暗色下复核过。
- 全量 unit + widget 2103 项通过，`dart format` 与 `flutter analyze` 干净。

<sup>Written for commit d22917d5bb1b14d208d0564bf05c4912e773326b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 统一首页每日提示文字大小，提升不同屏幕尺寸下的视觉一致性。
  * 优化亮色和暗色主题中的输入框占位符样式，使文字显示更加协调。

* **测试**
  * 新增记录页和首页的暗色主题预览，覆盖亮色与暗色两种显示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->