### PR TITLE
fix(db): 一条读不出来的坏行不再连累整页笔记加载

### DIFF
--- a/lib/services/database/database_favorite_mixin.dart
+++ b/lib/services/database/database_favorite_mixin.dart
@@ -271,7 +271,7 @@ mixin _DatabaseFavoriteMixin on _DatabaseServiceBase {
         limit: limit,
       );
 
-      return results.map((map) => Quote.fromJson(map)).toList();
+      return _parseQuoteRows(results);
     } catch (e) {
       logError('获取本周最受喜爱笔记时出错: $e', error: e, source: 'GetMostFavorited');
       return [];

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -156,24 +156,7 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
       }
     }
 
-    final quotes = <Quote>[];
-
-    for (final map in maps) {
-      try {
-        final quoteId = map['id'] as String;
-        final tagIds = tagsByQuoteId[quoteId] ?? [];
-
-        final quoteData = Map<String, dynamic>.from(map);
-        quoteData['tag_ids'] = tagIds.join(',');
-
-        final quote = Quote.fromJson(quoteData);
-        quotes.add(quote);
-      } catch (e) {
-        logDebug('解析笔记数据失败: $e, 数据: $map');
-      }
-    }
-
-    return quotes;
+    return _parseQuoteRows(maps, tagsByQuoteId: tagsByQuoteId);
   }
 
   /// 检查并修复数据库结构，确保所有必要的列都存在
@@ -263,7 +246,7 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
         limit: limit,
       );
 
-      return maps.map((m) => Quote.fromJson(m)).toList();
+      return _parseQuoteRows(maps);
     } catch (e) {
       logError(
         'getQuotesForSmartPush 失败: $e',

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -124,7 +124,7 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
     if (maps.isEmpty) return [];
 
-    final quoteIds = maps.map((m) => m['id'] as String).toList();
+    final quoteIds = maps.map((m) => m['id']).whereType<String>().toList();
 
     final tagsByQuoteId = <String, List<String>>{};
 
@@ -149,9 +149,12 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
     for (final result in allTagMaps) {
       final tagMaps = result as List;
       for (final item in tagMaps) {
-        final tagMap = item as Map<String, dynamic>;
-        final quoteId = tagMap['quote_id'] as String;
-        final tagId = tagMap['tag_id'] as String;
+        // 关联表的值同样不能硬转：一个坏值抛出来会连累整批查询，而逐行兜底
+        // （_parseQuoteRows）根本还没轮到运行。
+        if (item is! Map) continue;
+        final quoteId = item['quote_id'];
+        final tagId = item['tag_id'];
+        if (quoteId is! String || tagId is! String) continue;
         tagsByQuoteId.putIfAbsent(quoteId, () => []).add(tagId);
       }
     }

--- a/lib/services/database/database_query_mixin.dart
+++ b/lib/services/database/database_query_mixin.dart
@@ -458,7 +458,7 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     }
 
     // Fetch tags for the retrieved quotes
-    final quoteIds = maps.map((m) => m['id'] as String).toList();
+    final quoteIds = maps.map((m) => m['id']).whereType<String>().toList();
 
     final tagsByQuoteId = <String, List<String>>{};
     final tagsStopwatch = Stopwatch()..start();
@@ -485,9 +485,12 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     for (final result in allTagMaps) {
       final tagMaps = result as List;
       for (final item in tagMaps) {
-        final tagMap = item as Map<String, dynamic>;
-        final quoteId = tagMap['quote_id'] as String;
-        final tagId = tagMap['tag_id'] as String;
+        // 关联表的值同样不能硬转：一个坏值抛出来会连累整批查询，而逐行兜底
+        // （_parseQuoteRows）根本还没轮到运行。
+        if (item is! Map) continue;
+        final quoteId = item['quote_id'];
+        final tagId = item['tag_id'];
+        if (quoteId is! String || tagId is! String) continue;
         tagsByQuoteId.putIfAbsent(quoteId, () => []).add(tagId);
       }
     }

--- a/lib/services/database/database_query_mixin.dart
+++ b/lib/services/database/database_query_mixin.dart
@@ -497,13 +497,7 @@ mixin _DatabaseQueryMixin on _DatabaseServiceBase {
     // 反序列化单独计时：一页 50 条带完整 delta_content，这一段是纯 UI 线程工作，
     // 和 SQL 等待完全不同性质，混在一起就分不出该优化哪一头。
     final parseStopwatch = Stopwatch()..start();
-    final quotes = maps.map((map) {
-      final quoteId = map['id'] as String;
-      final tags = tagsByQuoteId[quoteId] ?? [];
-      final mutableMap = Map<String, dynamic>.from(map);
-      mutableMap['tag_ids'] = tags.join(',');
-      return Quote.fromJson(mutableMap);
-    }).toList();
+    final quotes = _parseQuoteRows(maps, tagsByQuoteId: tagsByQuoteId);
     parseStopwatch.stop();
 
     NoteListLoadMoreProfile.recordQuery(

--- a/lib/services/database/database_quote_crud_mixin.dart
+++ b/lib/services/database/database_quote_crud_mixin.dart
@@ -144,7 +144,7 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
         'SELECT tag_id FROM quote_tags WHERE quote_id = ?',
         [id],
       );
-      final tags = tagMaps.map((t) => t['tag_id'] as String).toList();
+      final tags = tagMaps.map((t) => t['tag_id']).whereType<String>().toList();
 
       final mutableMap = Map<String, dynamic>.from(maps.first);
       mutableMap['tag_ids'] = tags.join(',');
@@ -215,7 +215,7 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
 
       final tagsByQuoteId = <String, List<String>>{};
 
-      final quoteIds = maps.map((m) => m['id'] as String).toList();
+      final quoteIds = maps.map((m) => m['id']).whereType<String>().toList();
       // ⚡ Bolt: 使用 batch 批量执行查询，减少数据库往返和 N+1 开销
       final batch = db.batch();
 
@@ -237,9 +237,12 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
       for (final result in allTagMaps) {
         final tagMaps = result as List;
         for (final item in tagMaps) {
-          final tagMap = item as Map<String, dynamic>;
-          final quoteId = tagMap['quote_id'] as String;
-          final tagId = tagMap['tag_id'] as String;
+          // 关联表的值同样不能硬转：一个坏值抛出来会连累整批查询，而逐行兜底
+          // （_parseQuoteRows）根本还没轮到运行。
+          if (item is! Map) continue;
+          final quoteId = item['quote_id'];
+          final tagId = item['tag_id'];
+          if (quoteId is! String || tagId is! String) continue;
           tagsByQuoteId.putIfAbsent(quoteId, () => []).add(tagId);
         }
       }
@@ -339,7 +342,7 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
 
       final tagsByQuoteId = <String, List<String>>{};
 
-      final quoteIds = maps.map((m) => m['id'] as String).toList();
+      final quoteIds = maps.map((m) => m['id']).whereType<String>().toList();
       // 使用 batch 批量执行查询
       final batch = db.batch();
 
@@ -361,9 +364,12 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
       for (final result in allTagMaps) {
         final tagMaps = result as List;
         for (final item in tagMaps) {
-          final tagMap = item as Map<String, dynamic>;
-          final quoteId = tagMap['quote_id'] as String;
-          final tagId = tagMap['tag_id'] as String;
+          // 关联表的值同样不能硬转：一个坏值抛出来会连累整批查询，而逐行兜底
+          // （_parseQuoteRows）根本还没轮到运行。
+          if (item is! Map) continue;
+          final quoteId = item['quote_id'];
+          final tagId = item['tag_id'];
+          if (quoteId is! String || tagId is! String) continue;
           tagsByQuoteId.putIfAbsent(quoteId, () => []).add(tagId);
         }
       }

--- a/lib/services/database/database_quote_crud_mixin.dart
+++ b/lib/services/database/database_quote_crud_mixin.dart
@@ -149,7 +149,7 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
       final mutableMap = Map<String, dynamic>.from(maps.first);
       mutableMap['tag_ids'] = tags.join(',');
 
-      return Quote.fromJson(mutableMap);
+      return _tryParseQuoteRow(mutableMap);
     } catch (e) {
       logDebug('获取指定ID笔记失败: $e');
       return null;
@@ -244,13 +244,7 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
         }
       }
 
