### PR TITLE
docs: AGENTS.md 里那条快照缺口说明已随 #538 过期

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,12 +283,9 @@ pwsh ./scripts/build_msix_ci.ps1
   就早退，二次修复不写就没有留底。
   **遗留列清理必须排在所有建快照列的迁移之前**：`_removeTagIdsColumn` 重建 `quotes` 用的是
   写死的列清单，不含任何 `*_backup` 列，排在后面会把三剂后悔药一起抹掉。
-  - ⚠️ **已知缺口**：目前只有 `repairOutOfDomainSentiment` 满足前半条。
-    `migrateWeatherToKey` / `migrateDayPeriodToKey` 的 UPDATE 只写规范化值，靠
-    `_ensureBackupColumn` 那一次整列快照兜着；而它们由 `_checkAndMigrateWeatherData` /
-    `_checkAndMigrateDayPeriodData` 每次启动重查，**只要之后再有标签形态的值进来就会
-    重跑**（同步/导入都可能带进来），那一轮的原值就没有留底了。**不要把这两个当参考实现**，
-    照 `repairOutOfDomainSentiment` 写；这两处待单独修复。
+  - 这条规则一度被 `migrateWeatherToKey` / `migrateDayPeriodToKey` 违反着：它们的 UPDATE
+    只写规范化值，只靠 `_ensureBackupColumn` 建列那一次快照兜着，第二轮再跑时原值就没了。
+    已在 PR #538 补齐，三处现在写法一致，都可以照着抄。
 - 🔒 **逐行反序列化必须有兜底**：查询结果统一走 `_parseQuoteRows` / `_tryParseQuoteRow`，
   坏行跳过并计数。裸 `maps.map((m) => Quote.fromJson(m))` 会让一条坏行带走整页笔记，用户
   看到的是列表整个打不开。批处理阶段的 `as String` 强转同样要改成 `whereType<String>()`——


### PR DESCRIPTION
#538 已经把 `migrateWeatherToKey` / `migrateDayPeriodToKey` 的原值留底补齐并合并了，但 AGENTS.md 里那段说明还停在修复之前。

**现在这段是反向误导**：

```
⚠️ 已知缺口：目前只有 repairOutOfDomainSentiment 满足前半条。
   …… 不要把这两个当参考实现，照 repairOutOfDomainSentiment 写；这两处待单独修复。
```

那两个迁移**已经是正确写法了**（main 上 `weather_backup = weather` / `day_period_backup = day_period` 两处都在），照着抄没问题，而文档在劝人别抄、并把已完成的工作列为待办。

改成陈述历史 + 指向 #538：

```
- 这条规则一度被 migrateWeatherToKey / migrateDayPeriodToKey 违反着：它们的 UPDATE
  只写规范化值，只靠 _ensureBackupColumn 建列那一次快照兜着，第二轮再跑时原值就没了。
  已在 PR #538 补齐，三处现在写法一致，都可以照着抄。
```

## 为什么是单独一个 PR

这段本该跟着 #538 一起改，但 GitHub 不接受用非默认分支做 base（`PullRequest.base (invalid)`），当时就把文档和代码拆开了，说好等合并后补。后来我把补丁推到了 `claude/review-invariants-and-config`——那个分支的 PR（#535）**已经合并**，push 只是把删掉的分支重建了一遍，改动根本没进 main。这个 PR 从最新 main 重新开，是那次的正确做法。

## 验证

只改 AGENTS.md 一段文字，无代码、无测试改动。已确认 main 上两个迁移的 `*_backup` 写入都在，文档是唯一没跟上的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NLofg3wKNogeiWrbnCGY8

---
_Generated by [Claude Code](https://claude.ai/code/session_011NLofg3wKNogeiWrbnCGY8)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修正 `AGENTS.md` 中关于 `migrateWeatherToKey` / `migrateDayPeriodToKey` 快照缺口的过期说明，避免文档把已修复的问题当作已知缺口继续误导读者。

- 旧文档声称这两个迁移缺少原值留底、不应作为参考实现，但该缺口已在 PR #538 修复，文档与实际代码不符。
- 新文档改为陈述历史事实并指向 #538，说明三处迁移写法现已一致，均可作为参考。
- 仅改动文档文字，无代码或测试变更。

<sup>Written for commit c21fecd041979c189758f0e4a62cc417a460b3c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance to reflect that backup-column handling has been fixed.
  * Confirmed all three migrations now follow the standard pattern and can serve as reference implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->