### PR TITLE
fix(db): weather / day_period 的二次迁移也把原值留底

### DIFF
--- a/lib/services/database/schema_repair_adapter.dart
+++ b/lib/services/database/schema_repair_adapter.dart
@@ -372,11 +372,15 @@ class SchemaDataBackfillAdapter {
         var migratedCount = 0;
         final batch = transaction.batch();
         for (final entry in labelToKey.entries) {
-          batch.update(
-            'quotes',
-            {'day_period': entry.value},
-            where: 'day_period = ?',
-            whereArgs: [entry.key],
+          // 原值和新值写在**同一条** UPDATE 里。_ensureBackupColumn 只在建列那一次
+          // 整列快照，列已存在就早退——而这个迁移是可重复触发的
+          // （_checkAndMigrateDayPeriodData 每次启动重查，之后再有标签形态的值经
+          // 同步/导入进来就会重跑），只靠它的话那一轮的原值就没有留底了。
+          batch.rawUpdate(
+            'UPDATE quotes '
+            'SET day_period_backup = day_period, day_period = ? '
+            'WHERE day_period = ?',
+            [entry.value, entry.key],
           );
         }
         final results = await batch.commit();
@@ -444,11 +448,12 @@ class SchemaDataBackfillAdapter {
         var migratedCount = 0;
         final batch = transaction.batch();
         for (final entry in WeatherService.legacyWeatherKeyToLabel.entries) {
-          batch.update(
-            'quotes',
-            {'weather': entry.key},
-            where: 'weather = ?',
-            whereArgs: [entry.value],
+          // 同 migrateDayPeriodToKey：可重复触发，原值必须在自己这条 UPDATE 里留底。
+          batch.rawUpdate(
+            'UPDATE quotes '
+            'SET weather_backup = weather, weather = ? '
+            'WHERE weather = ?',
+            [entry.key, entry.value],
           );
         }
         final results = await batch.commit();

--- a/test/unit/services/database_schema_lifecycle_test.dart
+++ b/test/unit/services/database_schema_lifecycle_test.dart
@@ -44,6 +44,58 @@ void main() {
           ]));
     });
 