-      return maps.map((map) {
-        final quoteId = map['id'] as String;
-        final tags = tagsByQuoteId[quoteId] ?? [];
-        final mutableMap = Map<String, dynamic>.from(map);
-        mutableMap['tag_ids'] = tags.join(',');
-        return Quote.fromJson(mutableMap);
-      }).toList();
+      return _parseQuoteRows(maps, tagsByQuoteId: tagsByQuoteId);
     } catch (e) {
       logDebug('获取所有笔记失败: $e');
       return [];
@@ -374,13 +368,7 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
         }
       }
 
-      return maps.map((map) {
-        final quoteId = map['id'] as String;
-        final tags = tagsByQuoteId[quoteId] ?? [];
-        final mutableMap = Map<String, dynamic>.from(map);
-        mutableMap['tag_ids'] = tags.join(',');
-        return Quote.fromJson(mutableMap);
-      }).toList();
+      return _parseQuoteRows(maps, tagsByQuoteId: tagsByQuoteId);
     } catch (e, stackTrace) {
       logError(
         '获取周期内笔记失败',
@@ -578,7 +566,7 @@ mixin _DatabaseQuoteCrudMixin on _DatabaseServiceBase {
       whereArgs: ['%$query%'],
     );
 
-    return results.map((map) => Quote.fromJson(map)).toList();
+    return _parseQuoteRows(results);
   }
 
   /// 修复：更新笔记内容，增加数据验证和并发控制

--- a/lib/services/database/database_trash_mixin.dart
+++ b/lib/services/database/database_trash_mixin.dart
@@ -152,13 +152,7 @@ mixin _DatabaseTrashMixin on _DatabaseServiceBase {
       }
     }
 
