### PR TITLE
test: 钉住迁移顺序——遗留列清理必须排在建快照列的迁移之前

### DIFF
--- a/test/unit/services/database_schema_lifecycle_test.dart
+++ b/test/unit/services/database_schema_lifecycle_test.dart
@@ -216,6 +216,41 @@ void main() {
       );
       expect(marker, isEmpty);
     });
+
+    test('遗留列清理排在建快照列的迁移之前，快照不会被表重建抹掉', () async {
+      // performAllDataMigrations 是真实入口。它里面 cleanupLegacyTagIdsColumn 会靠
+      // **重建 quotes 表**来去掉遗留的 tag_ids 列，而重建用的是写死的列清单，不含任何
+      // *_backup 列。所以只要它排在 repairOutOfDomainSentiment 后面，前脚存下的原值
+      // 后脚就被整张表抹掉——修复变成了不可逆的删除。
+      final manager = DatabaseSchemaManager();
+      await manager.createTables(database);
+
+      // 造一个还带着遗留 tag_ids 列的库，触发那次表重建。
+      await database.execute('ALTER TABLE quotes ADD COLUMN tag_ids TEXT');
+      await database.insert('quotes', {
+        'id': 'demo-quote-zh-001',
+        'content': '我常以为是丑女造就了美人。',
+        'date': '2026-08-22T17:40:00.000Z',
+        'sentiment': 'thoughtful', // 不在词汇表里，会被修复置空
+      });
+
+      await manager.performAllDataMigrations(database);
+
+      final columns = (await database.rawQuery('PRAGMA table_info(quotes)'))
+          .map((column) => column['name'] as String)
+          .toSet();
+      expect(columns, isNot(contains('tag_ids')), reason: '遗留列清理应当执行过');
+      expect(columns, contains('sentiment_backup'), reason: '快照列不能被表重建抹掉');
+
+      final row = (await database.query(
+        'quotes',
+        where: 'id = ?',
+        whereArgs: ['demo-quote-zh-001'],
+      ))
+          .first;
+      expect(row['sentiment'], isNull);
+      expect(row['sentiment_backup'], 'thoughtful');
+    });
   });
 }
 


### PR DESCRIPTION
补 #532 留下的一个测试口子。**只加测试，不改代码。**

## 缺的是什么

#532 修了迁移顺序：把 `cleanupLegacyTagIdsColumn` 提到所有会建 `*_backup` 快照列的迁移**之前**。但当时的测试只覆盖了 `repairOutOfDomainSentiment` 本身，**没有测 `performAllDataMigrations` 这条真实链路上的先后** —— 而它会在每个用户启动时跑。

顺序错了的后果不是小问题：`cleanupLegacyTagIdsColumn` 靠**重建 `quotes` 表**去掉遗留的 `tag_ids` 列，而 `_removeTagIdsColumn` 重建时用的是写死的列清单，里面不含任何 `*_backup` 列。只要它排在修复后面，前脚存下的原值后脚就被整张表抹掉——**「修复」变成不可逆的删除**，而且 `weather_backup`、`day_period_backup` 会一并遭殃。

## 这个用例

走真实入口 `DatabaseSchemaManager.performAllDataMigrations`，而不是直接调修复方法：

1. `createTables` 建当前 schema，再 `ALTER TABLE quotes ADD COLUMN tag_ids TEXT` 造出一个还带遗留列的库 —— 这是触发那次表重建的必要条件；
2. 插一条 `sentiment: 'thoughtful'`（词汇表外，会被修复置空）的笔记；
3. 跑迁移，断言三件事：`tag_ids` 已消失（清理确实执行过）、`sentiment_backup` 列仍在、原值 `'thoughtful'` 完整保留。

放在 `database_schema_lifecycle_test.dart` 而不是新开文件：它测的正是 lifecycle 入口，和该文件既有的 `createTables` / `validateSchema` / 版本升级用例是同一层。

## 验证

把 `run()` 里的顺序临时改回修复前的样子重跑，用例失败在：

```
Expected: contains 'sentiment_backup'
  Actual: Set:[...]   // 快照列整个不见了
  快照列不能被表重建抹掉
```

正是要防的那件事，不是断言写宽了碰巧过。改回正确顺序后通过。

同时跑过 `database_schema_lifecycle` / `database_schema_manager_poi_name` / `database_backup_merge` / `database_service` 四个套件共 30 条，全绿；`dart format --set-exit-if-changed .` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NLofg3wKNogeiWrbnCGY8

---
_Generated by [Claude Code](https://claude.ai/code/session_011NLofg3wKNogeiWrbnCGY8)_

## Sourcery 总结

测试：
- 添加端到端生命周期迁移测试，确保旧列清理先于快照列迁移执行，并保留修复后的值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Add an end-to-end lifecycle migration test ensuring legacy column cleanup precedes snapshot-column migrations and preserves repaired values.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
# 补上 #532 迁移顺序修复的测试覆盖，只加测试不改代码

新增一个测试，走真实入口 `performAllDataMigrations` 验证 `cleanupLegacyTagIdsColumn` 必须排在建快照列的迁移之前，否则重建 `quotes` 表会抹掉刚写入的备份列和原值。

<sup>Written for commit 2b4af4a72bd7a7589ae54026939bbc3daf776777. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

