### PR TITLE
🎨 Palette: 为“更多选项”图标按钮补充无障碍提示

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -41,3 +41,6 @@
 ## 2026-08-21 - [Add tooltip to FloatingActionButton]
 **Learning:** Found an instance where `FloatingActionButton.extended` lacked a `tooltip` property, which affects accessibility for screen readers. Even if a `label` property provides visual text, a dedicated `tooltip` ensures the action's intent is clearly communicated to assistive technologies.
 **Action:** Always verify that `FloatingActionButton.extended` components have a `tooltip` attribute containing localized strings from `AppLocalizations`.
+## 2026-08-28 - [Add tooltips to "More Options" IconButtons]
+**Learning:** Icon-only buttons representing "More Options" (`Icons.more_vert`) often lack the `tooltip` property. While visually universally understood, omitting the tooltip prevents screen readers from announcing their purpose, leading to poor accessibility.
+**Action:** Always add a localized `tooltip` (e.g., `AppLocalizations.of(context).moreOptions`) to all icon-only `IconButton` instances, particularly those serving as menus or secondary actions.

--- a/lib/pages/ai_settings_page.dart
+++ b/lib/pages/ai_settings_page.dart
@@ -459,6 +459,7 @@ class _AISettingsPageState extends State<AISettingsPage> {
               builder: (context, controller, child) {
                 return IconButton(
                   icon: const Icon(Icons.more_vert),
+                  tooltip: l10n.moreOptions,
                   onPressed: () {
                     if (controller.isOpen) {
                       controller.close();

--- a/lib/widgets/media_player_widget.dart
+++ b/lib/widgets/media_player_widget.dart
@@ -611,6 +611,7 @@ class _MediaPlayerWidgetState extends State<MediaPlayerWidget> {
                         context,
                       ).colorScheme.onSurface.withValues(alpha: 0.6),
                     ),
+                    tooltip: AppLocalizations.of(context).moreOptions,
                     onPressed: () {
                       if (controller.isOpen) {
                         controller.close();


### PR DESCRIPTION
🎨 Palette: 为“更多选项”图标按钮补充无障碍提示

💡 What: 为 `ai_settings_page.dart` 和 `media_player_widget.dart` 中的 `Icons.more_vert` (更多选项) 图标按钮补充了 `tooltip` 属性。
🎯 Why: 纯图标按钮如果没有 tooltip，屏幕阅读器将无法朗读其功能，对依赖无障碍辅助功能的用户不友好；同时对于桌面端用户，悬浮提示也增加了可用性。
♿ Accessibility: 增加了无障碍提示 `AppLocalizations.of(context).moreOptions`。

---
*PR created automatically by Jules for task [12803003385927843854](https://jules.google.com/task/12803003385927843854) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为“更多选项”菜单按钮补充无障碍提示，使屏幕阅读器能读出按钮用途，并为桌面端用户提供悬浮提示。

- 在 `ai_settings_page.dart` 和 `media_player_widget.dart` 的 `IconButton` 上添加了本地化 `tooltip`（`AppLocalizations.of(context).moreOptions`）。
- 更新 `.jules/palette.md`，记录后续为纯图标按钮补充 `tooltip` 的约定。

<sup>Written for commit c635d09830dda5a2b8926289e2dd8cd32c46f81d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added localized tooltips to “More Options” buttons in AI settings and the audio player.
  * Screen readers now announce the purpose of these icon-only controls, with tooltips also available on hover or long-press.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->