+    test('weather / day_period 的二次迁移也要留底，不能只靠建列那一次快照', () async {
+      // _ensureBackupColumn 只在建列那一次整列快照，列已存在就早退。而这两个迁移
+      // 是可以再跑的（同步/导入之后又带进标签形态的值），只靠它的话，第二轮的原值
+      // 就没有任何地方留底——原值一旦被覆盖，回滚代码也找不回来。
+      //
+      // 这里直接调迁移本身而不走 performAllDataMigrations：触发它的
+      // _checkAndMigrateWeatherData 只用 `limit: 1` 抽一行做判断，抽到的那行已经是
+      // key 时整体跳过（那是另一个独立问题），会让这条用例测不到想测的东西。
+      final manager = DatabaseSchemaManager();
+      await manager.createTables(database);
+
+      Future<void> insert(String id, String weather, String dayPeriod) async {
+        await database.insert('quotes', {
+          'id': id,
+          'content': '正文 $id',
+          'date': '2026-08-22T17:40:00.000Z',
+          'weather': weather,
+          'day_period': dayPeriod,
+        });
+      }
+
+      Future<void> runMigrations() async {
+        await manager.migrateWeatherToKey(database);
+        await manager.migrateDayPeriodToKey(database);
+      }
+
+      // 第一轮：建快照列的那一次。
+      await insert('first-round', '晴', '晨曦');
+      await runMigrations();
+
+      // 第二轮：快照列此时已经存在，_ensureBackupColumn 的早退分支生效。
+      await insert('second-round', '多云', '黄昏');
+      await runMigrations();
+
+      Future<Map<String, Object?>> rowOf(String id) async =>
+          (await database.query('quotes', where: 'id = ?', whereArgs: [id]))
+              .first;
+
+      final first = await rowOf('first-round');
+      expect(first['weather'], 'clear');
+      expect(first['day_period'], 'dawn');
+      expect(first['weather_backup'], '晴');
+      expect(first['day_period_backup'], '晨曦');
+
+      final second = await rowOf('second-round');
+      expect(second['weather'], 'cloudy');
+      expect(second['day_period'], 'dusk');
+      // 回归点：第二轮的原值同样要留得下来。
+      expect(second['weather_backup'], '多云');
+      expect(second['day_period_backup'], '黄昏');
+    });
+
     test('upgrades a version 11 database through every remaining adapter',
         () async {
       await _createVersion11Schema(database);


### PR DESCRIPTION
Sourcery 在 #535 上指出：我新写的「不可逆写入前必须在自己那条 UPDATE 里留底」这条规则，**被现有代码违反着**。核实属实，这个 PR 把代码补齐。

## 缺口

`_ensureBackupColumn` 只在**建列那一次**整列快照，列已存在就早退：

```dart
if (columns.contains(columnName)) return;   // ← 第二轮从这里就返回了
```

而 `migrateWeatherToKey` / `migrateDayPeriodToKey` 的 UPDATE 只写规范化值，从不碰 `*_backup`。所以只要迁移再跑一次（同步或导入之后又带进标签形态的值），**那一轮的原值没有任何地方留底**——被覆盖之后回滚代码也找不回来。

这正是 #532 在 `sentiment` 上修过的同一个洞，另外两处一直还留着。

## 改动

照 `repairOutOfDomainSentiment` 的写法，原值和新值进同一条 UPDATE：

```dart
batch.rawUpdate(
  'UPDATE quotes SET weather_backup = weather, weather = ? WHERE weather = ?',
  [entry.key, entry.value],
);
```

已迁移过的行值已经是 key，不会再匹配 `WHERE`，所以不存在用新值覆盖早先快照的问题。

## 为什么测试直接调迁移，而不走 `performAllDataMigrations`

第一版用的是真实入口，结果第二轮**根本没迁移**——`'多云'` 原样留着。查下来是触发逻辑的问题：

```dart
final weatherCheck = await database.query(..., limit: 1);   // 只抽一行
if (legacyWeatherKeyToLabel.values.contains(weather)) { migrate }
```

`limit: 1` 只抽一行做判断。第一轮之后那行已经是 `'clear'`，于是整体跳过，哪怕别的行还是 `'多云'`。用真实入口测不到本 PR 想测的东西，所以测试改为直接调这两个迁移，测它们自己的契约。

## 顺带发现（**本 PR 不修**）

上面那个 `limit: 1` 抽样是**独立的真 bug**：抽到的行已经是 key 时整体跳过，**其它还是标签形态的行会一直留在库里不被迁移**。

不在这里顺手改，因为它会变动所有用户的迁移触发时机，值得单独一个 PR 和自己的测试。要不要开等你定。

## 和 #535 的关系

#535 把这个缺口写进了 AGENTS.md（标为「已知缺口 / 待单独修复」）。两个都合之后那段说明就过期了，需要删掉一小段——我会在 #535 合并后补一次提交，或者你先合 #535 我再更新。**这个 PR 本身不碰 AGENTS.md**，纯代码 + 测试。

## 验证

- 新增用例断言两轮迁移后 `weather_backup` / `day_period_backup` 各自保留了**当轮**原值。`git stash` 确认改动前失败于 `Expected: '多云' Actual: <null>`。
- unit 四片全过（1833 条）；schema / db 相关五个套件 34 条全过。
- `dart format --set-exit-if-changed .` 干净；`flutter analyze` 只剩 2 条既有的 `cacheExtent` info。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NLofg3wKNogeiWrbnCGY8

---
_Generated by [Claude Code](https://claude.ai/code/session_011NLofg3wKNogeiWrbnCGY8)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `weather` / `day_period` 迁移重复运行时原值不再留底的问题。之前 `_ensureBackupColumn` 只在建列那一次对整列做快照，列已存在就直接返回；迁移再跑一轮（同步或导入又带进标签形态的值）时，那一轮的原值没有任何备份，被覆盖后回滚代码也找不回来。

- 这是 `sentiment` 上修过的同类问题，另外两处这次一并补齐；原值和新值现在写进同一条 UPDATE，写法与 `repairOutOfDomainSentiment` 一致。
- 已迁移的行值已是 key，不会匹配 WHERE，所以不会用新值覆盖早先快照。
- 测试直接调用这两个迁移而非 `performAllDataMigrations`，因为触发逻辑用 `limit: 1` 抽样判断，抽到的行已是 key 就整体跳过——这是独立的 bug，本 PR 不修。

<sup>Written for commit b0dfd6b6171814fb3aa0a8be06a710c9756c7142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Sourcery 总结

在重复执行数据迁移时保留原始天气和时段值。

Bug 修复：
- 确保重复的天气和时段迁移在规范化之前，将每轮迁移的原始值保留在其备份列中。

测试：
- 添加回归测试，确认天气和时段备份值在两轮迁移后仍被保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve original weather and day-period values during repeated data migrations.

Bug Fixes:
- Ensure repeated weather and day-period migrations preserve each migration round’s original values in their backup columns before normalization.

Tests:
- Add regression coverage confirming weather and day-period backups are retained across two migration rounds.

</details>