### PR TITLE
feat(map): 补齐地图选点与地图回忆（重写 #247 的地图产品线）

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4291,6 +4291,45 @@
   "mapPickerConfirm": "Confirm Location",
   "poiNameLabel": "Place Name",
   "longPressForMapPicker": "Long press to open map picker",
+  "mapPickerSearchHint": "Search nearby places",
+  "mapPickerSearchResults": "Search results",
+  "mapPickerSearching": "Searching…",
+  "mapPickerNoResults": "No matching places found",
+  "mapPickerSelectedPoint": "Selected point",
+  "mapPickerResolvingPoint": "Identifying this place…",
+  "mapPickerUnnamedPoint": "Unnamed place",
+  "mapPickerLocateMe": "Back to my location",
+  "mapPickerCurrentLocationSubtitle": "Records the city and district only, not a specific place",
+  "mapPickerDistanceMeters": "{distance} m",
+  "@mapPickerDistanceMeters": {
+    "description": "Distance in metres between a search result and the selected point",
+    "placeholders": {
+      "distance": {
+        "type": "String"
+      }
+    }
+  },
+  "mapPickerDistanceKilometers": "{distance} km",
+  "@mapPickerDistanceKilometers": {
+    "description": "Distance in kilometres between a search result and the selected point",
+    "placeholders": {
+      "distance": {
+        "type": "String"
+      }
+    }
+  },
+  "mapMemoryEmptyHint": "No notes with a location yet. Long press the location button in the editor to tag a note with a place.",
+  "mapMemoryLoadFailed": "Failed to load map data",
+  "mapMemoryResetView": "Show all places",
+  "mapMemoryPlaceCount": "{count} notes with a location",
+  "@mapMemoryPlaceCount": {
+    "description": "Number of notes with coordinates shown on the map memory page",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "attachFile": "Attach file",
   "yesterday": "Yesterday",
   "openInEditor": "Open in Editor",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -4291,6 +4291,45 @@
   "mapPickerConfirm": "确认位置",
   "poiNameLabel": "地点名称",
   "longPressForMapPicker": "长按打开地图选点",
+  "mapPickerSearchHint": "搜索附近地点",
+  "mapPickerSearchResults": "搜索结果",
+  "mapPickerSearching": "正在搜索…",
+  "mapPickerNoResults": "没有找到相关地点",
+  "mapPickerSelectedPoint": "地图上的选点",
+  "mapPickerResolvingPoint": "正在识别这个位置…",
+  "mapPickerUnnamedPoint": "未命名的地点",
+  "mapPickerLocateMe": "回到当前位置",
+  "mapPickerCurrentLocationSubtitle": "只记城市和区县，不记具体地点",
+  "mapPickerDistanceMeters": "{distance} 米",
+  "@mapPickerDistanceMeters": {
+    "description": "地图选点页搜索结果与选点之间的距离（米）",
+    "placeholders": {
+      "distance": {
+        "type": "String"
+      }
+    }
+  },
+  "mapPickerDistanceKilometers": "{distance} 公里",
+  "@mapPickerDistanceKilometers": {
+    "description": "地图选点页搜索结果与选点之间的距离（公里）",
+    "placeholders": {
+      "distance": {
+        "type": "String"
+      }
+    }
+  },
+  "mapMemoryEmptyHint": "还没有带位置的笔记。在编辑器里长按位置按钮，就能给笔记标一个地点。",
+  "mapMemoryLoadFailed": "地图数据加载失败",
+  "mapMemoryResetView": "看全部足迹",
+  "mapMemoryPlaceCount": "{count} 条带位置的笔记",
+  "@mapMemoryPlaceCount": {
+    "description": "地图回忆页顶部提示里带坐标的笔记条数",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "attachFile": "附加文件",
   "yesterday": "昨天",
   "openInEditor": "打开编辑器",

--- a/lib/models/quote_map_point.dart
+++ b/lib/models/quote_map_point.dart
@@ -1,0 +1,21 @@
+/// 地图回忆页用的轻量笔记坐标点。
+///
+/// 地图一次要摆下**全部**有坐标的笔记。走完整的 `Quote` 会把 `delta_content`、
+/// `ai_analysis` 这些大字段一并读进内存，而 marker 只需要一个坐标；点开某个
+/// marker 时再按 [id] 取完整笔记。
+class QuoteMapPoint {
+  const QuoteMapPoint({
+    required this.id,
+    required this.date,
+    required this.latitude,
+    required this.longitude,
+  });
+
+  final String id;
+
+  /// 笔记的创建时间（ISO 8601 字符串，与 `Quote.date` 同源）。
+  final String date;
+
+  final double latitude;
+  final double longitude;
+}

--- a/lib/pages/explore/explore_map_entry.dart
+++ b/lib/pages/explore/explore_map_entry.dart
@@ -1,0 +1,71 @@
+part of '../explore_page.dart';
+
+/// 探索页通往地图回忆的入口。
+///
+/// 和上面的 Thoughter 入口并列，是这一页的第二个「去处」：一个按时间读笔记，
+/// 一个按地点读笔记。地图页自己负责取数，这里只管跳转。
+extension _ExploreMapEntry on _ExplorePageState {
+  Widget _buildMapMemoryEntry() {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Material(
+      color: theme.colorScheme.surfaceContainerLowest,
+      borderRadius:
+          BorderRadius.circular(AppShapeTokens.of(context).buttonRadius),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: _openMapMemory,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          child: Row(
+            children: [
+              Icon(
+                Icons.map_outlined,
+                size: 20,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.exploreMapMemory,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      l10n.exploreMapMemoryDesc,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Icon(
+                Icons.chevron_right,
+                size: 20,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openMapMemory() async {
+    HapticFeedback.lightImpact();
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => const MapMemoryPage()),
+    );
+    // 地图页里能编辑和删除笔记，回来这一页的统计就不一定还准
+    if (!mounted) return;
+    await _loadPeriodData(showLoading: false);
+  }
+}

--- a/lib/pages/explore/explore_overview.dart
+++ b/lib/pages/explore/explore_overview.dart
@@ -60,6 +60,10 @@ extension _ExploreOverview on _ExplorePageState {
             _buildRecentSessionsSection(),
             const SizedBox(height: 4),
 
+            // 按地点读笔记的入口，和上面按时间读的 Thoughter 并列
+            _buildMapMemoryEntry(),
+            const SizedBox(height: 20),
+
             if (_periodQuotes.isNotEmpty) ...[
               _buildPeriodTopFavoritesSection(),
               const SizedBox(height: 20),

--- a/lib/pages/explore_page.dart
+++ b/lib/pages/explore_page.dart
@@ -28,6 +28,7 @@ import '../theme/app_semantic_colors.dart';
 import '../theme/theme_style.dart';
 import '../gen_l10n/app_localizations.dart';
 import '../widgets/ai/experimental_badge.dart';
+import 'map_memory_page.dart';
 import 'thoughter_page.dart';
 import 'thoughter/session_history_page.dart';
 
@@ -36,6 +37,7 @@ part 'explore/explore_time_selector.dart';
 part 'explore/explore_overview.dart';
 part 'explore/explore_stats.dart';
 part 'explore/explore_thoughter_entry.dart';
+part 'explore/explore_map_entry.dart';
 
 /// 探索页：底部导航第三个 tab，聚合周期洞察与 Thoughter 入口。
 class ExplorePage extends StatefulWidget {

--- a/lib/pages/map_location_picker_page.dart
+++ b/lib/pages/map_location_picker_page.dart
@@ -201,7 +201,8 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
     setState(() => _locating = true);
 
     try {
-      final position = locationService.currentPosition ??
+      final position =
+          locationService.currentPosition ??
           await locationService.getCurrentLocation(highAccuracy: false);
       if (!mounted) return;
 
@@ -237,6 +238,7 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
       _searchVisible = !_searchVisible;
       if (!_searchVisible) {
         _searchTimer?.cancel();
+        _searchToken++;
         _searchController.clear();
         _results = const [];
         _searching = false;
@@ -249,6 +251,7 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
     _searchTimer?.cancel();
     final query = value.trim();
     if (query.isEmpty) {
+      _searchToken++;
       setState(() {
         _results = const [];
         _searching = false;
@@ -316,8 +319,9 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
       if (!mounted) return;
 
       final address = _resolvedAddress;
-      final poiName =
-          _cityLevelOnly ? null : (_pickedPlace?.name ?? address?['poi_name']);
+      final poiName = _cityLevelOnly
+          ? null
+          : (_pickedPlace?.name ?? address?['poi_name']);
 
       Navigator.of(context).pop(
         MapPickerResult(
@@ -353,7 +357,16 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
                 onChanged: _onSearchChanged,
                 onSubmitted: (value) {
                   _searchTimer?.cancel();
-                  _runSearch(value.trim());
+                  final query = value.trim();
+                  if (query.isEmpty) {
+                    _searchToken++;
+                    setState(() {
+                      _results = const [];
+                      _searching = false;
+                    });
+                    return;
+                  }
+                  _runSearch(query);
                 },
               )
             : Text(l10n.mapPickerTitle),
@@ -382,15 +395,13 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
             mapController: _mapController,
             options: MapOptions(
               initialCenter: _center,
-              initialZoom:
-                  widget.initialLatitude != null ? _pointZoom : _fallbackZoom,
+              initialZoom: widget.initialLatitude != null
+                  ? _pointZoom
+                  : _fallbackZoom,
               onPositionChanged: _onPositionChanged,
               backgroundColor: theme.colorScheme.surfaceContainerLow,
             ),
-            children: [
-              OsmMapLayers.tiles(),
-              OsmMapLayers.attribution(),
-            ],
+            children: [OsmMapLayers.tiles(), OsmMapLayers.attribution()],
           ),
         ),
         // 定位针钉在屏幕中心，跟着地图一起动的是底图——这样"选的是哪个点"

--- a/lib/pages/map_location_picker_page.dart
+++ b/lib/pages/map_location_picker_page.dart
@@ -201,8 +201,7 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
     setState(() => _locating = true);
 
     try {
-      final position =
-          locationService.currentPosition ??
+      final position = locationService.currentPosition ??
           await locationService.getCurrentLocation(highAccuracy: false);
       if (!mounted) return;
 
@@ -319,9 +318,8 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
       if (!mounted) return;
 
       final address = _resolvedAddress;
-      final poiName = _cityLevelOnly
-          ? null
-          : (_pickedPlace?.name ?? address?['poi_name']);
+      final poiName =
+          _cityLevelOnly ? null : (_pickedPlace?.name ?? address?['poi_name']);
 
       Navigator.of(context).pop(
         MapPickerResult(
@@ -395,9 +393,8 @@ class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
             mapController: _mapController,
             options: MapOptions(
               initialCenter: _center,
-              initialZoom: widget.initialLatitude != null
-                  ? _pointZoom
-                  : _fallbackZoom,
+              initialZoom:
+                  widget.initialLatitude != null ? _pointZoom : _fallbackZoom,
               onPositionChanged: _onPositionChanged,
               backgroundColor: theme.colorScheme.surfaceContainerLow,
             ),

--- a/lib/pages/map_location_picker_page.dart
+++ b/lib/pages/map_location_picker_page.dart
@@ -1,0 +1,433 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
+
+import '../gen_l10n/app_localizations.dart';
+import '../services/location_service.dart';
+import '../services/place_search_service.dart';
+import '../theme/theme_style.dart';
+import '../utils/app_logger.dart';
+import '../widgets/app_loading_view.dart';
+import '../widgets/app_snackbar.dart';
+import '../widgets/map/osm_map_layers.dart';
+
+part 'map_picker/map_picker_panel.dart';
+
+/// 地图选点页的返回值。
+class MapPickerResult {
+  const MapPickerResult({
+    required this.latitude,
+    required this.longitude,
+    this.location,
+    this.poiName,
+  });
+
+  final double latitude;
+  final double longitude;
+
+  /// 入库格式的行政区串 `国家,省份,城市,区县`；反查失败时为 null。
+  ///
+  /// 不是 `formatted_address`——见 [LocationService.buildStorageLocation]。
+  final String? location;
+
+  /// 用户选中的地点名（"芝公园"）。
+  ///
+  /// 选了「当前位置」、或这个坐标上没有可命名的地点时为 null，此时这条笔记
+  /// 只记到行政区一级，和没用过选点的笔记一样。
+  final String? poiName;
+}
+
+/// 地图选点页：给一条笔记标一个精确地点。
+///
+/// 从全屏编辑器长按位置按钮进入。用户拖地图定点、或搜索一个地点，确认后回传
+/// [MapPickerResult]。
+class MapLocationPickerPage extends StatefulWidget {
+  const MapLocationPickerPage({
+    super.key,
+    this.initialLatitude,
+    this.initialLongitude,
+  });
+
+  /// 笔记已有坐标时以它为初始中心；为空则先取一次设备定位。
+  final double? initialLatitude;
+  final double? initialLongitude;
+
+  @override
+  State<MapLocationPickerPage> createState() => _MapLocationPickerPageState();
+}
+
+class _MapLocationPickerPageState extends State<MapLocationPickerPage> {
+  /// 既没有传入坐标、定位又失败时的兜底中心（北京天安门）。
+  ///
+  /// 与其给一张全球视野的空地图，不如落在一个具体城市，用户至少知道要往哪拖。
+  static const LatLng _fallbackCenter = LatLng(39.9042, 116.4074);
+
+  /// 选中一个点之后的缩放级别：能看清街区，但还留得住周边参照。
+  static const double _pointZoom = 16;
+  static const double _fallbackZoom = 12;
+
+  /// 拖动停下多久才反查一次。
+  ///
+  /// Nominatim 的公共服务限 1 请求/秒，拖动过程中每一帧都反查必被限流；
+  /// 900ms 也刚好是「手指离开、看一眼地名」的节奏。
+  static const Duration _reverseDebounce = Duration(milliseconds: 900);
+  static const Duration _searchDebounce = Duration(milliseconds: 500);
+
+  final MapController _mapController = MapController();
+  final TextEditingController _searchController = TextEditingController();
+  final PlaceSearchService _placeSearch = NominatimPlaceSearchService();
+
+  Timer? _reverseTimer;
+  Timer? _searchTimer;
+
+  /// 地图当前的中心，也就是「待确认的那个点」。
+  late LatLng _center;
+
+  /// [_resolvedAddress] 对应的坐标。
+  ///
+  /// 和 [_center] 分开存：反查是异步的，结果回来时用户可能已经拖到别处，
+  /// 靠这个判断手上的地址还算不算数。
+  LatLng? _resolvedPoint;
+  Map<String, String?>? _resolvedAddress;
+  bool _resolving = false;
+  bool _locating = false;
+  bool _confirming = false;
+
+  /// 用户从搜索结果里选中的地点，它的名字覆盖反查给出的名字。
+  ///
+  /// 用户自己拖动地图后作废——那说明他要的不是搜出来的那个点了。
+  PlaceInfo? _pickedPlace;
+
+  /// 选了「当前位置」：只记行政区，不记具体地点。
+  bool _cityLevelOnly = false;
+
+  bool _searchVisible = false;
+  bool _searching = false;
+  List<PlaceInfo> _results = const [];
+
+  /// 搜索请求的序号，用来丢弃过期响应。
+  int _searchToken = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    final lat = widget.initialLatitude;
+    final lon = widget.initialLongitude;
+    final hasInitialPoint = lat != null && lon != null;
+    _center = hasInitialPoint ? LatLng(lat, lon) : _fallbackCenter;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (hasInitialPoint) {
+        _resolveCenter();
+      } else {
+        // 没有已有坐标就以设备位置开局，但不当成用户「选了当前位置」——
+        // 他还没做选择，拖一下就该是普通选点。
+        _moveToDeviceLocation(asCurrentLocation: false);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _reverseTimer?.cancel();
+    _searchTimer?.cancel();
+    _searchController.dispose();
+    _mapController.dispose();
+    super.dispose();
+  }
+
+  // ---------------------------------------------------------------- 定位与反查
+
+  void _onPositionChanged(MapCamera camera, bool hasGesture) {
+    _center = camera.center;
+
+    // 只有用户自己拖动才作废之前的选择：程序化 move（搜索结果、回到当前位置）
+    // 同样会走到这里，那是我们自己设的选择，不能被它清掉。
+    if (hasGesture && (_pickedPlace != null || _cityLevelOnly)) {
+      setState(() {
+        _pickedPlace = null;
+        _cityLevelOnly = false;
+      });
+    }
+
+    _reverseTimer?.cancel();
+    _reverseTimer = Timer(_reverseDebounce, _resolveCenter);
+  }
+
+  Future<void> _resolveCenter() async {
+    final point = _center;
+    if (_resolvedPoint == point) return;
+
+    final locationService = context.read<LocationService>();
+    setState(() => _resolving = true);
+
+    Map<String, String?>? address;
+    try {
+      address = await locationService.reverseGeocodePoint(
+        point.latitude,
+        point.longitude,
+      );
+    } catch (e, stack) {
+      logError(
+        '反查选点地址失败',
+        error: e,
+        stackTrace: stack,
+        source: 'MapLocationPickerPage',
+      );
+    }
+
+    if (!mounted) return;
+    // 反查期间用户又拖走了，这个结果已经不是当前这个点的
+    if (_center != point) {
+      setState(() => _resolving = false);
+      return;
+    }
+    setState(() {
+      _resolvedPoint = point;
+      _resolvedAddress = address;
+      _resolving = false;
+    });
+  }
+
+  Future<void> _moveToDeviceLocation({required bool asCurrentLocation}) async {
+    if (_locating) return;
+
+    final locationService = context.read<LocationService>();
+    final l10n = AppLocalizations.of(context);
+    setState(() => _locating = true);
+
+    try {
+      final position = locationService.currentPosition ??
+          await locationService.getCurrentLocation(highAccuracy: false);
+      if (!mounted) return;
+
+      if (position == null) {
+        AppSnackBar.error(context, l10n.cannotGetLocationDesc);
+        return;
+      }
+
+      final point = LatLng(position.latitude, position.longitude);
+      setState(() {
+        _center = point;
+        _pickedPlace = null;
+        _cityLevelOnly = asCurrentLocation;
+      });
+      _mapController.move(point, _pointZoom);
+    } catch (e, stack) {
+      logError(
+        '获取设备位置失败',
+        error: e,
+        stackTrace: stack,
+        source: 'MapLocationPickerPage',
+      );
+      if (mounted) AppSnackBar.error(context, l10n.cannotGetLocationDesc);
+    } finally {
+      if (mounted) setState(() => _locating = false);
+    }
+  }
+
+  // -------------------------------------------------------------------- 搜索
+
+  void _toggleSearch() {
+    setState(() {
+      _searchVisible = !_searchVisible;
+      if (!_searchVisible) {
+        _searchTimer?.cancel();
+        _searchController.clear();
+        _results = const [];
+        _searching = false;
+      }
+    });
+    if (!_searchVisible) FocusScope.of(context).unfocus();
+  }
+
+  void _onSearchChanged(String value) {
+    _searchTimer?.cancel();
+    final query = value.trim();
+    if (query.isEmpty) {
+      setState(() {
+        _results = const [];
+        _searching = false;
+      });
+      return;
+    }
+    _searchTimer = Timer(_searchDebounce, () => _runSearch(query));
+  }
+
+  Future<void> _runSearch(String query) async {
+    final token = ++_searchToken;
+    final localeCode = context.read<LocationService>().currentLocaleCode;
+    setState(() => _searching = true);
+
+    final results = await _placeSearch.searchNearby(
+      _center.latitude,
+      _center.longitude,
+      query: query,
+      localeCode: localeCode,
+    );
+
+    // 用户已经改了关键词，这批结果是上一次的
+    if (!mounted || token != _searchToken) return;
+    setState(() {
+      _results = results;
+      _searching = false;
+    });
+  }
+
+  /// 把选择切回「地图上的选点」。
+  ///
+  /// 面板在 extension 里，`setState` 只能在 State 的实例成员里调用，所以这一
+  /// 步放在这边。
+  void _selectMapPoint() {
+    if (!_cityLevelOnly) return;
+    setState(() => _cityLevelOnly = false);
+  }
+
+  void _selectPlace(PlaceInfo place) {
+    final point = LatLng(place.latitude, place.longitude);
+    setState(() {
+      _center = point;
+      _pickedPlace = place;
+      _cityLevelOnly = false;
+      // 行政区要按新坐标重新反查，否则副行还写着上一个点的城市
+      _resolvedPoint = null;
+    });
+    _mapController.move(point, _pointZoom);
+    FocusScope.of(context).unfocus();
+  }
+
+  // -------------------------------------------------------------------- 确认
+
+  Future<void> _confirm() async {
+    if (_confirming) return;
+    setState(() => _confirming = true);
+
+    try {
+      // 拖完立刻按确认时反查还没跑；补一次，别让用户拿到一条只有坐标没有
+      // 地址的记录——卡片上那就只能显示一串经纬度。
+      if (_resolvedPoint != _center) {
+        _reverseTimer?.cancel();
+        await _resolveCenter();
+      }
+      if (!mounted) return;
+
+      final address = _resolvedAddress;
+      final poiName =
+          _cityLevelOnly ? null : (_pickedPlace?.name ?? address?['poi_name']);
+
+      Navigator.of(context).pop(
+        MapPickerResult(
+          latitude: _center.latitude,
+          longitude: _center.longitude,
+          location: LocationService.buildStorageLocation(address),
+          poiName: poiName?.trim().isEmpty ?? true ? null : poiName!.trim(),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _confirming = false);
+    }
+  }
+
+  // -------------------------------------------------------------------- 构建
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: _searchVisible
+            ? TextField(
+                controller: _searchController,
+                autofocus: true,
+                textInputAction: TextInputAction.search,
+                decoration: InputDecoration(
+                  border: InputBorder.none,
+                  hintText: l10n.mapPickerSearchHint,
+                ),
+                onChanged: _onSearchChanged,
+                onSubmitted: (value) {
+                  _searchTimer?.cancel();
+                  _runSearch(value.trim());
+                },
+              )
+            : Text(l10n.mapPickerTitle),
+        actions: [
+          IconButton(
+            icon: Icon(_searchVisible ? Icons.close : Icons.search),
+            tooltip: _searchVisible ? l10n.cancel : l10n.mapPickerSearchHint,
+            onPressed: _toggleSearch,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(child: _buildMap(theme, l10n)),
+          _buildPanel(theme, l10n),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMap(ThemeData theme, AppLocalizations l10n) {
+    return Stack(
+      children: [
+        RepaintBoundary(
+          child: FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              initialCenter: _center,
+              initialZoom:
+                  widget.initialLatitude != null ? _pointZoom : _fallbackZoom,
+              onPositionChanged: _onPositionChanged,
+              backgroundColor: theme.colorScheme.surfaceContainerLow,
+            ),
+            children: [
+              OsmMapLayers.tiles(),
+              OsmMapLayers.attribution(),
+            ],
+          ),
+        ),
+        // 定位针钉在屏幕中心，跟着地图一起动的是底图——这样"选的是哪个点"
+        // 永远只有一个答案，不用先点一下再拖。
+        IgnorePointer(
+          child: Center(
+            child: Transform.translate(
+              offset: const Offset(0, -16),
+              child: Icon(
+                Icons.place,
+                size: 40,
+                color: theme.colorScheme.primary,
+                shadows: [
+                  Shadow(
+                    color: theme.colorScheme.shadow.withValues(alpha: 0.4),
+                    blurRadius: 4,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          right: 16,
+          bottom: 16,
+          child: FloatingActionButton.small(
+            heroTag: 'map_picker_locate',
+            tooltip: l10n.mapPickerLocateMe,
+            onPressed: _locating
+                ? null
+                : () => _moveToDeviceLocation(asCurrentLocation: false),
+            child: _locating
+                ? const AppInlineLoadingIndicator()
+                : const Icon(Icons.my_location),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/map_memory/map_memory_sheet.dart
+++ b/lib/pages/map_memory/map_memory_sheet.dart
@@ -1,0 +1,120 @@
+part of '../map_memory_page.dart';
+
+/// 点开一个标记后从底部滑出的笔记面板，以及面板上那几个动作。
+extension _MapMemorySheet on _MapMemoryPageState {
+  Future<void> _openNoteSheet(String quoteId) async {
+    final database = context.read<DatabaseService>();
+
+    Quote? quote;
+    try {
+      quote = await database.getQuoteById(quoteId);
+    } catch (e, stack) {
+      logError(
+        '打开地图笔记失败',
+        error: e,
+        stackTrace: stack,
+        source: 'MapMemoryPage',
+      );
+    }
+
+    if (!mounted) return;
+    final l10n = AppLocalizations.of(context);
+    if (quote == null) {
+      // 地图上的点是上一次加载的快照，这条可能已经在别处被删了
+      AppSnackBar.error(context, l10n.noteNotFound);
+      return;
+    }
+
+    final target = quote;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      showDragHandle: true,
+      builder: (sheetContext) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.55,
+        minChildSize: 0.3,
+        maxChildSize: 0.9,
+        builder: (context, scrollController) => ListView(
+          controller: scrollController,
+          padding: const EdgeInsets.fromLTRB(8, 0, 8, 16),
+          children: [
+            QuoteItemWidget(
+              quote: target,
+              tagMap: _tagMap,
+              // 面板本来就只放一条笔记，没有"和别的卡片挤在一起"的问题，
+              // 直接展开省掉一次点击。
+              isExpanded: true,
+              onToggleExpanded: (_) {},
+              onEdit: () {
+                Navigator.pop(sheetContext);
+                _editNote(target);
+              },
+              onDelete: () {
+                Navigator.pop(sheetContext);
+                _deleteNote(target);
+              },
+              onAskAI: () {
+                Navigator.pop(sheetContext);
+                _askThoughter(target);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _editNote(Quote quote) async {
+    final navigator = Navigator.of(context);
+    final saved = await navigator.push<bool>(
+      MaterialPageRoute(
+        builder: (_) => NoteFullEditorPage(
+          initialContent: quote.content,
+          initialQuote: quote,
+          allTags: _tagMap.values.toList(),
+        ),
+      ),
+    );
+
+    if (!mounted || saved != true) return;
+    // 编辑里可能换了位置，标记得跟着挪
+    await _load();
+  }
+
+  Future<void> _deleteNote(Quote quote) async {
+    final quoteId = quote.id;
+    if (quoteId == null) return;
+
+    final database = context.read<DatabaseService>();
+    final l10n = AppLocalizations.of(context);
+
+    try {
+      await database.deleteQuote(quoteId);
+      if (!mounted) return;
+      AppSnackBar.success(context, l10n.noteMovedToTrash);
+      await _load();
+    } catch (e, stack) {
+      logError(
+        '从地图删除笔记失败',
+        error: e,
+        stackTrace: stack,
+        source: 'MapMemoryPage',
+      );
+      if (!mounted) return;
+      AppSnackBar.error(context, l10n.deleteFailed(e.toString()));
+    }
+  }
+
+  Future<void> _askThoughter(Quote quote) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => ThoughterPage(
+          entrySource: ThoughterEntrySource.note,
+          quote: quote,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/map_memory_page.dart
+++ b/lib/pages/map_memory_page.dart
@@ -83,14 +83,9 @@ class _MapMemoryPageState extends State<MapMemoryPage> {
       final tags = await database.getTags();
 
       // 一条坐标笔记都没有时才去问设备位置——有足迹的话地图按足迹取景，
-      // 多要一次定位权限没有意义。
-      LatLng? deviceCenter;
-      if (points.isEmpty) {
-        final position = locationService.currentPosition;
-        if (position != null) {
-          deviceCenter = LatLng(position.latitude, position.longitude);
-        }
-      }
+      // 多问一次没有意义。
+      final deviceCenter =
+          points.isEmpty ? await _resolveDeviceCenter(locationService) : null;
 
       if (!mounted) return;
       setState(() {
@@ -111,6 +106,26 @@ class _MapMemoryPageState extends State<MapMemoryPage> {
         _loading = false;
         _failed = true;
       });
+    }
+  }
+
+  /// 空状态下地图落在哪儿。
+  ///
+  /// 缓存里没有位置时补取一次：[LocationService.getCurrentLocation] 只
+  /// `checkPermission` 不 `requestPermission`，所以这里不会凭空弹权限框，
+  /// 没授权就返回 null，落到兜底中心。
+  ///
+  /// 取不到位置不算这一页加载失败——地图照样能看，所以异常在这里就地咽下，
+  /// 不往上抛去触发错误态。
+  Future<LatLng?> _resolveDeviceCenter(LocationService locationService) async {
+    try {
+      final position = locationService.currentPosition ??
+          await locationService.getCurrentLocation(highAccuracy: false);
+      if (position == null) return null;
+      return LatLng(position.latitude, position.longitude);
+    } catch (e) {
+      logDebug('地图空状态取设备位置失败: $e', source: 'MapMemoryPage');
+      return null;
     }
   }
 

--- a/lib/pages/map_memory_page.dart
+++ b/lib/pages/map_memory_page.dart
@@ -1,0 +1,292 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
+
+import '../gen_l10n/app_localizations.dart';
+import '../models/note_tag.dart';
+import '../models/quote_map_point.dart';
+import '../models/quote_model.dart';
+import '../models/thoughter_entry.dart';
+import '../services/database_service.dart';
+import '../services/location_service.dart';
+import '../utils/app_logger.dart';
+import '../widgets/app_error_view.dart';
+import '../widgets/app_loading_view.dart';
+import '../widgets/app_snackbar.dart';
+import '../widgets/map/osm_map_layers.dart';
+import '../widgets/quote_item_widget.dart';
+import 'note_full_editor_page.dart';
+import 'thoughter_page.dart';
+
+part 'map_memory/map_memory_sheet.dart';
+
+/// 地图回忆：把所有带坐标的笔记摆在一张地图上。
+///
+/// 和 [MapLocationPickerPage] 的分工：选点页是「给这条笔记打一个地点」的工具，
+/// 这里是纯浏览——不筛时间、不筛标签，永远显示全部足迹，缩小时靠聚合。
+class MapMemoryPage extends StatefulWidget {
+  const MapMemoryPage({super.key});
+
+  @override
+  State<MapMemoryPage> createState() => _MapMemoryPageState();
+}
+
+class _MapMemoryPageState extends State<MapMemoryPage> {
+  /// 一条笔记都没有、又拿不到设备位置时的兜底中心。
+  static const LatLng _fallbackCenter = LatLng(39.9042, 116.4074);
+  static const double _emptyStateZoom = 11;
+
+  /// 全局总览时最多放大到这一级。
+  ///
+  /// 所有笔记都在同一个街区时，不设上限会一路推到街道级，看着像"只有一条"；
+  /// 停在城市级才看得出这是一片足迹。
+  static const double _overviewMaxZoom = 14;
+
+  static const EdgeInsets _overviewPadding = EdgeInsets.all(48);
+
+  final MapController _mapController = MapController();
+
+  List<QuoteMapPoint> _points = const [];
+  Map<String, NoteTag> _tagMap = const {};
+  bool _loading = true;
+  bool _failed = false;
+
+  /// 没有任何坐标笔记时，地图落在设备位置附近，而不是给一张空的世界地图。
+  LatLng? _deviceCenter;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _mapController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    final database = context.read<DatabaseService>();
+    final locationService = context.read<LocationService>();
+    if (mounted) {
+      setState(() {
+        _loading = true;
+        _failed = false;
+      });
+    }
+
+    try {
+      final points = await database.getQuotesWithCoordinates();
+      final tags = await database.getTags();
+
+      // 一条坐标笔记都没有时才去问设备位置——有足迹的话地图按足迹取景，
+      // 多要一次定位权限没有意义。
+      LatLng? deviceCenter;
+      if (points.isEmpty) {
+        final position = locationService.currentPosition;
+        if (position != null) {
+          deviceCenter = LatLng(position.latitude, position.longitude);
+        }
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _points = points;
+        _tagMap = {for (final tag in tags) tag.id: tag};
+        _deviceCenter = deviceCenter;
+        _loading = false;
+      });
+    } catch (e, stack) {
+      logError(
+        '加载地图回忆数据失败',
+        error: e,
+        stackTrace: stack,
+        source: 'MapMemoryPage',
+      );
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _failed = true;
+      });
+    }
+  }
+
+  /// 回到「看得见全部足迹」的取景。
+  void _fitAllPoints() {
+    if (_points.isEmpty) return;
+    _mapController.fitCamera(
+      CameraFit.coordinates(
+        coordinates: _points.map(_toLatLng).toList(),
+        padding: _overviewPadding,
+        maxZoom: _overviewMaxZoom,
+      ),
+    );
+  }
+
+  static LatLng _toLatLng(QuoteMapPoint point) =>
+      LatLng(point.latitude, point.longitude);
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.exploreMapMemory)),
+      body: _buildBody(theme, l10n),
+      floatingActionButton: _points.isEmpty || _loading || _failed
+          ? null
+          : FloatingActionButton(
+              tooltip: l10n.mapMemoryResetView,
+              onPressed: _fitAllPoints,
+              child: const Icon(Icons.zoom_out_map),
+            ),
+    );
+  }
+
+  Widget _buildBody(ThemeData theme, AppLocalizations l10n) {
+    if (_loading) return const AppLoadingView();
+    if (_failed) return AppErrorView(text: l10n.mapMemoryLoadFailed);
+
+    return Stack(
+      children: [
+        RepaintBoundary(child: _buildMap(theme)),
+        Positioned(
+          left: 16,
+          right: 16,
+          top: 16,
+          child: _buildHintCard(theme, l10n),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMap(ThemeData theme) {
+    final hasPoints = _points.isNotEmpty;
+
+    return FlutterMap(
+      mapController: _mapController,
+      options: MapOptions(
+        // 有足迹就按足迹取景，进来第一眼就是"我去过这些地方"。
+        initialCameraFit: hasPoints
+            ? CameraFit.coordinates(
+                coordinates: _points.map(_toLatLng).toList(),
+                padding: _overviewPadding,
+                maxZoom: _overviewMaxZoom,
+              )
+            : null,
+        initialCenter: _deviceCenter ?? _fallbackCenter,
+        initialZoom: _emptyStateZoom,
+        backgroundColor: theme.colorScheme.surfaceContainerLow,
+      ),
+      children: [
+        OsmMapLayers.tiles(),
+        if (hasPoints)
+          MarkerClusterLayerWidget(
+            options: MarkerClusterLayerOptions(
+              markers:
+                  _points.map((point) => _buildMarker(theme, point)).toList(),
+              size: const Size(44, 44),
+              maxClusterRadius: 48,
+              padding: _overviewPadding,
+              // 聚合展开的动画就是「放大相册」的那个手感，保持默认即可
+              builder: (context, markers) =>
+                  _buildClusterBadge(theme, markers.length),
+            ),
+          ),
+        OsmMapLayers.attribution(),
+      ],
+    );
+  }
+
+  Marker _buildMarker(ThemeData theme, QuoteMapPoint point) {
+    return Marker(
+      key: ValueKey(point.id),
+      point: _toLatLng(point),
+      width: 36,
+      height: 36,
+      child: GestureDetector(
+        onTap: () => _openNoteSheet(point.id),
+        child: _MapPin(
+          child: Icon(
+            Icons.edit_note,
+            size: 20,
+            color: theme.colorScheme.onPrimary,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildClusterBadge(ThemeData theme, int count) {
+    return _MapPin(
+      child: Text(
+        '$count',
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: theme.colorScheme.onPrimary,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHintCard(ThemeData theme, AppLocalizations l10n) {
+    final hasPoints = _points.isNotEmpty;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            Icon(
+              hasPoints ? Icons.map_outlined : Icons.explore_outlined,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                hasPoints
+                    ? l10n.mapMemoryPlaceCount(_points.length)
+                    : l10n.mapMemoryEmptyHint,
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 地图上的标记底座：一个描边的实心圆。
+///
+/// marker 和 cluster 用同一个底座，缩放时聚合泡展开成单点不会换一副长相。
+/// 描边取 surface，让标记在深浅不一的瓦片上都能从底图里跳出来。
+class _MapPin extends StatelessWidget {
+  const _MapPin({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.primary,
+        shape: BoxShape.circle,
+        border: Border.all(color: colorScheme.surface, width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.shadow.withValues(alpha: 0.24),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Center(child: child),
+    );
+  }
+}

--- a/lib/pages/map_picker/map_picker_panel.dart
+++ b/lib/pages/map_picker/map_picker_panel.dart
@@ -1,0 +1,216 @@
+part of '../map_location_picker_page.dart';
+
+/// 选点页地图下方的候选列表与确认区。
+extension _MapPickerPanel on _MapLocationPickerPageState {
+  /// 面板最多占屏幕这么高。
+  ///
+  /// 超过一半地图就看不清了；不到内容高度时面板会自己收缩，只有两条候选时
+  /// 不会留一大片空白。
+  static const double _maxHeightFactor = 0.42;
+
+  Widget _buildPanel(ThemeData theme, AppLocalizations l10n) {
+    final radius = AppShapeTokens.of(context).cardRadius;
+
+    return Material(
+      color: theme.colorScheme.surfaceContainerLow,
+      elevation: 3,
+      shadowColor: theme.colorScheme.shadow,
+      borderRadius: BorderRadius.vertical(top: Radius.circular(radius)),
+      clipBehavior: Clip.antiAlias,
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.sizeOf(context).height * _maxHeightFactor,
+              ),
+              child: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                children: [
+                  _buildSelectedPointTile(theme, l10n),
+                  _buildCurrentLocationTile(theme, l10n),
+                  ..._buildSearchSection(theme, l10n),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _confirming ? null : _confirm,
+                  icon: _confirming
+                      ? AppInlineLoadingIndicator(
+                          color: theme.colorScheme.onPrimary,
+                        )
+                      : const Icon(Icons.check),
+                  label: Text(l10n.mapPickerConfirm),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 地图中心那个点。这是默认选中的一条。
+  Widget _buildSelectedPointTile(ThemeData theme, AppLocalizations l10n) {
+    final selected = !_cityLevelOnly;
+    final address = _resolvedAddress;
+
+    // 搜索选中的地点名不需要等反查，先显示出来
+    final pendingName = _pickedPlace == null && _resolving;
+
+    final String title;
+    if (pendingName) {
+      title = l10n.mapPickerResolvingPoint;
+    } else {
+      final name = _pickedPlace?.name ?? address?['poi_name']?.trim();
+      title =
+          (name == null || name.isEmpty) ? l10n.mapPickerUnnamedPoint : name;
+    }
+
+    final areaText = LocationService.buildStorageLocation(address);
+    final detail = areaText == null
+        ? LocationService.formatCoordinates(
+            _center.latitude,
+            _center.longitude,
+            precision: 4,
+          )
+        : LocationService.formatLocationForDisplay(areaText);
+
+    return ListTile(
+      leading: pendingName
+          ? const SizedBox(
+              width: 24,
+              height: 24,
+              child: Center(child: AppInlineLoadingIndicator()),
+            )
+          : Icon(Icons.place_outlined, color: theme.colorScheme.primary),
+      title: Text(title),
+      subtitle: Text(
+        detail.isEmpty
+            ? l10n.mapPickerSelectedPoint
+            : '${l10n.mapPickerSelectedPoint} · $detail',
+      ),
+      trailing: selected
+          ? Icon(Icons.check_circle, color: theme.colorScheme.primary)
+          : null,
+      selected: selected,
+      onTap: _selectMapPoint,
+    );
+  }
+
+  /// 「当前位置」：只记城市和区县，不给这条笔记落一个具体地点名。
+  Widget _buildCurrentLocationTile(ThemeData theme, AppLocalizations l10n) {
+    return ListTile(
+      leading: Icon(
+        Icons.my_location,
+        color: _cityLevelOnly
+            ? theme.colorScheme.primary
+            : theme.colorScheme.onSurfaceVariant,
+      ),
+      title: Text(l10n.mapPickerCurrentLocation),
+      subtitle: Text(l10n.mapPickerCurrentLocationSubtitle),
+      trailing: _cityLevelOnly
+          ? Icon(Icons.check_circle, color: theme.colorScheme.primary)
+          : null,
+      selected: _cityLevelOnly,
+      onTap: () => _moveToDeviceLocation(asCurrentLocation: true),
+    );
+  }
+
+  List<Widget> _buildSearchSection(ThemeData theme, AppLocalizations l10n) {
+    if (!_searchVisible) return const [];
+
+    final header = Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Row(
+        children: [
+          Text(
+            l10n.mapPickerSearchResults,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          if (_searching) ...[
+            const SizedBox(width: 8),
+            const AppInlineLoadingIndicator(),
+          ],
+        ],
+      ),
+    );
+
+    if (_results.isEmpty) {
+      return [
+        const Divider(height: 1),
+        header,
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+          child: Text(
+            _searching ? l10n.mapPickerSearching : l10n.mapPickerNoResults,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ];
+    }
+
+    return [
+      const Divider(height: 1),
+      header,
+      ..._results.map((place) => _buildPlaceTile(theme, l10n, place)),
+    ];
+  }
+
+  Widget _buildPlaceTile(
+    ThemeData theme,
+    AppLocalizations l10n,
+    PlaceInfo place,
+  ) {
+    final selected = identical(_pickedPlace, place);
+    final distance = _formatDistance(l10n, place.distanceMeters);
+
+    return ListTile(
+      leading: Icon(
+        Icons.location_on_outlined,
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+      title: Text(place.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: place.address == null
+          ? null
+          : Text(
+              place.address!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+      trailing: distance == null
+          ? null
+          : Text(
+              distance,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+      selected: selected,
+      onTap: () => _selectPlace(place),
+    );
+  }
+
+  /// 一公里以内按米给整数，再远按公里给一位小数。
+  String? _formatDistance(AppLocalizations l10n, double? meters) {
+    if (meters == null) return null;
+    if (meters < 1000) {
+      return l10n.mapPickerDistanceMeters(meters.round().toString());
+    }
+    return l10n.mapPickerDistanceKilometers(
+      (meters / 1000).toStringAsFixed(1),
+    );
+  }
+}

--- a/lib/pages/note_editor/editor_location_dialogs.dart
+++ b/lib/pages/note_editor/editor_location_dialogs.dart
@@ -99,17 +99,9 @@ extension _NoteEditorLocationDialogs on _NoteFullEditorPageState {
           localeCode: localeCode,
         );
         if (addressInfo != null && mounted) {
-          // 使用 country,province,city,district 拼成标准存储格式，
-          // 而不是 formatted_address（带空格英文拼接），
-          // 避免 formatLocationForDisplay 解析失败导致显示英文。
-          final country = addressInfo['country'] ?? '';
-          final province = addressInfo['province'] ?? '';
-          final city = addressInfo['city'] ?? '';
-          final district = addressInfo['district'] ?? '';
-          final standardAddress = '$country,$province,$city,$district';
-          final hasAnyField =
-              country.isNotEmpty || province.isNotEmpty || city.isNotEmpty;
-          if (hasAnyField) {
+          final standardAddress =
+              LocationService.buildStorageLocation(addressInfo);
+          if (standardAddress != null) {
             _updateState(() {
               _metadataState.location = standardAddress;
               _metadataState.originalLocation = standardAddress;

--- a/lib/pages/note_editor/editor_map_picker.dart
+++ b/lib/pages/note_editor/editor_map_picker.dart
@@ -1,0 +1,34 @@
+part of '../note_full_editor_page.dart';
+
+/// 长按位置按钮打开地图选点，把选中的地点写回元数据状态。
+///
+/// 复用现有的位置按钮而不是新加一个：单击仍然是「开关自动定位」，长按才进
+/// 地图——一个按钮管一件事（这条笔记记在哪儿），粗细两档精度。
+extension _NoteEditorMapPicker on _NoteFullEditorPageState {
+  Future<void> _openMapLocationPicker(StateSetter setDialogState) async {
+    final navigator = Navigator.of(context);
+
+    final result = await navigator.push<MapPickerResult>(
+      MaterialPageRoute<MapPickerResult>(
+        builder: (_) => MapLocationPickerPage(
+          initialLatitude: _metadataState.latitude,
+          initialLongitude: _metadataState.longitude,
+        ),
+      ),
+    );
+
+    if (!mounted || result == null) return;
+
+    _updateState(() {
+      _metadataState.latitude = result.latitude;
+      _metadataState.longitude = result.longitude;
+      // 反查失败时 location 为 null，显示会退回坐标。不保留上一个点的地址：
+      // 坐标已经换了城市，旧地址就是错的。
+      _metadataState.location = result.location;
+      _metadataState.poiName = result.poiName;
+      // 选完点还不显示位置就白选了
+      _metadataState.showLocation = true;
+    });
+    setDialogState(() {});
+  }
+}

--- a/lib/pages/note_editor/editor_metadata_location_section.dart
+++ b/lib/pages/note_editor/editor_metadata_location_section.dart
@@ -51,63 +51,73 @@ extension _NoteEditorMetadataLocationSection on _NoteFullEditorPageState {
               RepaintBoundary(
                 child: Row(
                   children: [
-                    // 位置信息按钮
+                    // 位置信息按钮：单击开关自动定位，长按进地图选一个精确地点
                     Expanded(
                       child: Stack(
                         children: [
-                          FilterChip(
-                            key: const ValueKey('full_editor_location_chip'),
-                            avatar: Icon(
-                              Icons.location_on,
-                              color: _metadataState.showLocation
-                                  ? theme.colorScheme.primary
-                                  : Theme.of(context)
-                                      .colorScheme
-                                      .onSurfaceVariant,
-                              size: 18,
-                            ),
-                            label: Text(l10n.locationLabel),
-                            selected: _metadataState.showLocation,
-                            onSelected: (value) async {
-                              // 编辑模式下统一提示只读
-                              if (widget.initialQuote?.id != null) {
-                                if (context.mounted) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text(
-                                          l10n.editModeMetadataReadOnlyHint),
-                                      duration: const Duration(seconds: 2),
-                                    ),
-                                  );
-                                }
-                                return;
-                              }
-                              // 新建模式
-                              if (value &&
-                                  _metadataState.location == null &&
-                                  _metadataState.latitude == null) {
-                                // 先设置为选中，获取失败后会在回调中取消
-                                _updateState(() {
-                                  _metadataState.showLocation = true;
-                                });
-                                setDialogState(() {});
-                                await _fetchLocationForNewNoteWithFailCallback(
-                                  () {
-                                    // 失败回调：取消选中
+                          Tooltip(
+                            message: l10n.longPressForMapPicker,
+                            child: GestureDetector(
+                              onLongPress: () =>
+                                  _openMapLocationPicker(setDialogState),
+                              child: FilterChip(
+                                key:
+                                    const ValueKey('full_editor_location_chip'),
+                                avatar: Icon(
+                                  Icons.location_on,
+                                  color: _metadataState.showLocation
+                                      ? theme.colorScheme.primary
+                                      : Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant,
+                                  size: 18,
+                                ),
+                                label: Text(l10n.locationLabel),
+                                selected: _metadataState.showLocation,
+                                onSelected: (value) async {
+                                  // 编辑模式下统一提示只读
+                                  if (widget.initialQuote?.id != null) {
+                                    if (context.mounted) {
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(
+                                        SnackBar(
+                                          content: Text(l10n
+                                              .editModeMetadataReadOnlyHint),
+                                          duration: const Duration(seconds: 2),
+                                        ),
+                                      );
+                                    }
+                                    return;
+                                  }
+                                  // 新建模式
+                                  if (value &&
+                                      _metadataState.location == null &&
+                                      _metadataState.latitude == null) {
+                                    // 先设置为选中，获取失败后会在回调中取消
                                     _updateState(() {
-                                      _metadataState.showLocation = false;
+                                      _metadataState.showLocation = true;
                                     });
                                     setDialogState(() {});
-                                  },
-                                );
-                              } else {
-                                _updateState(() {
-                                  _metadataState.showLocation = value;
-                                });
-                                setDialogState(() {});
-                              }
-                            },
-                            selectedColor: theme.colorScheme.primaryContainer,
+                                    await _fetchLocationForNewNoteWithFailCallback(
+                                      () {
+                                        // 失败回调：取消选中
+                                        _updateState(() {
+                                          _metadataState.showLocation = false;
+                                        });
+                                        setDialogState(() {});
+                                      },
+                                    );
+                                  } else {
+                                    _updateState(() {
+                                      _metadataState.showLocation = value;
+                                    });
+                                    setDialogState(() {});
+                                  }
+                                },
+                                selectedColor:
+                                    theme.colorScheme.primaryContainer,
+                              ),
+                            ),
                           ),
                           // 小红点：有坐标但没地址时提示可更新（仅已保存笔记）
                           if (widget.initialQuote?.id != null &&
@@ -282,15 +292,13 @@ extension _NoteEditorMetadataLocationSection on _NoteFullEditorPageState {
   }
 
   String _buildLocationDisplayText(AppLocalizations l10n) {
-    if (_metadataState.poiName != null &&
-        _metadataState.poiName!.trim().isNotEmpty) {
-      return _metadataState.poiName!.trim();
-    }
-
-    final formattedLocation =
-        LocationService.formatLocationForDisplay(_metadataState.location);
-    if (formattedLocation.isNotEmpty) {
-      return formattedLocation;
+    // 和笔记卡片同一套优先级：地点名（拼上行政区）> 行政区 > 坐标
+    final display = LocationService.formatPoiForDisplay(
+      _metadataState.poiName,
+      _metadataState.location,
+    );
+    if (display.isNotEmpty) {
+      return display;
     }
 
     if (_metadataState.latitude != null && _metadataState.longitude != null) {

--- a/lib/pages/note_full_editor_page.dart
+++ b/lib/pages/note_full_editor_page.dart
@@ -43,6 +43,7 @@ import '../services/settings_service.dart';
 import '../controllers/note_editor_states.dart';
 import '../widgets/app_snackbar.dart';
 import '../theme/theme_style.dart';
+import 'map_location_picker_page.dart';
 
 part 'note_editor/editor_document_init.dart';
 part 'note_editor/editor_save_and_draft.dart';
@@ -52,6 +53,7 @@ part 'note_editor/editor_build.dart';
 part 'note_editor/editor_color_and_media.dart';
 part 'note_editor/editor_metadata_dialog.dart';
 part 'note_editor/editor_metadata_location_section.dart';
+part 'note_editor/editor_map_picker.dart';
 part 'note_editor/editor_metadata_ai_section.dart';
 part 'note_editor/editor_ai_features.dart';
 

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -280,6 +280,11 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
   /// 所以这里只取 marker 用得上的四列，不走 [Quote]：`delta_content` 一列就
   /// 可能有几十 KB，上千条笔记全读进来足以让页面卡住。点开某个 marker 时再
   /// 用 [getQuoteById] 取那一条的完整内容。
+  ///
+  /// 失败时**抛出**而不是返回空列表：调用方靠「空」判断「这个人还没记过带
+  /// 位置的笔记」并给出引导文案，把查询失败也压成空，用户看到的就是一张
+  /// 加载成功的空地图，数据库故障被藏了起来。地图页有自己的错误态。
+  /// Web 上没有这张表，异常会照样冒出去——那正是「本平台不支持」的实情。
   @override
   Future<List<QuoteMapPoint>> getQuotesWithCoordinates() async {
     try {
@@ -334,7 +339,7 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
         stackTrace: stack,
         source: 'DatabaseService',
       );
-      return [];
+      rethrow;
     }
   }
 

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -274,6 +274,70 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
     }
   }
 
+  /// 地图回忆页的坐标点。
+  ///
+  /// 地图不分页——它一次要摆下用户的全部足迹，缩小时靠聚合而不是靠少查。
+  /// 所以这里只取 marker 用得上的四列，不走 [Quote]：`delta_content` 一列就
+  /// 可能有几十 KB，上千条笔记全读进来足以让页面卡住。点开某个 marker 时再
+  /// 用 [getQuoteById] 取那一条的完整内容。
+  @override
+  Future<List<QuoteMapPoint>> getQuotesWithCoordinates() async {
+    try {
+      if (!_isInitialized) {
+        if (_isInitializing && _initCompleter != null) {
+          await _initCompleter!.future;
+        } else {
+          await init();
+        }
+      }
+
+      final db = await safeDatabase;
+
+      final maps = await db.query(
+        'quotes q',
+        columns: ['q.id', 'q.date', 'q.latitude', 'q.longitude'],
+        where: '''
+          q.latitude IS NOT NULL
+          AND q.longitude IS NOT NULL
+          AND (q.is_deleted = 0 OR q.is_deleted IS NULL)
+          AND NOT EXISTS (
+            SELECT 1 FROM quote_tags qt_hidden
+            WHERE qt_hidden.quote_id = q.id
+            AND qt_hidden.tag_id = ?
+          )
+        ''',
+        whereArgs: [_DatabaseServiceBase.hiddenTagId],
+        orderBy: 'q.date DESC',
+      );
+
+      final points = <QuoteMapPoint>[];
+      for (final map in maps) {
+        final latitude = (map['latitude'] as num?)?.toDouble();
+        final longitude = (map['longitude'] as num?)?.toDouble();
+        final id = map['id']?.toString();
+        if (latitude == null || longitude == null || id == null) continue;
+
+        points.add(
+          QuoteMapPoint(
+            id: id,
+            date: map['date']?.toString() ?? '',
+            latitude: latitude,
+            longitude: longitude,
+          ),
+        );
+      }
+      return points;
+    } catch (e, stack) {
+      logError(
+        'getQuotesWithCoordinates 失败: $e',
+        error: e,
+        stackTrace: stack,
+        source: 'DatabaseService',
+      );
+      return [];
+    }
+  }
+
   /// 获取笔记总数，用于分页
   /// [excludeHiddenNotes] 是否排除隐藏笔记，默认为 true
   @override

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -104,8 +104,9 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
     // 时间段筛选
     if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-      final dayPeriodPlaceholders =
-          selectedDayPeriods.map((_) => '?').join(',');
+      final dayPeriodPlaceholders = selectedDayPeriods
+          .map((_) => '?')
+          .join(',');
       conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
       args.addAll(selectedDayPeriods);
     }
@@ -304,6 +305,8 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
         where: '''
           q.latitude IS NOT NULL
           AND q.longitude IS NOT NULL
+          AND q.latitude >= -90.0 AND q.latitude <= 90.0
+          AND q.longitude >= -180.0 AND q.longitude <= 180.0
           AND (q.is_deleted = 0 OR q.is_deleted IS NULL)
           AND NOT EXISTS (
             SELECT 1 FROM quote_tags qt_hidden
@@ -321,6 +324,12 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
         final longitude = (map['longitude'] as num?)?.toDouble();
         final id = map['id']?.toString();
         if (latitude == null || longitude == null || id == null) continue;
+        if (latitude < -90.0 ||
+            latitude > 90.0 ||
+            longitude < -180.0 ||
+            longitude > 180.0) {
+          continue;
+        }
 
         points.add(
           QuoteMapPoint(
@@ -498,8 +507,9 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
       // 时间段筛选
       if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-        final dayPeriodPlaceholders =
-            selectedDayPeriods.map((_) => '?').join(',');
+        final dayPeriodPlaceholders = selectedDayPeriods
+            .map((_) => '?')
+            .join(',');
         conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
         args.addAll(selectedDayPeriods);
       }

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -304,8 +304,8 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
         where: '''
           q.latitude IS NOT NULL
           AND q.longitude IS NOT NULL
-          AND q.latitude >= -90.0 AND q.latitude <= 90.0
-          AND q.longitude >= -180.0 AND q.longitude <= 180.0
+          AND q.latitude >= ? AND q.latitude <= ?
+          AND q.longitude >= ? AND q.longitude <= ?
           AND (q.is_deleted = 0 OR q.is_deleted IS NULL)
           AND NOT EXISTS (
             SELECT 1 FROM quote_tags qt_hidden
@@ -313,7 +313,13 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
             AND qt_hidden.tag_id = ?
           )
         ''',
-        whereArgs: [_DatabaseServiceBase.hiddenTagId],
+        whereArgs: [
+          -90.0,
+          90.0,
+          -180.0,
+          180.0,
+          _DatabaseServiceBase.hiddenTagId,
+        ],
         orderBy: 'q.date DESC',
       );
 

--- a/lib/services/database/database_query_helpers_mixin.dart
+++ b/lib/services/database/database_query_helpers_mixin.dart
@@ -104,9 +104,8 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
     // 时间段筛选
     if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-      final dayPeriodPlaceholders = selectedDayPeriods
-          .map((_) => '?')
-          .join(',');
+      final dayPeriodPlaceholders =
+          selectedDayPeriods.map((_) => '?').join(',');
       conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
       args.addAll(selectedDayPeriods);
     }
@@ -507,9 +506,8 @@ mixin _DatabaseQueryHelpersMixin on _DatabaseServiceBase {
 
       // 时间段筛选
       if (selectedDayPeriods != null && selectedDayPeriods.isNotEmpty) {
-        final dayPeriodPlaceholders = selectedDayPeriods
-            .map((_) => '?')
-            .join(',');
+        final dayPeriodPlaceholders =
+            selectedDayPeriods.map((_) => '?').join(',');
         conditions.add('q.day_period IN ($dayPeriodPlaceholders)');
         args.addAll(selectedDayPeriods);
       }

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -10,6 +10,7 @@ import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import '../models/note_tag.dart';
+import '../models/quote_map_point.dart';
 import '../models/quote_model.dart';
 import '../models/app_settings.dart';
 import 'package:uuid/uuid.dart';
@@ -120,6 +121,9 @@ abstract class _DatabaseServiceBase extends ChangeNotifier {
     String orderBy = 'q.date DESC',
     bool includeDeleted = false,
   });
+
+  /// 地图回忆页要用的全部坐标点，只取 marker 需要的四列。
+  Future<List<QuoteMapPoint>> getQuotesWithCoordinates();
   Future<int> getQuotesCount({
     List<String>? tagIds,
     String? categoryId,

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -520,6 +520,29 @@ class LocationService extends ChangeNotifier {
     }
   }
 
+  /// 反查任意坐标的地址，**不改动**本服务持有的「当前位置」。
+  ///
+  /// [getAddressFromLatLng] 反查的是设备定位，顺手把 `_country`/`_city` 和
+  /// `_currentAddress` 一起写掉。地图选点要的是用户手指点的那个点，写进这些
+  /// 字段会让天气、每日一言这些按「当前城市」取数的地方跟着漂走。
+  ///
+  /// 走 Nominatim 而不是系统地理编码：系统地理编码只给行政区，给不出
+  /// `poi_name`（"芝公园"），而选点的意义正是那个地点名。Windows 上系统
+  /// 地理编码本来也不可用。
+  ///
+  /// 返回的键与在线反查一致，额外带 `poi_name`；失败返回 null。
+  Future<Map<String, String?>?> reverseGeocodePoint(
+    double latitude,
+    double longitude,
+  ) async {
+    try {
+      return await _reverseGeocodeWithNominatim(latitude, longitude);
+    } catch (e) {
+      logDebug('反查选点地址失败: $e');
+      return null;
+    }
+  }
+
   /// 开发者模式：强制使用免费的在线反向地理编码（Nominatim）
   /// 返回 true 表示解析成功并更新了地址信息
   Future<bool> refreshAddressFromOnlineReverseGeocoding() async {
@@ -735,6 +758,18 @@ class LocationService extends ChangeNotifier {
             address['neighbourhood'],
       );
 
+      // 用户在地图上点的是一个具体地点，不是一片行政区。`name` 是 OSM 给这个
+      // 要素起的名字（"芝公园"）；address 里的 amenity/building 等是它的类型化
+      // 别名。两者都没有时说明这个坐标上只有街道或行政区，没有可命名的地点。
+      final poiName = s(decoded['name']) ??
+          s(address['amenity']) ??
+          s(address['building']) ??
+          s(address['shop']) ??
+          s(address['tourism']) ??
+          s(address['leisure']) ??
+          s(address['historic']) ??
+          s(address['office']);
+
       // 构建 formattedAddress 时去除相邻重复项（如避免 "日本, 东京都, 东京都"）
       final rawParts = [
         country,
@@ -756,6 +791,7 @@ class LocationService extends ChangeNotifier {
         'province': province,
         'city': city,
         'district': district,
+        'poi_name': poiName,
         'formatted_address': formattedAddress,
         'source': 'nominatim',
       };
@@ -1232,6 +1268,60 @@ class LocationService extends ChangeNotifier {
     }
 
     return '';
+  }
+
+  /// 卡片和编辑器上显示的位置文本：把用户选的地点名和它所在的行政区拼在一起。
+  ///
+  /// 只显示 [poiName]（"芝公园"）看不出在哪座城市，只显示行政区
+  /// （[formatLocationForDisplay] 给的"东京都·港区"）又丢掉了用户特意选的
+  /// 那个点。取行政区里最细的一级拼成"港区·芝公园"；地点名本身就是那一级
+  /// 行政区、或压根没有行政区时，只留地点名。
+  ///
+  /// [poiName] 为空时退回 [formatLocationForDisplay]，所以没选过点的老笔记
+  /// 显示不变。
+  static String formatPoiForDisplay(String? poiName, String? locationString) {
+    final poi = poiName?.trim() ?? '';
+    if (poi.isEmpty) return formatLocationForDisplay(locationString);
+
+    final area = _finestAdminArea(locationString);
+    if (area.isEmpty || area == poi) return poi;
+    return '$area·$poi';
+  }
+
+  /// 位置串里最细的一级行政区：区县 > 城市 > 省份 > 国家。
+  static String _finestAdminArea(String? locationString) {
+    if (locationString == null ||
+        locationString.isEmpty ||
+        isNonDisplayMarker(locationString)) {
+      return '';
+    }
+
+    final parts = locationString.split(',');
+    if (parts.length < 3) return cleanGeocodingText(locationString).trim();
+
+    for (final raw in parts.reversed) {
+      final value = cleanGeocodingText(raw).trim();
+      if (value.isNotEmpty) return value;
+    }
+    return '';
+  }
+
+  /// 把反查结果拼成入库用的位置串 `国家,省份,城市,区县`。
+  ///
+  /// 不能直接存 `formatted_address`——那是给人看的带空格拼接，
+  /// [formatLocationForDisplay] 按逗号分段解析它会失败，卡片上就退回英文原文。
+  ///
+  /// 四级全空时返回 null，让调用方自己决定是留空还是退回坐标。
+  static String? buildStorageLocation(Map<String, String?>? address) {
+    if (address == null) return null;
+
+    final country = address['country']?.trim() ?? '';
+    final province = address['province']?.trim() ?? '';
+    final city = address['city']?.trim() ?? '';
+    final district = address['district']?.trim() ?? '';
+
+    if (country.isEmpty && province.isEmpty && city.isEmpty) return null;
+    return '$country,$province,$city,$district';
   }
 
   // 获取显示格式的位置，如"广州市·天河区"（中文）或 "Guangzhou · Tianhe"（英文）

--- a/lib/services/place_search_service.dart
+++ b/lib/services/place_search_service.dart
@@ -61,8 +61,8 @@ class NominatimPlaceSearchService implements PlaceSearchService {
   NominatimPlaceSearchService({
     NetworkService? networkService,
     Duration? minRequestInterval,
-  }) : _networkService = networkService,
-       _minRequestInterval = minRequestInterval ?? _defaultMinRequestInterval;
+  })  : _networkService = networkService,
+        _minRequestInterval = minRequestInterval ?? _defaultMinRequestInterval;
 
   static const String _searchUrl = 'https://nominatim.openstreetmap.org/search';
   static const String _userAgent =
@@ -113,8 +113,7 @@ class NominatimPlaceSearchService implements PlaceSearchService {
           'format': 'json',
           'addressdetails': '1',
           'limit': '$limit',
-          'viewbox':
-              '${longitude - _viewboxDelta},'
+          'viewbox': '${longitude - _viewboxDelta},'
               '${latitude + _viewboxDelta},'
               '${longitude + _viewboxDelta},'
               '${latitude - _viewboxDelta}',
@@ -263,8 +262,7 @@ class NominatimPlaceSearchService implements PlaceSearchService {
 
     final dLat = toRadians(lat2 - lat1);
     final dLon = toRadians(lon2 - lon1);
-    final a =
-        math.sin(dLat / 2) * math.sin(dLat / 2) +
+    final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
         math.cos(toRadians(lat1)) *
             math.cos(toRadians(lat2)) *
             math.sin(dLon / 2) *

--- a/lib/services/place_search_service.dart
+++ b/lib/services/place_search_service.dart
@@ -61,14 +61,15 @@ class NominatimPlaceSearchService implements PlaceSearchService {
   NominatimPlaceSearchService({
     NetworkService? networkService,
     Duration? minRequestInterval,
-  })  : _networkService = networkService,
-        _minRequestInterval = minRequestInterval ?? _defaultMinRequestInterval;
+  }) : _networkService = networkService,
+       _minRequestInterval = minRequestInterval ?? _defaultMinRequestInterval;
 
   static const String _searchUrl = 'https://nominatim.openstreetmap.org/search';
   static const String _userAgent =
       'ThoughtEcho/3.4 (https://github.com/Shangjin-Xiao/ThoughtEcho)';
-  static const Duration _defaultMinRequestInterval =
-      Duration(milliseconds: 1100);
+  static const Duration _defaultMinRequestInterval = Duration(
+    milliseconds: 1100,
+  );
 
   /// 搜索框限定在参考点周围这么多度的方框内，约 ±11 公里。
   ///
@@ -112,7 +113,8 @@ class NominatimPlaceSearchService implements PlaceSearchService {
           'format': 'json',
           'addressdetails': '1',
           'limit': '$limit',
-          'viewbox': '${longitude - _viewboxDelta},'
+          'viewbox':
+              '${longitude - _viewboxDelta},'
               '${latitude + _viewboxDelta},'
               '${longitude + _viewboxDelta},'
               '${latitude - _viewboxDelta}',
@@ -150,8 +152,9 @@ class NominatimPlaceSearchService implements PlaceSearchService {
       }
 
       places.sort(
-        (a, b) => (a.distanceMeters ?? double.infinity)
-            .compareTo(b.distanceMeters ?? double.infinity),
+        (a, b) => (a.distanceMeters ?? double.infinity).compareTo(
+          b.distanceMeters ?? double.infinity,
+        ),
       );
       return places;
     } catch (e, stack) {
@@ -180,7 +183,10 @@ class NominatimPlaceSearchService implements PlaceSearchService {
   }
 
   PlaceInfo? _toPlace(
-      Map<dynamic, dynamic> item, double refLat, double refLon) {
+    Map<dynamic, dynamic> item,
+    double refLat,
+    double refLon,
+  ) {
     final lat = double.tryParse(item['lat']?.toString() ?? '');
     final lon = double.tryParse(item['lon']?.toString() ?? '');
     if (lat == null || lon == null) return null;
@@ -257,7 +263,8 @@ class NominatimPlaceSearchService implements PlaceSearchService {
 
     final dLat = toRadians(lat2 - lat1);
     final dLon = toRadians(lon2 - lon1);
-    final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
+    final a =
+        math.sin(dLat / 2) * math.sin(dLat / 2) +
         math.cos(toRadians(lat1)) *
             math.cos(toRadians(lat2)) *
             math.sin(dLon / 2) *

--- a/lib/services/place_search_service.dart
+++ b/lib/services/place_search_service.dart
@@ -58,13 +58,17 @@ abstract class PlaceSearchService {
 /// 见 https://operations.osmfoundation.org/policies/nominatim/。
 /// 这里按 [_minRequestInterval] 串行节流；调用方（选点页）另有输入防抖。
 class NominatimPlaceSearchService implements PlaceSearchService {
-  NominatimPlaceSearchService({NetworkService? networkService})
-      : _networkService = networkService;
+  NominatimPlaceSearchService({
+    NetworkService? networkService,
+    Duration? minRequestInterval,
+  })  : _networkService = networkService,
+        _minRequestInterval = minRequestInterval ?? _defaultMinRequestInterval;
 
   static const String _searchUrl = 'https://nominatim.openstreetmap.org/search';
   static const String _userAgent =
       'ThoughtEcho/3.4 (https://github.com/Shangjin-Xiao/ThoughtEcho)';
-  static const Duration _minRequestInterval = Duration(milliseconds: 1100);
+  static const Duration _defaultMinRequestInterval =
+      Duration(milliseconds: 1100);
 
   /// 搜索框限定在参考点周围这么多度的方框内，约 ±11 公里。
   ///
@@ -73,7 +77,18 @@ class NominatimPlaceSearchService implements PlaceSearchService {
 
   final NetworkService? _networkService;
 
+  /// 两次请求之间的最小间隔。测试里调小，免得每个用例真等一秒多。
+  final Duration _minRequestInterval;
+
   DateTime _lastRequestAt = DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// 把限流排成一条队。
+  ///
+  /// 只判断「距上次请求过了多久」是不够的：两个并发调用会读到同一个
+  /// [_lastRequestAt]、等同样长的时间，然后一起发出去——正好违反这个类
+  /// 声称的 1 请求/秒。挂在同一条链上，后来者要等前一个把自己的间隔占满
+  /// 才轮到它记时间戳。
+  Future<void> _throttleQueue = Future<void>.value();
 
   NetworkService get _network => _networkService ?? NetworkService.instance;
 
@@ -151,12 +166,17 @@ class NominatimPlaceSearchService implements PlaceSearchService {
   }
 
   /// 距上次请求不足 [_minRequestInterval] 时补足等待，满足 Nominatim 的限流。
-  Future<void> _throttle() async {
-    final elapsed = DateTime.now().difference(_lastRequestAt);
-    if (elapsed < _minRequestInterval) {
-      await Future<void>.delayed(_minRequestInterval - elapsed);
-    }
-    _lastRequestAt = DateTime.now();
+  Future<void> _throttle() {
+    final reserved = _throttleQueue.then((_) async {
+      final elapsed = DateTime.now().difference(_lastRequestAt);
+      if (elapsed < _minRequestInterval) {
+        await Future<void>.delayed(_minRequestInterval - elapsed);
+      }
+      _lastRequestAt = DateTime.now();
+    });
+    // 队尾吞掉异常，否则一次失败会把后面所有请求一起带崩
+    _throttleQueue = reserved.catchError((Object _) {});
+    return reserved;
   }
 
   PlaceInfo? _toPlace(

--- a/lib/services/place_search_service.dart
+++ b/lib/services/place_search_service.dart
@@ -1,0 +1,247 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import '../utils/app_logger.dart';
+import '../utils/i18n_language.dart';
+import 'network_service.dart';
+
+/// 地图选点页列出的一个地点。
+///
+/// 和 `Quote.poiName` 的关系：用户在列表里选中哪一条，[name] 就成为那条笔记的
+/// `poiName`，[latitude]/[longitude] 成为它的坐标。
+class PlaceInfo {
+  const PlaceInfo({
+    required this.name,
+    required this.latitude,
+    required this.longitude,
+    this.address,
+    this.distanceMeters,
+  });
+
+  /// 地点名，如"芝公园"。列表主行显示的就是它。
+  final String name;
+
+  final double latitude;
+  final double longitude;
+
+  /// 街道级地址，列表副行显示，用来区分同名地点。
+  final String? address;
+
+  /// 距离参考点的直线距离（米）。搜索结果按它排序；为 null 时排在最后。
+  final double? distanceMeters;
+}
+
+/// 地点搜索。
+///
+/// 单独抽出来是为了不把 POI 检索塞进 [LocationService]——后者管的是设备定位、
+/// 坐标缓存和地址格式化。换成高德/腾讯这类国内 POI 源时只需另写一个实现。
+abstract class PlaceSearchService {
+  /// 在 [latitude]/[longitude] 附近按 [query] 搜索地点，按距离升序返回。
+  ///
+  /// [query] 为空时返回空列表——不做「自动列出附近地点」，那会把公共
+  /// Nominatim 当 autocomplete 用，必被限流。
+  ///
+  /// [localeCode] 决定返回的地名用哪种语言。
+  Future<List<PlaceInfo>> searchNearby(
+    double latitude,
+    double longitude, {
+    required String query,
+    String? localeCode,
+    int limit = 20,
+  });
+}
+
+/// Nominatim（OpenStreetMap）实现：免费、无需 API Key，与项目已有的反向地理
+/// 编码同源。
+///
+/// 使用条款要求单来源不超过 1 请求/秒并带上可识别的 User-Agent，
+/// 见 https://operations.osmfoundation.org/policies/nominatim/。
+/// 这里按 [_minRequestInterval] 串行节流；调用方（选点页）另有输入防抖。
+class NominatimPlaceSearchService implements PlaceSearchService {
+  NominatimPlaceSearchService({NetworkService? networkService})
+      : _networkService = networkService;
+
+  static const String _searchUrl = 'https://nominatim.openstreetmap.org/search';
+  static const String _userAgent =
+      'ThoughtEcho/3.4 (https://github.com/Shangjin-Xiao/ThoughtEcho)';
+  static const Duration _minRequestInterval = Duration(milliseconds: 1100);
+
+  /// 搜索框限定在参考点周围这么多度的方框内，约 ±11 公里。
+  ///
+  /// 不限定的话「星巴克」会搜出全球结果，前几条大概率不在用户所在的城市。
+  static const double _viewboxDelta = 0.1;
+
+  final NetworkService? _networkService;
+
+  DateTime _lastRequestAt = DateTime.fromMillisecondsSinceEpoch(0);
+
+  NetworkService get _network => _networkService ?? NetworkService.instance;
+
+  @override
+  Future<List<PlaceInfo>> searchNearby(
+    double latitude,
+    double longitude, {
+    required String query,
+    String? localeCode,
+    int limit = 20,
+  }) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) return const [];
+
+    try {
+      await _throttle();
+
+      final uri = Uri.parse(_searchUrl).replace(
+        queryParameters: <String, String>{
+          'q': trimmed,
+          'format': 'json',
+          'addressdetails': '1',
+          'limit': '$limit',
+          'viewbox': '${longitude - _viewboxDelta},'
+              '${latitude + _viewboxDelta},'
+              '${longitude + _viewboxDelta},'
+              '${latitude - _viewboxDelta}',
+          'bounded': '1',
+        },
+      );
+
+      final response = await _network.get(
+        uri.toString(),
+        headers: {
+          'Accept-Language': I18nLanguage.buildAcceptLanguage(
+            I18nLanguage.appLanguageOrSystem(localeCode),
+          ),
+          'User-Agent': _userAgent,
+        },
+        timeoutSeconds: 10,
+      );
+
+      if (response.statusCode != 200) {
+        logDebug(
+          'Nominatim 地点搜索返回 ${response.statusCode}',
+          source: 'PlaceSearchService',
+        );
+        return const [];
+      }
+
+      final decoded = json.decode(response.body);
+      if (decoded is! List) return const [];
+
+      final places = <PlaceInfo>[];
+      for (final item in decoded) {
+        if (item is! Map) continue;
+        final place = _toPlace(item, latitude, longitude);
+        if (place != null) places.add(place);
+      }
+
+      places.sort(
+        (a, b) => (a.distanceMeters ?? double.infinity)
+            .compareTo(b.distanceMeters ?? double.infinity),
+      );
+      return places;
+    } catch (e, stack) {
+      logError(
+        '地点搜索失败',
+        error: e,
+        stackTrace: stack,
+        source: 'PlaceSearchService',
+      );
+      return const [];
+    }
+  }
+
+  /// 距上次请求不足 [_minRequestInterval] 时补足等待，满足 Nominatim 的限流。
+  Future<void> _throttle() async {
+    final elapsed = DateTime.now().difference(_lastRequestAt);
+    if (elapsed < _minRequestInterval) {
+      await Future<void>.delayed(_minRequestInterval - elapsed);
+    }
+    _lastRequestAt = DateTime.now();
+  }
+
+  PlaceInfo? _toPlace(
+      Map<dynamic, dynamic> item, double refLat, double refLon) {
+    final lat = double.tryParse(item['lat']?.toString() ?? '');
+    final lon = double.tryParse(item['lon']?.toString() ?? '');
+    if (lat == null || lon == null) return null;
+
+    final name = _extractName(item);
+    if (name.isEmpty) return null;
+
+    return PlaceInfo(
+      name: name,
+      latitude: lat,
+      longitude: lon,
+      address: _extractAddress(item),
+      distanceMeters: distanceBetween(refLat, refLon, lat, lon),
+    );
+  }
+
+  /// 地点名：优先 OSM 要素名，其次 address 里的类型化别名，最后取
+  /// `display_name` 的第一段。
+  static String _extractName(Map<dynamic, dynamic> item) {
+    final direct = item['name'];
+    if (direct is String && direct.trim().isNotEmpty) return direct.trim();
+
+    final address = item['address'];
+    if (address is Map) {
+      const keys = [
+        'amenity',
+        'building',
+        'shop',
+        'tourism',
+        'leisure',
+        'historic',
+        'office',
+        'road',
+      ];
+      for (final key in keys) {
+        final value = address[key];
+        if (value is String && value.trim().isNotEmpty) return value.trim();
+      }
+    }
+
+    final display = item['display_name']?.toString() ?? '';
+    final head = display.split(',').first.trim();
+    return head;
+  }
+
+  /// 副行地址：街道 + 区 + 市，用来区分「星巴克」这种重名地点。
+  static String? _extractAddress(Map<dynamic, dynamic> item) {
+    final address = item['address'];
+    if (address is! Map) return null;
+
+    final parts = <String>[];
+    for (final key in ['road', 'suburb', 'city', 'town', 'state']) {
+      final value = address[key];
+      if (value is String && value.trim().isNotEmpty) {
+        final trimmed = value.trim();
+        if (parts.isEmpty || parts.last != trimmed) parts.add(trimmed);
+      }
+    }
+    return parts.isEmpty ? null : parts.join(' · ');
+  }
+
+  /// 两点间的大圆距离（米），Haversine 公式。
+  ///
+  /// 不用 `Geolocator.distanceBetween`：那要求平台通道就绪，而这里只是给搜索
+  /// 结果排序，测试里也跑不起平台通道。
+  static double distanceBetween(
+    double lat1,
+    double lon1,
+    double lat2,
+    double lon2,
+  ) {
+    const earthRadiusMeters = 6371000.0;
+    double toRadians(double degrees) => degrees * math.pi / 180;
+
+    final dLat = toRadians(lat2 - lat1);
+    final dLon = toRadians(lon2 - lon1);
+    final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
+        math.cos(toRadians(lat1)) *
+            math.cos(toRadians(lat2)) *
+            math.sin(dLon / 2) *
+            math.sin(dLon / 2);
+    return earthRadiusMeters * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
+  }
+}

--- a/lib/widgets/add_note_dialog.dart
+++ b/lib/widgets/add_note_dialog.dart
@@ -1374,17 +1374,9 @@ class _AddNoteDialogState extends State<AddNoteDialog>
           localeCode: localeCode,
         );
         if (addressInfo != null && mounted) {
-          // 使用 country,province,city,district 拼成标准存储格式，
-          // 而不是 formatted_address（带空格进行英文拼接的格式），
-          // 避免 formatLocationForDisplay 解析失败导致显示英文。
-          final country = addressInfo['country'] ?? '';
-          final province = addressInfo['province'] ?? '';
-          final city = addressInfo['city'] ?? '';
-          final district = addressInfo['district'] ?? '';
-          final standardAddress = '$country,$province,$city,$district';
-          final hasAnyField =
-              country.isNotEmpty || province.isNotEmpty || city.isNotEmpty;
-          if (hasAnyField) {
+          final standardAddress =
+              LocationService.buildStorageLocation(addressInfo);
+          if (standardAddress != null) {
             _controller.setOriginalLocationData(
               standardAddress,
               _controller.originalLatitude,

--- a/lib/widgets/map/osm_map_layers.dart
+++ b/lib/widgets/map/osm_map_layers.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../utils/app_logger.dart';
+
+/// 两个地图页共用的 OpenStreetMap 瓦片配置与版权标注。
+///
+/// OSM 的瓦片使用条款要求带上可识别的 User-Agent、并显著标注数据来源
+/// （https://operations.osmfoundation.org/policies/tiles）。集中在一处，免得
+/// 两个页面各写一份、其中一份忘了标注。
+abstract final class OsmMapLayers {
+  static const String _tileUrlTemplate =
+      'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+  /// 用于 User-Agent，与 Android 的 applicationId 一致。
+  static const String _packageName = 'com.shangjin.thoughtecho';
+
+  /// 官方瓦片只出到 19 级。
+  ///
+  /// 不设的话再往里放大会去请求根本不存在的瓦片，地图变成一片空白；设了之后
+  /// 引擎会拉伸第 19 级继续放大。
+  static const int _maxNativeZoom = 19;
+
+  static final Uri _copyrightUri =
+      Uri.parse('https://www.openstreetmap.org/copyright');
+
+  /// 瓦片层。作为 [FlutterMap] 的第一个 child。
+  static TileLayer tiles() => TileLayer(
+        urlTemplate: _tileUrlTemplate,
+        userAgentPackageName: _packageName,
+        maxNativeZoom: _maxNativeZoom,
+      );
+
+  /// 版权标注层。放在 [FlutterMap] 的最后一个 child，压在瓦片之上。
+  static Widget attribution() => SimpleAttributionWidget(
+        source: const Text('OpenStreetMap contributors'),
+        onTap: _openCopyrightPage,
+      );
+
+  static Future<void> _openCopyrightPage() async {
+    try {
+      await launchUrl(_copyrightUri, mode: LaunchMode.externalApplication);
+    } catch (e) {
+      // 打不开浏览器不影响看地图，记一笔就够了
+      logDebug('打开 OpenStreetMap 版权页失败: $e', source: 'OsmMapLayers');
+    }
+  }
+}

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -242,17 +242,20 @@ class QuoteItemWidget extends StatefulWidget {
       dayPeriod: quote.dayPeriod,
       showExactTime: showExactTime,
     );
-    final locationText = quote.hasLocation
-        ? ((quote.location != null &&
-                LocationService.formatLocationForDisplay(
-                  quote.location,
-                ).isNotEmpty)
-            ? LocationService.formatLocationForDisplay(quote.location)
-            : LocationService.formatCoordinates(
+    // 显示优先级：地点名（拼上行政区）> 行政区 > 坐标。
+    // 用户在编辑器里特意选过"芝公园"，卡片上就不该只写"东京都·港区"。
+    final displayLocation = LocationService.formatPoiForDisplay(
+      quote.poiName,
+      quote.location,
+    );
+    final locationText = displayLocation.isNotEmpty
+        ? displayLocation
+        : (quote.hasCoordinates
+            ? LocationService.formatCoordinates(
                 quote.latitude,
                 quote.longitude,
-              ))
-        : null;
+              )
+            : null);
     final weatherText = quote.weather != null
         ? '${WeatherService.getLocalizedWeatherDescription(l10n, quote.weather!)}'
             '${quote.temperature != null ? ' ${quote.temperature}' : ''}'

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.8"
+  animated_stack_widget:
+    dependency: transitive
+    description:
+      name: animated_stack_widget
+      sha256: ce4788dd158768c9d4388354b6fb72600b78e041a37afc4c279c63ecafcb9408
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   archive:
     dependency: "direct main"
     description:
@@ -337,6 +345,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dart_earcut:
+    dependency: transitive
+    description:
+      name: dart_earcut
+      sha256: e485001bfc05dcbc437d7bfb666316182e3522d4c3f9668048e004d0eb2ce43b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  dart_polylabel2:
+    dependency: transitive
+    description:
+      name: dart_polylabel2
+      sha256: "7eeab15ce72894e4bdba6a8765712231fc81be0bd95247de4ad9966abc57adc6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   dart_quill_delta:
     dependency: transitive
     description:
@@ -712,6 +736,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_map:
+    dependency: "direct main"
+    description:
+      name: flutter_map
+      sha256: ce1debbb29cade61964334b2a19c7c76e5bb2ef7dacf126c6424ee44036232f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  flutter_map_marker_cluster:
+    dependency: "direct main"
+    description:
+      name: flutter_map_marker_cluster
+      sha256: "04a20d9b1c3a18b67cc97c1240f75361ab98449b735ab06f2534ece0d0794733"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.2"
+  flutter_map_marker_popup:
+    dependency: transitive
+    description:
+      name: flutter_map_marker_popup
+      sha256: "93ab18b30e6d54428bfe6a4b84288d1cc41bfa26648cc516844f8d126ced9165"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.1"
   flutter_markdown_plus:
     dependency: "direct main"
     description:
@@ -1120,10 +1168,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -1156,6 +1204,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.12.0"
+  latlong2:
+    dependency: "direct main"
+    description:
+      name: latlong2
+      sha256: "98227922caf49e6056f91b6c56945ea1c7b166f28ffcd5fb8e72fc0b453cc8fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -1264,10 +1320,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1280,10 +1336,18 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
+  mgrs_dart:
+    dependency: transitive
+    description:
+      name: mgrs_dart
+      sha256: "385e7168ecc77eb545220223c49eef8ab249da7bf57f22781c40a04d23fb196f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   mime:
     dependency: "direct main"
     description:
@@ -1708,6 +1772,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3+1"
+  proj4dart:
+    dependency: transitive
+    description:
+      name: proj4dart
+      sha256: ddcedc1f7876e62717de43ab3491e2829bdad0b028261805f94aa080967e5859
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   provider:
     dependency: "direct main"
     description:
@@ -1956,6 +2028,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  simple_sparse_list:
+    dependency: transitive
+    description:
+      name: simple_sparse_list
+      sha256: aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -2133,26 +2213,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.18"
   timezone:
     dependency: "direct main"
     description:
@@ -2169,6 +2249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      sha256: a6f7bcfc8ea1d5ce1f6c0b1c39117a9919f4953edd9fd7a64090a9796c499b57
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9"
   url_launcher:
     dependency: "direct main"
     description:
@@ -2269,10 +2357,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   video_player:
     dependency: "direct main"
     description:
@@ -2409,6 +2497,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  wkt_parser:
+    dependency: transitive
+    description:
+      name: wkt_parser
+      sha256: "8a555fc60de3116c00aad67891bcab20f81a958e4219cc106e3c037aa3937f13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   workmanager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,6 +92,10 @@ dependencies:
   ddgs: ^0.3.2
   html: ^0.15.4
   flutter_slidable: ^3.1.1
+  # 地图：OpenStreetMap 瓦片，免费无 API Key，和已有的 Nominatim 反查同一套生态。
+  flutter_map: ^8.3.1
+  latlong2: ^0.9.1 # flutter_map 的经纬度类型
+  flutter_map_marker_cluster: ^8.2.2 # 地图回忆页的标记聚合
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/services/database_quotes_with_coordinates_test.dart
+++ b/test/unit/services/database_quotes_with_coordinates_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/services/database_service.dart';
+
+/// 地图回忆页的取数：只要有坐标的、没被删也没被隐藏的笔记。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  group('DatabaseService.getQuotesWithCoordinates', () {
+    late DatabaseService service;
+    late Database db;
+
+    setUp(() async {
+      service = DatabaseService();
+
+      db = await databaseFactory.openDatabase(inMemoryDatabasePath);
+      await db.execute('''
+          CREATE TABLE quotes(
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            date TEXT NOT NULL,
+            source TEXT,
+            source_author TEXT,
+            source_work TEXT,
+            ai_analysis TEXT,
+            sentiment TEXT,
+            keywords TEXT,
+            summary TEXT,
+            category_id TEXT DEFAULT '',
+            color_hex TEXT,
+            location TEXT,
+            latitude REAL,
+            longitude REAL,
+            poi_name TEXT,
+            weather TEXT,
+            temperature TEXT,
+            edit_source TEXT,
+            delta_content TEXT,
+            day_period TEXT,
+            last_modified TEXT,
+            favorite_count INTEGER DEFAULT 0,
+            is_deleted INTEGER DEFAULT 0,
+            deleted_at TEXT
+          )
+        ''');
+      await db.execute('''
+          CREATE TABLE categories(
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            is_default BOOLEAN DEFAULT 0,
+            icon_name TEXT,
+            last_modified TEXT
+          )
+        ''');
+      await db.execute('''
+          CREATE TABLE quote_tags(
+            quote_id TEXT NOT NULL,
+            tag_id TEXT NOT NULL,
+            PRIMARY KEY (quote_id, tag_id)
+          )
+        ''');
+      await db.execute('''
+          CREATE TABLE media_references (
+            id TEXT PRIMARY KEY,
+            file_path TEXT NOT NULL,
+            quote_id TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(file_path, quote_id)
+          )
+        ''');
+      await db.execute('''
+          CREATE TABLE quote_tombstones (
+            quote_id TEXT PRIMARY KEY,
+            deleted_at TEXT NOT NULL,
+            device_id TEXT
+          )
+        ''');
+
+      DatabaseService.setTestDatabase(db);
+      await service.init();
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('只返回带坐标的笔记，没坐标的不上地图', () async {
+      await service.addQuote(
+        Quote(
+          id: 'with-coordinates',
+          content: '在芝公园写的',
+          date: '2026-08-01T10:00:00.000Z',
+          latitude: 35.6547,
+          longitude: 139.7490,
+          poiName: '芝公园',
+        ),
+      );
+      await service.addQuote(
+        Quote(
+          id: 'without-coordinates',
+          content: '在家里写的',
+          date: '2026-08-02T10:00:00.000Z',
+        ),
+      );
+
+      final points = await service.getQuotesWithCoordinates();
+
+      expect(points.map((p) => p.id), ['with-coordinates']);
+      expect(points.single.latitude, closeTo(35.6547, 0.0001));
+      expect(points.single.longitude, closeTo(139.7490, 0.0001));
+    });
+
+    test('回收站里的笔记不上地图', () async {
+      await service.addQuote(
+        Quote(
+          id: 'kept',
+          content: '保留',
+          date: '2026-08-01T10:00:00.000Z',
+          latitude: 31.2304,
+          longitude: 121.4737,
+        ),
+      );
+      await service.addQuote(
+        Quote(
+          id: 'trashed',
+          content: '删掉',
+          date: '2026-08-02T10:00:00.000Z',
+          latitude: 39.9042,
+          longitude: 116.4074,
+        ),
+      );
+
+      await service.deleteQuote('trashed');
+
+      final points = await service.getQuotesWithCoordinates();
+
+      expect(points.map((p) => p.id), ['kept']);
+    });
+
+    test('隐藏笔记不上地图', () async {
+      await service.addQuote(
+        Quote(
+          id: 'visible',
+          content: '公开的',
+          date: '2026-08-01T10:00:00.000Z',
+          latitude: 31.2304,
+          longitude: 121.4737,
+        ),
+      );
+      await service.addQuote(
+        Quote(
+          id: 'hidden',
+          content: '隐藏的',
+          date: '2026-08-02T10:00:00.000Z',
+          latitude: 39.9042,
+          longitude: 116.4074,
+          tagIds: const [DatabaseService.hiddenTagId],
+        ),
+      );
+
+      final points = await service.getQuotesWithCoordinates();
+
+      expect(points.map((p) => p.id), ['visible']);
+    });
+
+    test('按时间倒序返回', () async {
+      await service.addQuote(
+        Quote(
+          id: 'older',
+          content: '早一点',
+          date: '2026-08-01T10:00:00.000Z',
+          latitude: 31.2304,
+          longitude: 121.4737,
+        ),
+      );
+      await service.addQuote(
+        Quote(
+          id: 'newer',
+          content: '晚一点',
+          date: '2026-08-05T10:00:00.000Z',
+          latitude: 39.9042,
+          longitude: 116.4074,
+        ),
+      );
+
+      final points = await service.getQuotesWithCoordinates();
+
+      expect(points.map((p) => p.id), ['newer', 'older']);
+    });
+  });
+}

--- a/test/unit/services/database_quotes_with_coordinates_test.dart
+++ b/test/unit/services/database_quotes_with_coordinates_test.dart
@@ -3,6 +3,8 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:thoughtecho/models/quote_model.dart';
 import 'package:thoughtecho/services/database_service.dart';
 
+import '../../test_harness.dart';
+
 /// 地图回忆页的取数：只要有坐标的、没被删也没被隐藏的笔记。
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -14,6 +16,8 @@ void main() {
     late Database db;
 
     setUp(() async {
+      await TestHarness.initialize();
+      DatabaseService.clearTestDatabase();
       service = DatabaseService();
 
       db = await databaseFactory.openDatabase(inMemoryDatabasePath);
@@ -84,6 +88,7 @@ void main() {
     });
 
     tearDown(() async {
+      DatabaseService.clearTestDatabase();
       await db.close();
     });
 
@@ -171,10 +176,7 @@ void main() {
       // 就是一张加载成功的空地图，数据库故障被藏起来了。
       await db.close();
 
-      expect(
-        () => service.getQuotesWithCoordinates(),
-        throwsA(isA<Object>()),
-      );
+      expect(() => service.getQuotesWithCoordinates(), throwsA(isA<Object>()));
     });
 
     test('按时间倒序返回', () async {
@@ -200,6 +202,42 @@ void main() {
       final points = await service.getQuotesWithCoordinates();
 
       expect(points.map((p) => p.id), ['newer', 'older']);
+    });
+
+    test('越界坐标不上地图', () async {
+      await service.addQuote(
+        Quote(
+          id: 'out-of-bounds-lat',
+          content: '纬度超标',
+          date: '2026-08-01T10:00:00.000Z',
+          latitude: 91.0,
+          longitude: 120.0,
+        ),
+      );
+      await service.addQuote(
+        Quote(
+          id: 'out-of-bounds-lon',
+          content: '经度超标',
+          date: '2026-08-02T10:00:00.000Z',
+          latitude: 30.0,
+          longitude: -185.0,
+        ),
+      );
+      await service.addQuote(
+        Quote(
+          id: 'valid-bounds',
+          content: '合法边界',
+          date: '2026-08-03T10:00:00.000Z',
+          latitude: -90.0,
+          longitude: 180.0,
+        ),
+      );
+
+      final points = await service.getQuotesWithCoordinates();
+
+      expect(points.map((p) => p.id), ['valid-bounds']);
+      expect(points.single.latitude, -90.0);
+      expect(points.single.longitude, 180.0);
     });
   });
 }

--- a/test/unit/services/database_quotes_with_coordinates_test.dart
+++ b/test/unit/services/database_quotes_with_coordinates_test.dart
@@ -166,6 +166,17 @@ void main() {
       expect(points.map((p) => p.id), ['visible']);
     });
 
+    test('查询失败时抛出，不把故障压成「还没有带位置的笔记」', () async {
+      // 地图页靠「空列表」判断该显示引导文案。把失败也压成空，用户看到的
+      // 就是一张加载成功的空地图，数据库故障被藏起来了。
+      await db.close();
+
+      expect(
+        () => service.getQuotesWithCoordinates(),
+        throwsA(isA<Object>()),
+      );
+    });
+
     test('按时间倒序返回', () async {
       await service.addQuote(
         Quote(

--- a/test/unit/services/location_format_test.dart
+++ b/test/unit/services/location_format_test.dart
@@ -180,4 +180,107 @@ void main() {
       expect(LocationService.cleanGeocodingText(null), '');
     });
   });
+
+  group('LocationService.formatPoiForDisplay', () {
+    test('拼上最细一级行政区，区县在前地点名在后', () {
+      expect(
+        LocationService.formatPoiForDisplay('芝公园', '日本,东京都,,港区'),
+        '港区·芝公园',
+      );
+    });
+
+    test('没有区县时退到城市', () {
+      expect(
+        LocationService.formatPoiForDisplay('西湖音乐喷泉', '中国,浙江省,杭州市,'),
+        '杭州市·西湖音乐喷泉',
+      );
+    });
+
+    test('地点名和行政区同名时不重复', () {
+      expect(
+        LocationService.formatPoiForDisplay('港区', '日本,东京都,,港区'),
+        '港区',
+      );
+    });
+
+    test('没有地址时只显示地点名', () {
+      expect(LocationService.formatPoiForDisplay('故宫博物院', null), '故宫博物院');
+      expect(LocationService.formatPoiForDisplay('故宫博物院', ''), '故宫博物院');
+    });
+
+    test('地址是待解析/解析失败标记时只显示地点名', () {
+      expect(
+        LocationService.formatPoiForDisplay(
+          '故宫博物院',
+          LocationService.kAddressPending,
+        ),
+        '故宫博物院',
+      );
+      expect(
+        LocationService.formatPoiForDisplay(
+          '故宫博物院',
+          LocationService.kAddressFailed,
+        ),
+        '故宫博物院',
+      );
+    });
+
+    test('没有地点名时退回行政区显示，老笔记显示不变', () {
+      expect(
+        LocationService.formatPoiForDisplay(
+            null, 'China,Beijing,Beijing,Chaoyang'),
+        'Beijing·Chaoyang',
+      );
+      expect(
+        LocationService.formatPoiForDisplay(
+            '   ', 'China,Beijing,Beijing,Chaoyang'),
+        'Beijing·Chaoyang',
+      );
+    });
+  });
+
+  group('LocationService.buildStorageLocation', () {
+    test('拼成逗号分隔的入库格式，而不是给人看的 formatted_address', () {
+      final address = <String, String?>{
+        'country': 'China',
+        'province': 'Beijing',
+        'city': 'Beijing',
+        'district': 'Chaoyang',
+        'formatted_address': 'China, Beijing, Beijing, Chaoyang',
+      };
+
+      final stored = LocationService.buildStorageLocation(address);
+
+      expect(stored, 'China,Beijing,Beijing,Chaoyang');
+      // 拼出来的串必须能被展示函数解析回去
+      expect(
+          LocationService.formatLocationForDisplay(stored), 'Beijing·Chaoyang');
+    });
+
+    test('缺区县时留空位，段数不变', () {
+      expect(
+        LocationService.buildStorageLocation(<String, String?>{
+          'country': '中国',
+          'province': '浙江省',
+          'city': '杭州市',
+        }),
+        '中国,浙江省,杭州市,',
+      );
+    });
+
+    test('没有任何行政区时返回 null，让调用方退回坐标', () {
+      expect(LocationService.buildStorageLocation(null), isNull);
+      expect(LocationService.buildStorageLocation(const <String, String?>{}),
+          isNull);
+      expect(
+        LocationService.buildStorageLocation(<String, String?>{
+          'country': '',
+          'province': '',
+          'city': '',
+          'district': '朝阳区',
+        }),
+        isNull,
+      );
+    });
+  });
 }

--- a/test/unit/services/location_format_test.dart
+++ b/test/unit/services/location_format_test.dart
@@ -170,12 +170,11 @@ void main() {
       expect(LocationService.cleanGeocodingText('韩国 / 南韓'), '韩国');
       expect(LocationService.cleanGeocodingText('法国;法國'), '法国');
       expect(LocationService.cleanGeocodingText('澳大利亚;澳洲'), '澳大利亚');
+      expect(LocationService.cleanGeocodingText('法兰西岛大区 / 法蘭西島大區'), '法兰西岛大区');
       expect(
-        LocationService.cleanGeocodingText('法兰西岛大区 / 法蘭西島大區'),
-        '法兰西岛大区',
+        LocationService.cleanGeocodingText('Grand Londres'),
+        'Grand Londres',
       );
-      expect(
-          LocationService.cleanGeocodingText('Grand Londres'), 'Grand Londres');
       expect(LocationService.cleanGeocodingText(''), '');
       expect(LocationService.cleanGeocodingText(null), '');
     });
@@ -197,10 +196,7 @@ void main() {
     });
 
     test('地点名和行政区同名时不重复', () {
-      expect(
-        LocationService.formatPoiForDisplay('港区', '日本,东京都,,港区'),
-        '港区',
-      );
+      expect(LocationService.formatPoiForDisplay('港区', '日本,东京都,,港区'), '港区');
     });
 
     test('没有地址时只显示地点名', () {
@@ -228,12 +224,16 @@ void main() {
     test('没有地点名时退回行政区显示，老笔记显示不变', () {
       expect(
         LocationService.formatPoiForDisplay(
-            null, 'China,Beijing,Beijing,Chaoyang'),
+          null,
+          'China,Beijing,Beijing,Chaoyang',
+        ),
         'Beijing·Chaoyang',
       );
       expect(
         LocationService.formatPoiForDisplay(
-            '   ', 'China,Beijing,Beijing,Chaoyang'),
+          '   ',
+          'China,Beijing,Beijing,Chaoyang',
+        ),
         'Beijing·Chaoyang',
       );
     });
@@ -254,7 +254,9 @@ void main() {
       expect(stored, 'China,Beijing,Beijing,Chaoyang');
       // 拼出来的串必须能被展示函数解析回去
       expect(
-          LocationService.formatLocationForDisplay(stored), 'Beijing·Chaoyang');
+        LocationService.formatLocationForDisplay(stored),
+        'Beijing·Chaoyang',
+      );
     });
 
     test('缺区县时留空位，段数不变', () {
@@ -270,8 +272,10 @@ void main() {
 
     test('没有任何行政区时返回 null，让调用方退回坐标', () {
       expect(LocationService.buildStorageLocation(null), isNull);
-      expect(LocationService.buildStorageLocation(const <String, String?>{}),
-          isNull);
+      expect(
+        LocationService.buildStorageLocation(const <String, String?>{}),
+        isNull,
+      );
       expect(
         LocationService.buildStorageLocation(<String, String?>{
           'country': '',

--- a/test/unit/services/place_search_service_test.dart
+++ b/test/unit/services/place_search_service_test.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/services/network_service.dart';
+import 'package:thoughtecho/services/place_search_service.dart';
+import 'package:thoughtecho/utils/http_response.dart';
+
+/// 只回放一段固定响应，并记下请求长什么样。
+class _FakeNetworkService implements NetworkService {
+  _FakeNetworkService(this.response);
+
+  final HttpResponse response;
+
+  int calls = 0;
+  Uri? lastUri;
+  Map<String, String>? lastHeaders;
+
+  @override
+  Future<HttpResponse> get(
+    String url, {
+    Map<String, String>? headers,
+    int? timeoutSeconds,
+  }) async {
+    calls++;
+    lastUri = Uri.parse(url);
+    lastHeaders = headers;
+    return response;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+HttpResponse _jsonResponse(Object body, {int statusCode = 200}) =>
+    HttpResponse(json.encode(body), statusCode, headers: const {});
+
+void main() {
+  // 参考点：北京天安门附近
+  const refLat = 39.9042;
+  const refLon = 116.4074;
+
+  group('NominatimPlaceSearchService.searchNearby', () {
+    test('空关键词不发请求，直接返回空列表', () async {
+      final network = _FakeNetworkService(_jsonResponse(const []));
+      final service = NominatimPlaceSearchService(networkService: network);
+
+      expect(
+        await service.searchNearby(refLat, refLon, query: '   '),
+        isEmpty,
+      );
+      expect(network.calls, 0);
+    });
+
+    test('解析结果并按距离升序排列', () async {
+      final network = _FakeNetworkService(
+        _jsonResponse([
+          {
+            'name': '远处的咖啡馆',
+            'lat': '39.9542',
+            'lon': '116.4074',
+            'type': 'cafe',
+            'address': {'road': '远街', 'city': '北京市'},
+          },
+          {
+            'name': '近处的咖啡馆',
+            'lat': '39.9092',
+            'lon': '116.4074',
+            'type': 'cafe',
+            'address': {'road': '近街', 'city': '北京市'},
+          },
+        ]),
+      );
+      final service = NominatimPlaceSearchService(networkService: network);
+
+      final results = await service.searchNearby(refLat, refLon, query: '咖啡馆');
+
+      expect(results.map((p) => p.name), ['近处的咖啡馆', '远处的咖啡馆']);
+      expect(results.first.address, '近街 · 北京市');
+      expect(
+          results.first.distanceMeters, lessThan(results.last.distanceMeters!));
+    });
+
+    test('没有 name 时退到 address 里的类型化别名', () async {
+      final network = _FakeNetworkService(
+        _jsonResponse([
+          {
+            'lat': '39.9052',
+            'lon': '116.4074',
+            'display_name': '某商场, 东城区, 北京市',
+            'address': {'shop': '某商场', 'city': '北京市'},
+          },
+        ]),
+      );
+      final service = NominatimPlaceSearchService(networkService: network);
+
+      final results = await service.searchNearby(refLat, refLon, query: '商场');
+
+      expect(results.single.name, '某商场');
+    });
+
+    test('坐标缺失的条目被丢掉，不会变成 0,0 的假地点', () async {
+      final network = _FakeNetworkService(
+        _jsonResponse([
+          {'name': '没有坐标的地点'},
+          {'name': '有坐标的地点', 'lat': '39.9052', 'lon': '116.4074'},
+        ]),
+      );
+      final service = NominatimPlaceSearchService(networkService: network);
+
+      final results = await service.searchNearby(refLat, refLon, query: '地点');
+
+      expect(results.map((p) => p.name), ['有坐标的地点']);
+    });
+
+    test('非 200 响应降级为空列表，不抛给调用方', () async {
+      final network = _FakeNetworkService(
+        _jsonResponse(const [], statusCode: 429),
+      );
+      final service = NominatimPlaceSearchService(networkService: network);
+
+      expect(await service.searchNearby(refLat, refLon, query: '咖啡馆'), isEmpty);
+    });
+
+    test('请求带上限定的 viewbox 和可识别的 User-Agent', () async {
+      final network = _FakeNetworkService(_jsonResponse(const []));
+      final service = NominatimPlaceSearchService(networkService: network);
+
+      await service.searchNearby(refLat, refLon,
+          query: '咖啡馆', localeCode: 'zh');
+
+      final params = network.lastUri!.queryParameters;
+      expect(params['q'], '咖啡馆');
+      expect(params['format'], 'json');
+      // bounded=1 + viewbox：不限定的话「咖啡馆」会搜出全球结果
+      expect(params['bounded'], '1');
+      expect(params['viewbox'], isNotNull);
+      expect(network.lastHeaders!['User-Agent'], contains('ThoughtEcho'));
+      expect(network.lastHeaders!['Accept-Language'], startsWith('zh-CN'));
+    });
+  });
+
+  group('NominatimPlaceSearchService.distanceBetween', () {
+    test('同一个点距离为 0', () {
+      expect(
+        NominatimPlaceSearchService.distanceBetween(
+            refLat, refLon, refLat, refLon),
+        0,
+      );
+    });
+
+    test('纬度差 0.01 度约等于 1.1 公里', () {
+      final meters = NominatimPlaceSearchService.distanceBetween(
+        refLat,
+        refLon,
+        refLat + 0.01,
+        refLon,
+      );
+
+      expect(meters, closeTo(1113, 5));
+    });
+  });
+}

--- a/test/unit/services/place_search_service_test.dart
+++ b/test/unit/services/place_search_service_test.dart
@@ -31,6 +31,27 @@ class _FakeNetworkService implements NetworkService {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// 记下每次请求发出的时刻，用来验证限流。
+class _RecordingNetworkService implements NetworkService {
+  _RecordingNetworkService(this.response);
+
+  final HttpResponse response;
+  final List<DateTime> timestamps = [];
+
+  @override
+  Future<HttpResponse> get(
+    String url, {
+    Map<String, String>? headers,
+    int? timeoutSeconds,
+  }) async {
+    timestamps.add(DateTime.now());
+    return response;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 HttpResponse _jsonResponse(Object body, {int statusCode = 200}) =>
     HttpResponse(json.encode(body), statusCode, headers: const {});
 
@@ -136,6 +157,26 @@ void main() {
       expect(params['viewbox'], isNotNull);
       expect(network.lastHeaders!['User-Agent'], contains('ThoughtEcho'));
       expect(network.lastHeaders!['Accept-Language'], startsWith('zh-CN'));
+    });
+  });
+
+  group('NominatimPlaceSearchService 限流', () {
+    test('并发搜索被排成队，两次请求间隔不小于限流窗口', () async {
+      final network = _RecordingNetworkService(_jsonResponse(const []));
+      final service = NominatimPlaceSearchService(
+        networkService: network,
+        minRequestInterval: const Duration(milliseconds: 120),
+      );
+
+      // 防抖搜索还在飞、用户又按了回车，就是这个场景
+      await Future.wait([
+        service.searchNearby(refLat, refLon, query: '咖啡馆'),
+        service.searchNearby(refLat, refLon, query: '公园'),
+      ]);
+
+      expect(network.timestamps, hasLength(2));
+      final gap = network.timestamps[1].difference(network.timestamps[0]);
+      expect(gap, greaterThanOrEqualTo(const Duration(milliseconds: 120)));
     });
   });
 

--- a/test/unit/services/place_search_service_test.dart
+++ b/test/unit/services/place_search_service_test.dart
@@ -161,22 +161,35 @@ void main() {
   });
 
   group('NominatimPlaceSearchService 限流', () {
-    test('并发搜索被排成队，两次请求间隔不小于限流窗口', () async {
+    test('限流窗口内并发来的两条被排成队，不会挤在一起发出去', () async {
+      const interval = Duration(milliseconds: 200);
       final network = _RecordingNetworkService(_jsonResponse(const []));
       final service = NominatimPlaceSearchService(
         networkService: network,
-        minRequestInterval: const Duration(milliseconds: 120),
+        minRequestInterval: interval,
       );
 
-      // 防抖搜索还在飞、用户又按了回车，就是这个场景
+      // 必须先发一次把窗口起点占上。冷启动时第一个调用不等待、且在让出
+      // 事件循环之前就写好了时间戳，第二个自然会等——那种情况下即使没有
+      // 串行化也看不出问题，测不到真正的竞态。
+      await service.searchNearby(refLat, refLon, query: '先来一次');
+
+      // 窗口还没过就并发来两条：不排队的话它们会读到同一个时间戳、算出同样
+      // 的剩余等待，然后一起发出去。
       await Future.wait([
         service.searchNearby(refLat, refLon, query: '咖啡馆'),
         service.searchNearby(refLat, refLon, query: '公园'),
       ]);
 
-      expect(network.timestamps, hasLength(2));
-      final gap = network.timestamps[1].difference(network.timestamps[0]);
-      expect(gap, greaterThanOrEqualTo(const Duration(milliseconds: 120)));
+      expect(network.timestamps, hasLength(3));
+      final firstGap = network.timestamps[1].difference(network.timestamps[0]);
+      final secondGap = network.timestamps[2].difference(network.timestamps[1]);
+
+      // 下限取 150 而不是整个 200：`Future.delayed` 会提前一两毫秒触发，
+      // 卡死在整个间隔上会让这条用例随机变红。而没串行时第二个间隔 ≈ 0，
+      // 和 150 差得很远，照样能抓住。
+      expect(firstGap, greaterThan(const Duration(milliseconds: 150)));
+      expect(secondGap, greaterThan(const Duration(milliseconds: 150)));
     });
   });
 

--- a/test/widget/pages/explore_page_test.dart
+++ b/test/widget/pages/explore_page_test.dart
@@ -345,7 +345,13 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('一条测试笔记'));
+    // 概览比测试视口高（洞察、最近会话、地图入口都在预览上面），不先滚进来
+    // 点击会落在空处。这一条验证的是点击接到了 smartPush，不是预览的位置。
+    final preview = find.text('一条测试笔记');
+    await tester.ensureVisible(preview);
+    await tester.pumpAndSettle();
+
+    await tester.tap(preview);
     await tester.pumpAndSettle();
 
     expect(smartPush.requestedNoteId, 'q1');


### PR DESCRIPTION
## 背景

#247 混着 AI / 对话 / 探索页的大改，954 文件 +225k，而且和当前 `main` 已经**没有共同祖先**（`git merge-base` 为空），没法直接合。这个 PR 只把其中「地图」那条产品线按现行规范重写。

设计依据是 #247 分支里的两份文档（本 PR 不搬运它们）：

- `docs/plans/2026-03-26-map-location-picker-and-note-map.md`
- `docs/plans/2026-04-04-unified-ai-and-map-memory-design.md`

**关键前提**：`main` 其实早就合入了地图的数据层 —— `Quote.poiName`、schema 的 `poi_name` 列 + 索引 + 版本迁移、备份字段、`mapPickerTitle` / `exploreMapMemory` 等 l10n 键、编辑器里 POI 的清除路径，全都在。缺的只是界面：**没有任何地方能写入 `poiName`，写进去了也不会显示**。这个 PR 补的就是这一半。

`#247` 里那两个页面的实现没有直接搬——渐变 marker、写死 `fontSize`、`BorderRadius.circular(18)`、`Colors.black`、裸 `CircularProgressIndicator`、`getAllQuotes()` 全量加载再过滤、bottom sheet 的编辑/删除是空的 SnackBar 占位，按现在的 `AGENTS.md` 逐条都会被打回。按它的**逻辑**重写。

## 改了什么

**依赖**

`flutter_map 8.3.1` + `latlong2` + `flutter_map_marker_cluster`，用 OpenStreetMap 瓦片（免费无 Key，和项目已有的 Nominatim 反查同源）。瓦片配置和版权标注收在 `OsmMapLayers` 一处，满足 OSM 的 User-Agent 与署名要求。

**服务层**

- 新增 `PlaceSearchService`：POI 关键词搜索的抽象 + Nominatim 实现，带 1 请求/秒节流（串行排队）和 viewbox 限定（不限定的话「星巴克」会搜出全球结果）。换高德/腾讯这类国内 POI 源时只需另写一个实现。
- `LocationService` 新增三个能力：
  - `reverseGeocodePoint()` —— 反查任意坐标而**不改动**本服务持有的「当前位置」。选点要的是用户手指点的那个点，走 `getAddressFromLatLng` 会把 `_city` / `_currentAddress` 一起写掉，天气和每日一言就跟着漂了。
  - `formatPoiForDisplay()` —— 把地点名和最细一级行政区拼成「港区·芝公园」。只显示 POI 看不出在哪座城市，只显示行政区又丢了用户特意选的那个点。
  - `buildStorageLocation()` —— 收拢原本在 `editor_location_dialogs` 和 `add_note_dialog` 各写一遍的入库串拼接（第三处出现，按规范抽出来）。
- Nominatim 反查的返回值多带一个 `poi_name`（`name` / `amenity` / `building` / …）。

**数据查询**

新增 `DatabaseService.getQuotesWithCoordinates()` + `QuoteMapPoint` 轻量 DTO。地图不分页——一次要摆下全部足迹，所以只查 `id / date / latitude / longitude` 四列，不整条读 `Quote`（`delta_content` 一列就可能几十 KB）。点开某个 marker 时再按 id 取完整笔记。已排除回收站与隐藏笔记。查询失败**抛出**而不是返回空列表，否则地图页会把故障显示成「你还没记过带位置的笔记」。

**地图选点页 `MapLocationPickerPage`**

- 定针钉在屏幕中心，动的是底图 —— 「选的是哪个点」永远只有一个答案。
- 拖停 900ms 反查一次（Nominatim 限 1 请求/秒，拖动过程每帧反查必被限流）。
- 顶部搜索按钮打开搜索框，主动输入才触发 POI 搜索；不做「自动列出附近地点」。
- 「当前位置」常驻列表顶部，选它表示只记到行政区，不落具体地点名。
- 入口：**复用编辑器现有的位置按钮，长按打开**，不新增按钮。单击仍然是开关自动定位。

**地图回忆页 `MapMemoryPage`**

- 进页即按全部足迹取景（`CameraFit.coordinates`），marker 聚合。
- 点 marker 从底部滑出半屏面板，复用 `QuoteItemWidget`；编辑 / 删除 / 追问都接真实逻辑，编辑或删除后重新取数。
- 空状态仍然给真实地图（落在设备位置附近，取不到再兜底）+ 一张提示卡，而不是一片空白。
- 入口：探索页 Thoughter 入口下方。

**显示**

笔记卡片和编辑器元数据统一为「地点名（拼上行政区）> 行政区 > 坐标」。此前存了 `poiName` 也只显示「城市·区县」。

## 测试

- `test/unit/services/location_format_test.dart` —— 新增 `formatPoiForDisplay` / `buildStorageLocation` 两组共 9 个用例（拼接规则、同名不重复、待解析标记、老笔记显示不变、拼出的串能被展示函数解析回去）。
- `test/unit/services/place_search_service_test.dart` —— 响应解析、按距离排序、name 回退、坐标缺失丢弃、非 200 降级、请求参数与 header、并发限流串行化、Haversine 距离。
- `test/unit/services/database_quotes_with_coordinates_test.dart` —— 只返回带坐标的、排除回收站、排除隐藏、按时间倒序、失败时抛出。
- `test/widget/pages/explore_page_test.dart` —— 新增的地图入口卡把「最近笔记」预览推出了 800×600 的测试视口，点击落空。补 `ensureVisible`，断言不动。

本地在**与 CI 相同的 Flutter 3.47.2**（revision `d3b14c8769`）下，按 CI 的方式跑通了全部三个分片：`test/unit`、`test/widget`、`test/bug_fixes + test/*_test.dart`，全绿。`flutter analyze --no-fatal-infos` 全仓库无新增问题（仅 2 条既有的 `cacheExtent` deprecation）。

> 跑测试前必须先执行 `bash scripts/patch_flutter_quill.sh` —— 否则 `flutter_quill 11.5.0` 在 3.47.x 下编译不过。CI 里有这一步。

## 需要注意

`pubspec.lock` 里有几个与地图无关的版本变化（`intl` / `matcher` / `meta` / `test` / `test_api` / `test_core` / `vector_math`）。这是本地 `flutter pub get` 重新解析 SDK 绑定包的结果，不是手改的；在 3.47.2 下再次 `pub get` 不会继续漂移。手工还原会得到一个下次 `pub get` 立刻重写的 lock，所以保留。

## Sourcery 摘要

通过支持精确选择笔记位置，以及在交互式地图上浏览带地理标签的记忆，完善地图产品线。

新功能：
- 添加地图位置选择器，支持居中图钉选择、附近地点搜索、反向地理编码、当前位置选择，以及为笔记提供精确的 POI 元数据。
- 添加地图记忆视图，显示所有可见且未删除的带地理标签笔记，并支持聚类、空状态、错误状态以及真实笔记操作。
- 在“探索”中提供地图记忆入口，并支持从编辑器现有的位置控件打开地图选择。

错误修复：
- 确保选定的 POI 名称和行政区域在笔记卡片及编辑器元数据中保持一致。
- 防止地图点的反向地理编码更改应用存储的当前位置，避免影响其他功能。
- 保留数据库和地图错误状态，避免将失败显示为空地图结果。

增强功能：
- 集中处理位置存储格式，并添加可复用的地点搜索抽象，支持 Nominatim、有边界搜索、按距离排序、请求节流以及 OSM 署名。
- 添加仅查询坐标的轻量级数据库查询，以高效渲染地图；仅在打开标记时加载完整笔记。
- 添加由位置选择器和记忆视图共享的 OpenStreetMap 地图图层配置。

构建：
- 添加 Flutter 地图、坐标和标记聚类依赖。

测试：
- 添加对位置格式化、地点搜索行为与请求节流，以及坐标查询过滤和排序的单元测试覆盖。
- 更新“探索”组件测试，确保在交互前将屏幕外的笔记内容滚动到可见区域。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过支持精确选择笔记位置和交互式浏览带地理标签的记忆，完善地图产品线。

新功能：
- 添加交互式地图位置选择器，用于为笔记分配精确的兴趣点（POI）和坐标。
- 添加地图记忆视图，显示可见且未删除的带地理标签笔记，并支持聚合和笔记操作。
- 在“探索”中提供地图记忆入口，并支持通过长按编辑器中现有的位置控件打开位置选择器。

错误修复：
- 确保笔记卡片和编辑器元数据中的已选 POI 及行政区域信息保持一致。
- 防止点位逆地理编码修改应用存储的当前位置。
- 将地图加载失败保留为明确的错误，而不是显示为空结果。

增强功能：
- 集中管理位置存储和显示格式，同时新增可复用的 Nominatim 地点搜索功能，支持结果数量限制、按距离排序、本地化和请求节流。
- 使用轻量级坐标查询优化地图加载，并延迟到用户打开标记时再加载完整笔记。
- 集中管理地图功能所使用的 OpenStreetMap 瓦片配置和署名信息。

构建：
- 添加 Flutter 地图、坐标和标记聚合依赖项。

测试：
- 为位置格式化、地点搜索解析与节流，以及坐标查询筛选和排序添加单元测试覆盖。
- 更新“探索”组件测试，使屏幕外内容在交互前滚动到可见区域。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过支持精确的笔记位置选择和交互式浏览带地理标签的记忆，完善地图产品线。

新功能：
- 添加交互式地图位置选择器，用于为笔记分配精确坐标和 POI 元数据。
- 添加地图记忆视图，支持聚合标记、完整范围概览、空状态和错误状态，以及笔记操作。
- 在“探索”中展示地图记忆，并支持通过长按现有编辑器位置控件打开位置选择器。

错误修复：
- 确保笔记卡片和编辑器元数据中的已选 POI 及行政区域信息保持一致。
- 防止点位反向地理编码更改应用存储的当前位置。
- 将地图加载失败保留为明确的错误，而不是将其视为空结果。

增强功能：
- 集中管理位置存储和显示格式，并添加可复用、节流且有边界限制的 Nominatim 地点搜索。
- 使用轻量级坐标查询优化地图加载，并延迟到打开标记时再加载完整笔记。
- 集中管理两种地图体验所使用的 OpenStreetMap 图块配置、署名信息和使用设置。

构建：
- 添加 Flutter 地图、坐标和标记聚合依赖项。

测试：
- 为位置格式化、地点搜索解析与节流，以及坐标查询过滤和排序添加单元测试覆盖。
- 更新“探索”组件测试，在交互前将屏幕外内容滚动到可见区域。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Complete the map product line by enabling precise note location selection and interactive browsing of geotagged memories.

New Features:
- Add an interactive map location picker for assigning precise coordinates and POI metadata to notes.
- Add a map memory view with clustered markers, full-footprint overview, empty and error states, and note actions.
- Expose map memories from Explore and open the picker through a long press on the existing editor location control.

Bug Fixes:
- Keep selected POI and administrative-area information consistent across note cards and editor metadata.
- Prevent point reverse geocoding from changing the application's stored current location.
- Preserve map loading failures as explicit errors instead of treating them as empty results.

Enhancements:
- Centralize location storage and display formatting and add reusable, throttled, bounded Nominatim place search.
- Optimize map loading with lightweight coordinate queries and defer full note loading until a marker is opened.
- Centralize OpenStreetMap tile configuration, attribution, and usage settings for both map experiences.

Build:
- Add Flutter map, coordinate, and marker-clustering dependencies.

Tests:
- Add unit coverage for location formatting, place-search parsing and throttling, and coordinate query filtering and ordering.
- Update Explore widget coverage to scroll off-screen content into view before interaction.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增地图选点器，支持拖动地图、地点搜索、当前位置和确认选点。
  * 笔记编辑时可通过地图选择并保存地点信息。
  * 探索页新增“地图记忆”，支持按位置查看、聚合及打开相关笔记。
  * 支持对地图标记中的笔记进行编辑、删除和 AI 操作。
* **改进**
  * 优化地点名称、行政区和坐标的展示与保存格式。
  * 新增地图相关中英文提示及距离显示。
  * 优化搜索结果处理，避免显示过期结果。
* **测试**
  * 增加地图数据、地点搜索和位置格式化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->