-    return maps.map((map) {
-      final quoteId = map['id'] as String;
-      final tags = tagsByQuoteId[quoteId] ?? [];
-      final mutableMap = Map<String, dynamic>.from(map);
-      mutableMap['tag_ids'] = tags.join(',');
-      return Quote.fromJson(mutableMap);
-    }).toList();
+    return _parseQuoteRows(maps, tagsByQuoteId: tagsByQuoteId);
   }
 
   @override

--- a/lib/services/database/database_trash_mixin.dart
+++ b/lib/services/database/database_trash_mixin.dart
@@ -119,7 +119,7 @@ mixin _DatabaseTrashMixin on _DatabaseServiceBase {
 
     if (maps.isEmpty) return [];
 
-    final quoteIds = maps.map((m) => m['id'] as String).toList();
+    final quoteIds = maps.map((m) => m['id']).whereType<String>().toList();
 
     final tagsByQuoteId = <String, List<String>>{};
 
@@ -145,9 +145,12 @@ mixin _DatabaseTrashMixin on _DatabaseServiceBase {
     for (final result in allTagMaps) {
       final tagMaps = result as List;
       for (final item in tagMaps) {
-        final tagMap = item as Map<String, dynamic>;
-        final quoteId = tagMap['quote_id'] as String;
-        final tagId = tagMap['tag_id'] as String;
+        // 关联表的值同样不能硬转：一个坏值抛出来会连累整批查询，而逐行兜底
+        // （_parseQuoteRows）根本还没轮到运行。
+        if (item is! Map) continue;
+        final quoteId = item['quote_id'];
+        final tagId = item['tag_id'];
+        if (quoteId is! String || tagId is! String) continue;
         tagsByQuoteId.putIfAbsent(quoteId, () => []).add(tagId);
       }
     }

--- a/lib/services/database/quote_row_parser.dart
+++ b/lib/services/database/quote_row_parser.dart
@@ -29,7 +29,11 @@ List<Quote> _parseQuoteRows(
     try {
       quote = _tryParseQuoteRow(map, tagsByQuoteId: tagsByQuoteId);
     } catch (e) {
-      firstReason ??= _logSafeText(e.toString());
+      // 只记异常**类型**，绝不记 e.toString()：Quote.fromJson 的兜底分支抛的是
+      // `FormatException('解析Quote JSON失败: $e, JSON: $json')`，那个 $json 是
+      // 整行数据——content 和 delta_content 都在里面。把它写进日志等于把用户的
+      // 笔记正文抄进日志库，截断也只是少抄一点。
+      firstReason ??= e.runtimeType.toString();
       quote = null;
     }
 
@@ -66,14 +70,18 @@ Quote? _tryParseQuoteRow(
   Map<String, Object?> map, {
   Map<String, List<String>>? tagsByQuoteId,
 }) {
-  if (tagsByQuoteId == null) {
-    return Quote.fromJson(Map<String, dynamic>.from(map));
-  }
-  // id 缺失或不是字符串时不能硬转，那本身就是一行坏数据。
+  // id 的类型检查对**所有**路径生效：不带标签那一路（按内容搜索、智能推送、
+  // 收藏列表）原来直接进 fromJson，而 fromJson 对 id 用的是 `?.toString()`——
+  // 一个 BLOB id 不会抛异常，会被转成一串没意义的字符，坏行就这么混进结果里了。
   final quoteId = map['id'];
   if (quoteId is! String) {
     return null;
   }
+
+  if (tagsByQuoteId == null) {
+    return Quote.fromJson(Map<String, dynamic>.from(map));
+  }
+
   final mutableMap = Map<String, dynamic>.from(map);
   mutableMap['tag_ids'] = (tagsByQuoteId[quoteId] ?? const <String>[]).join(
     ',',
@@ -83,15 +91,6 @@ Quote? _tryParseQuoteRow(
 
 /// 汇总日志里最多列几个行 id。
 const int _skippedPreviewLimit = 10;
-
-/// 异常文本的日志安全形式：去控制字符 + 限长（里面会带上原始的非法字段值）。
-String _logSafeText(String text) {
-  const maxLength = 120;
-  final cleaned = text.replaceAll(RegExp(r'[\x00-\x1F\x7F]'), ' ').trim();
-  return cleaned.length > maxLength
-      ? '${cleaned.substring(0, maxLength)}…'
-      : cleaned;
-}
 
 /// 行 id 的日志安全形式：id 也可能来自外来数据，限长并去掉控制字符。
 String _shortRowId(Object? id) {

--- a/lib/services/database/quote_row_parser.dart
+++ b/lib/services/database/quote_row_parser.dart
@@ -18,22 +18,39 @@ List<Quote> _parseQuoteRows(
   Map<String, List<String>>? tagsByQuoteId,
 }) {
   final quotes = <Quote>[];
-  final skipped = <String>[];
+  // 只留固定长度的预览 + 计数：一批全是坏行时，逐行打日志会把「限量」这件事本身
+  // 架空，异常文本里还带着原始的非法字段值。
+  final skippedPreview = <String>[];
+  var skippedCount = 0;
+  String? firstReason;
 
   for (final map in maps) {
-    final quote = _tryParseQuoteRow(map, tagsByQuoteId: tagsByQuoteId);
+    Quote? quote;
+    try {
+      quote = _tryParseQuoteRow(map, tagsByQuoteId: tagsByQuoteId);
+    } catch (e) {
+      firstReason ??= _logSafeText(e.toString());
+      quote = null;
+    }
+
     if (quote != null) {
       quotes.add(quote);
-    } else {
-      skipped.add(_shortRowId(map['id']));
+      continue;
+    }
+
+    skippedCount++;
+    if (skippedPreview.length < _skippedPreviewLimit) {
+      skippedPreview.add(_shortRowId(map['id']));
     }
   }
 
-  if (skipped.isNotEmpty) {
+  if (skippedCount > 0) {
+    final omitted = skippedCount - skippedPreview.length;
     logWarning(
-      '跳过 ${skipped.length} 条无法解析的笔记（数据不符合本应用的字段要求）: '
-      '${skipped.take(10).join(', ')}'
-      '${skipped.length > 10 ? ' …另有 ${skipped.length - 10} 条' : ''}',
+      '跳过 $skippedCount 条无法解析的笔记（数据不符合本应用的字段要求）: '
+      '${skippedPreview.join(', ')}'
+      '${omitted > 0 ? ' …另有 $omitted 条' : ''}'
+      '${firstReason != null ? '；首个原因: $firstReason' : ''}',
       source: 'QuoteRowParser',
     );
   }
@@ -41,29 +58,39 @@ List<Quote> _parseQuoteRows(
   return quotes;
 }
 
-/// 单行反序列化；失败返回 null 由调用方决定怎么处理。
+/// 单行反序列化；解析不了就抛给调用方，由 [_parseQuoteRows] 统一计数和记录。
+///
+/// 这里**不打日志**：一行一条的话，几千行坏数据就能把日志刷爆，而异常文本里还带着
+/// 原始的非法字段值。原因只在汇总那一条里报一次。
 Quote? _tryParseQuoteRow(
   Map<String, Object?> map, {
   Map<String, List<String>>? tagsByQuoteId,
 }) {
-  try {
-    if (tagsByQuoteId == null) {
-      return Quote.fromJson(Map<String, dynamic>.from(map));
-    }
-    // id 缺失或不是字符串时不能硬转，那本身就是一行坏数据。
-    final quoteId = map['id'];
-    if (quoteId is! String) {
-      return null;
-    }
-    final mutableMap = Map<String, dynamic>.from(map);
-    mutableMap['tag_ids'] = (tagsByQuoteId[quoteId] ?? const <String>[]).join(
-      ',',
-    );
-    return Quote.fromJson(mutableMap);
-  } catch (e) {
-    logDebug('笔记行解析失败，已跳过: $e', source: 'QuoteRowParser');
+  if (tagsByQuoteId == null) {
+    return Quote.fromJson(Map<String, dynamic>.from(map));
+  }
+  // id 缺失或不是字符串时不能硬转，那本身就是一行坏数据。
+  final quoteId = map['id'];
+  if (quoteId is! String) {
     return null;
   }
+  final mutableMap = Map<String, dynamic>.from(map);
+  mutableMap['tag_ids'] = (tagsByQuoteId[quoteId] ?? const <String>[]).join(
+    ',',
+  );
+  return Quote.fromJson(mutableMap);
+}
+
+/// 汇总日志里最多列几个行 id。
+const int _skippedPreviewLimit = 10;
+
+/// 异常文本的日志安全形式：去控制字符 + 限长（里面会带上原始的非法字段值）。
+String _logSafeText(String text) {
+  const maxLength = 120;
+  final cleaned = text.replaceAll(RegExp(r'[\x00-\x1F\x7F]'), ' ').trim();
+  return cleaned.length > maxLength
+      ? '${cleaned.substring(0, maxLength)}…'
+      : cleaned;
 }
 
 /// 行 id 的日志安全形式：id 也可能来自外来数据，限长并去掉控制字符。

--- a/lib/services/database/quote_row_parser.dart
+++ b/lib/services/database/quote_row_parser.dart
@@ -1,0 +1,76 @@
+part of '../database_service.dart';
+
+/// quotes 行 → [Quote] 的统一反序列化入口，**坏行跳过而不是让整批查询失败**。
+///
+/// [Quote.fromJson] 对正文为空、日期不可解析、颜色格式不对的行会抛异常。原来七处
+/// 读取都是 `maps.map((m) => Quote.fromJson(m))` 裸调用，一条坏行就能让**整页笔记
+/// 加载失败**——用户看到的不是「有一条笔记怪怪的」，而是列表整个打不开，且没有任何
+/// 途径能自己修好。
+///
+/// 坏行从哪来：早期版本的导入不做值域收敛（现已在导入边界补上），以及任何绕过导入
+/// 直接落库的路径。库里已经存在的行，光靠修导入是清不掉的。
+///
+/// 兜底只做「跳过 + 告警」，不做修复：能修的（越界 `sentiment`）由启动迁移
+/// `repairOutOfDomainSentiment` 负责，那里会先快照原值；这里悄悄改数据反而会把问题
+/// 藏起来。
+List<Quote> _parseQuoteRows(
+  List<Map<String, Object?>> maps, {
+  Map<String, List<String>>? tagsByQuoteId,
+}) {
+  final quotes = <Quote>[];
+  final skipped = <String>[];
+
+  for (final map in maps) {
+    final quote = _tryParseQuoteRow(map, tagsByQuoteId: tagsByQuoteId);
+    if (quote != null) {
+      quotes.add(quote);
+    } else {
+      skipped.add(_shortRowId(map['id']));
+    }
+  }
+
+  if (skipped.isNotEmpty) {
+    logWarning(
+      '跳过 ${skipped.length} 条无法解析的笔记（数据不符合本应用的字段要求）: '
+      '${skipped.take(10).join(', ')}'
+      '${skipped.length > 10 ? ' …另有 ${skipped.length - 10} 条' : ''}',
+      source: 'QuoteRowParser',
+    );
+  }
+
+  return quotes;
+}
+
+/// 单行反序列化；失败返回 null 由调用方决定怎么处理。
+Quote? _tryParseQuoteRow(
+  Map<String, Object?> map, {
+  Map<String, List<String>>? tagsByQuoteId,
+}) {
+  try {
+    if (tagsByQuoteId == null) {
+      return Quote.fromJson(Map<String, dynamic>.from(map));
+    }
+    // id 缺失或不是字符串时不能硬转，那本身就是一行坏数据。
+    final quoteId = map['id'];
+    if (quoteId is! String) {
+      return null;
+    }
+    final mutableMap = Map<String, dynamic>.from(map);
+    mutableMap['tag_ids'] = (tagsByQuoteId[quoteId] ?? const <String>[]).join(
+      ',',
+    );
+    return Quote.fromJson(mutableMap);
+  } catch (e) {
+    logDebug('笔记行解析失败，已跳过: $e', source: 'QuoteRowParser');
+    return null;
+  }
+}
+
+/// 行 id 的日志安全形式：id 也可能来自外来数据，限长并去掉控制字符。
+String _shortRowId(Object? id) {
+  const maxLength = 40;
+  final text = (id?.toString() ?? '<无 id>')
+      .replaceAll(RegExp(r'[\x00-\x1F\x7F]'), ' ')
+      .trim();
+  return text.length > maxLength ? '${text.substring(0, maxLength)}…' : text;
+}

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -32,6 +32,7 @@ import 'data_directory_service.dart';
 import '../utils/note_list_load_more_profile.dart';
 
 part 'database/database_cache_mixin.dart';
+part 'database/quote_row_parser.dart';
 part 'database/database_query_mixin.dart';
 part 'database/database_query_helpers_mixin.dart';
 part 'database/database_quote_crud_mixin.dart';

--- a/test/unit/services/quote_row_parser_test.dart
+++ b/test/unit/services/quote_row_parser_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:thoughtecho/services/database_service.dart';
+
+import '../../test_harness.dart';
+
+/// 一条读不出来的坏行，不能连累整批查询。
+///
+/// `Quote.fromJson` 对正文为空、日期不可解析的行会抛异常。原来七处读取都是裸调用
+/// `maps.map((m) => Quote.fromJson(m))`，一条坏行就能让**整页笔记加载失败**——用户
+/// 看到的不是「有一条笔记怪怪的」，而是列表整个打不开。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  late DatabaseService service;
+  late Database db;
+
+  setUp(() async {
+    await TestHarness.initialize();
+    DatabaseService.clearTestDatabase();
+    service = DatabaseService();
+
+    db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+    await _createQuoteTables(db);
+
+    DatabaseService.setTestDatabase(db);
+    await service.init();
+  });
+
+  tearDown(() async {
+    DatabaseService.clearTestDatabase();
+    await db.close();
+  });
+
+  Future<void> insertRow(String id, String content, String date) async {
+    await db.insert('quotes', {
+      'id': id,
+      'content': content,
+      'date': date,
+      'last_modified': '2026-08-22T17:40:00.000Z',
+    });
+  }
+
+  test('正文为空的坏行被跳过，同批的好笔记照常返回', () async {
+    await insertRow('good-1', '正常的笔记', '2026-08-22T17:40:00.000Z');
+    await insertRow('bad-empty', '', '2026-08-21T17:40:00.000Z');
+    await insertRow('good-2', '另一条正常的笔记', '2026-08-20T17:40:00.000Z');
+
+    final quotes = await service.getUserQuotes();
+
+    expect(
+      quotes.map((q) => q.id),
+      containsAll(<String>['good-1', 'good-2']),
+    );
+    expect(quotes.map((q) => q.id), isNot(contains('bad-empty')));
+  });
+
+  test('日期无法解析的坏行同样只丢自己', () async {
+    await insertRow('good-1', '正常的笔记', '2026-08-22T17:40:00.000Z');
+    await insertRow('bad-date', '日期是坏的', '不是日期');
+
+    final quotes = await service.getUserQuotes();
+
+    expect(quotes.map((q) => q.id), contains('good-1'));
+    expect(quotes.map((q) => q.id), isNot(contains('bad-date')));
+  });
+
+  test('整批都是坏行时返回空列表而不是抛异常', () async {
+    await insertRow('bad-1', '', '2026-08-22T17:40:00.000Z');
+    await insertRow('bad-2', '坏日期', '不是日期');
+
+    // 关键是「不抛」：抛出去的话调用方拿不到任何数据，列表整个打不开。
+    expect(await service.getUserQuotes(), isEmpty);
+  });
+
+  test('按内容搜索也走同一个兜底', () async {
+    await insertRow('good-1', '找得到的笔记', '2026-08-22T17:40:00.000Z');
+    await insertRow('bad-date', '找得到的笔记但日期坏了', '不是日期');
+
+    final results = await service.searchQuotesByContent('找得到的笔记');
+
+    expect(results.map((q) => q.id), contains('good-1'));
+    expect(results.map((q) => q.id), isNot(contains('bad-date')));
+  });
+}
+
+Future<void> _createQuoteTables(Database db) async {
+  await db.execute('''
+      CREATE TABLE quotes(
+        id TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        date TEXT NOT NULL,
+        source TEXT,
+        source_author TEXT,
+        source_work TEXT,
+        ai_analysis TEXT,
+        sentiment TEXT,
+        keywords TEXT,
+        summary TEXT,
+        category_id TEXT DEFAULT '',
+        color_hex TEXT,
+        location TEXT,
+        latitude REAL,
+        longitude REAL,
+        poi_name TEXT,
+        weather TEXT,
+        temperature TEXT,
+        edit_source TEXT,
+        delta_content TEXT,
+        day_period TEXT,
+        last_modified TEXT,
+        favorite_count INTEGER DEFAULT 0,
+        is_deleted INTEGER DEFAULT 0,
+        deleted_at TEXT
+      )
+    ''');
+  await db.execute('''
+      CREATE TABLE quote_tags (
+        quote_id TEXT NOT NULL,
+        tag_id TEXT NOT NULL,
+        PRIMARY KEY (quote_id, tag_id)
+      )
+    ''');
+  await db.execute('''
+      CREATE TABLE categories(
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        is_default INTEGER DEFAULT 0,
+        icon_name TEXT,
+        last_modified TEXT
+      )
+    ''');
+  await db.execute('''
+      CREATE TABLE quote_tombstones(
+        quote_id TEXT PRIMARY KEY,
+        deleted_at TEXT
+      )
+    ''');
+}

--- a/test/unit/services/quote_row_parser_test.dart
+++ b/test/unit/services/quote_row_parser_test.dart
@@ -75,6 +75,43 @@ void main() {
     expect(await service.getUserQuotes(), isEmpty);
   });
 
+  test('id 是 BLOB 的行也只丢自己：预处理阶段的强转不能绕过逐行兜底', () async {
+    // 构建 quoteIds / 标签映射那几步原来硬转 `as String`，会在 _parseQuoteRows
+    // 还没轮到之前就抛出来，把整批查询带走。
+    //
+    // 必须用 BLOB 才复现得了：TEXT 列有 TEXT 亲和性，塞进去的整数会被 SQLite 转成
+    // 字符串读回来，只有 BLOB 原样保留（读出来是 Uint8List）。
+    await insertRow('good-1', '正常的笔记', '2026-08-22T17:40:00.000Z');
+    await db.rawInsert(
+      "INSERT INTO quotes (id, content, date, last_modified) "
+      "VALUES (x'DEADBEEF', ?, ?, ?)",
+      [
+        '这一行的 id 是 BLOB',
+        '2026-08-21T17:40:00.000Z',
+        '2026-08-21T17:40:00.000Z',
+      ],
+    );
+
+    final quotes = await service.getUserQuotes();
+
+    expect(quotes.map((q) => q.id), contains('good-1'));
+  });
+
+  test('关联表里的坏 tag_id 同样不能带走整批查询', () async {
+    // 坏的 quote_id 会被 `IN (...)` 直接筛掉，真正能进到映射构建里的是「quote_id
+    // 正常、tag_id 是 BLOB」这种行——原来那句 `tagMap['tag_id'] as String` 会在
+    // 这里抛出来。
+    await insertRow('good-1', '正常的笔记', '2026-08-22T17:40:00.000Z');
+    await db.rawInsert(
+      "INSERT INTO quote_tags (quote_id, tag_id) VALUES (?, x'DEADBEEF')",
+      ['good-1'],
+    );
+
+    final quotes = await service.getUserQuotes();
+
+    expect(quotes.map((q) => q.id), contains('good-1'));
+  });
+
   test('按内容搜索也走同一个兜底', () async {
     await insertRow('good-1', '找得到的笔记', '2026-08-22T17:40:00.000Z');
     await insertRow('bad-date', '找得到的笔记但日期坏了', '不是日期');

--- a/test/unit/services/quote_row_parser_test.dart
+++ b/test/unit/services/quote_row_parser_test.dart
@@ -21,6 +21,9 @@ void main() {
     await TestHarness.initialize();
     DatabaseService.clearTestDatabase();
     service = DatabaseService();
+    // DatabaseService 是单例，_isInitialized 会跨用例留下来，后面的 init() 就成了
+    // 空操作，而 db 每个用例都是新的内存库。reinitialize() 把这层状态清干净。
+    service.reinitialize();
 
     db = await databaseFactory.openDatabase(inMemoryDatabasePath);
     await _createQuoteTables(db);
@@ -32,6 +35,7 @@ void main() {
   tearDown(() async {
     DatabaseService.clearTestDatabase();
     await db.close();
+    service.reinitialize();
   });
 
   Future<void> insertRow(String id, String content, String date) async {
@@ -110,6 +114,26 @@ void main() {
     final quotes = await service.getUserQuotes();
 
     expect(quotes.map((q) => q.id), contains('good-1'));
+  });
+
+  test('不带标签那一路也过 id 类型检查：BLOB id 不能被转成一串乱码混进结果', () async {
+    // fromJson 对 id 用的是 `?.toString()`，BLOB 不会抛异常，会被转成没意义的
+    // 字符串——那一行不是「解析失败」，而是悄悄带着假 id 进了结果。
+    await insertRow('good-1', '找得到的笔记', '2026-08-22T17:40:00.000Z');
+    await db.rawInsert(
+      "INSERT INTO quotes (id, content, date, last_modified) "
+      "VALUES (x'DEADBEEF', ?, ?, ?)",
+      [
+        '找得到的笔记但 id 是 BLOB',
+        '2026-08-21T17:40:00.000Z',
+        '2026-08-21T17:40:00.000Z'
+      ],
+    );
+
+    // searchQuotesByContent 走的是不带 tagsByQuoteId 的那条路径。
+    final results = await service.searchQuotesByContent('找得到的笔记');
+
+    expect(results.map((q) => q.id), ['good-1']);
   });
 
   test('按内容搜索也走同一个兜底', () async {


### PR DESCRIPTION
#532 在**导入口**堵住了坏数据。这个 PR 处理它的系统版：**读路径没有任何逐行兜底**，所以库里已经存在的坏行照样能把整个列表干掉。两者互不依赖，可以独立合入。

## 问题

`Quote.fromJson` 对正文为空、日期不可解析、颜色格式不对的行会抛异常。七处读取里有五处是裸调用：

```dart
return maps.map((m) => Quote.fromJson(m)).toList();
```

异常直接穿透到调用方。后果不是「有条笔记怪怪的」，而是**笔记列表整个打不开**，而且用户没有任何途径能自己修好——那条坏行会一直在那儿。

坏行从哪来：早期版本的导入不做值域收敛（#532 已在导入边界补上），以及任何绕过导入直接落库的路径。**已经躺在库里的行，光靠修导入是清不掉的。**

## 改动

抽出 `_parseQuoteRows` / `_tryParseQuoteRow` 作为统一入口，坏行跳过并告警。

这不是新发明的写法——`_directGetQuotes` 里**本来就手写了一份逐行 try/catch**，只是没人把它推广到另外六处。同时那段「建 `mutableMap` + 拼 `tag_ids` + `fromJson`」的四行代码原样重复了四次，一并收口。

日志按 #532 的口径处理：限量（前 10 条）、限长（40 字符）、去控制字符——行 id 同样可能来自外来数据。

**兜底只做跳过和告警，不做修复。** 能修的（越界 `sentiment`）由启动迁移 `repairOutOfDomainSentiment` 负责，那里会先把原值快照到 `sentiment_backup`；在读路径上悄悄改数据只会把问题藏起来，这一点和 #532 里「`fromJson` 坚持不收敛」是同一条原则。

`database_trash_mixin` 提取媒体路径那处**保持原样**：它自己的 try/catch 有不同语义（记录失败但继续硬删流程），不属于这次收口的范围。

## 验证

Flutter 3.47.1 stable（与 CI 所钉版本一致）：

- `flutter analyze --no-fatal-infos lib/ test/unit/services` → 干净（余下 2 条 `cacheExtent` deprecation info 在未改动文件中，改动前就有）。
- `flutter test test/unit/services` → 686 passed。3 个文件加载失败（`smart_push_*`），**与本次改动无关**：flutter_quill 11.5.0 与该 Flutter 版本不兼容，编译错误在包内部。
- 数据库相关套件（`database_pagination` / `database_service` / `database_trash_flow` / `database_multi_tag_filter` / `database_optimization` / `quote_model` / `favorite_count_persistence`）→ 72 passed。
- `dart format` 对全部改动文件无变更。

新增 `test/unit/services/quote_row_parser_test.dart`，覆盖空正文、坏日期、整批皆坏、按内容搜索四种情况。**已用 `git stash` 确认其中三条在改动前会失败**；第四条在改动前就通过，因为它走的正是原来唯一有兜底的 `_directGetQuotes`——这条留着，用来钉住那个已有行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NLofg3wKNogeiWrbnCGY8

---
_Generated by [Claude Code](https://claude.ai/code/session_011NLofg3wKNogeiWrbnCGY8)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复数据库读取路径：一条坏行（正文为空、日期不可解析、`id` 或关联表值类型异常）不再连累整页笔记加载——坏行被跳过并告警，好笔记照常返回。

- 抽出 `_parseQuoteRows` / `_tryParseQuoteRow` 作为读取路径统一反序列化入口，收拢四处重复的「建 `mutableMap` + 拼 `tag_ids` + `fromJson`」代码。
- 预处理阶段的硬转（`as String`）会在逐行兜底运行之前先抛异常，已改为 `whereType<String>()` / 逐项判类型跳过。
- 兜底只做跳过和告警，不做修复；越界 `sentiment` 仍由启动迁移 `repairOutOfDomainSentiment` 处理。
- `database_trash_mixin` 提取媒体路径保持原样：那里的 try/catch 语义不同（记录失败但继续硬删流程）。
- `id` 类型检查对所有解析路径生效——不带标签那一路（按内容搜索、智能推送、收藏列表）原来会把 BLOB `id` 转成乱码混进结果，现在直接跳过。
- 跳过日志只汇总一条：限 10 个行 id（去控制字符、限 40 字符），仅记首个异常类型。`Quote.fromJson` 的异常文本带整行 JSON（含笔记正文），一个字都不进日志。
- 新增测试覆盖空正文、坏日期、整批皆坏、按内容搜索、BLOB `id`、坏 `tag_id` 六种情况。

<sup>Written for commit 7a10ef6edbdb2e55dc881d52a6b64e1802f91058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Sourcery 摘要

使数据库笔记读取能够适应格式错误的持久化行，同时不修改底层数据。

错误修复：
- 通过跳过无效行并继续返回有效笔记，防止格式错误的数据库行导致整个笔记列表或内容搜索失败。

增强功能：
- 在数据库读取路径中集中处理笔记行解析，并使用有界且经过清理的警告，同时保留现有的不修改数据的回退行为。

测试：
- 增加数据库服务测试覆盖：空内容、无效日期、仅包含格式错误行的批次，以及包含无效行的内容搜索。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使数据库笔记读取能够抵御格式错误的持久化数据行，而不修改底层数据。

错误修复：
- 通过跳过无效数据行并继续处理有效结果，防止格式错误的持久化笔记行导致整个笔记列表、批量查询或内容搜索失败。

改进：
- 在数据库读取路径之间集中处理笔记行解析，并使用有界、经过清理的警告日志，同时保留不修改无效数据的策略。
- 强化相关标签和笔记 ID 的处理，避免格式错误的关联值中止批量读取。

测试：
- 为数据库服务增加覆盖测试，包括空内容、无效日期、无效 ID 和标签、全部无效的批次，以及包含格式错误数据行的内容搜索。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

增强数据库笔记读取对格式错误的持久化数据行的容错能力，同时保留有效结果，并保持无效数据不变。

错误修复：
- 防止格式错误的持久化笔记数据行导致整个数据库列表、批量查询或内容搜索失败：跳过无效数据行，同时保留有效结果。

改进：
- 在各数据库读取路径中统一笔记数据行解析逻辑，使用有界且经过清理的警告日志，并以容错方式处理格式错误的 ID 和标签关系，而不修改已存储的数据。

测试：
- 增加数据库服务测试覆盖：空内容、无效日期、格式错误的 ID 和标签、全部无效的批次，以及包含无效数据行的搜索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make database note reads resilient to malformed persisted rows while preserving valid results and leaving invalid data unchanged.

Bug Fixes:
- Prevent malformed persisted note rows from causing entire database lists, batch queries, or content searches to fail by skipping invalid rows while retaining valid results.

Enhancements:
- Centralize note-row parsing across database read paths with bounded, sanitized warning logs and tolerant handling of malformed IDs and tag relationships without modifying stored data.

Tests:
- Add database service coverage for empty content, invalid dates, malformed IDs and tags, all-invalid batches, and searches containing invalid rows.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 优化笔记数据读取与搜索结果处理，遇到格式异常或损坏的数据时会跳过无效记录，避免影响其他正常内容。
  - 改进标签及已删除笔记的加载稳定性，减少因单条异常数据导致整批查询失败的情况。
  - 完善异常记录与安全提示，便于问题排查。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->