### PR TITLE
style(note-list): 折叠提示并进来源行，短笔记缩略图回到 72

### DIFF
--- a/lib/widgets/note_list/collapsed_media_thumbnail.dart
+++ b/lib/widgets/note_list/collapsed_media_thumbnail.dart
@@ -29,31 +29,25 @@ class CollapsedMediaThumbnail extends StatelessWidget {
     this.size = defaultSize,
   });
 
-  /// 缩略图的三档边长，从小到大。
+  /// 缩略图的两档边长，从小到大。
   ///
   /// 版式规则是**图不比正文高**：并排的两列里，谁也不该撑出对方够不着的空白。
-  /// 正文只有一两行时用最小档，正文排满折叠盒（160px）时才用最大档，由
-  /// [sizeForContentHeight] 按实测正文高度挑。
+  /// 正文排满折叠盒（160px）时用大档，其余用小档，由 [sizeForContentHeight] 按
+  /// 实测正文高度挑。
   ///
-  /// 只有三档、而不是连续贴合正文高度：解码尺寸就是 `imageCache` 的键，每多一种
+  /// 只有两档、而不是连续贴合正文高度：解码尺寸就是 `imageCache` 的键，每多一种
   /// 尺寸就多一份解码和一份常驻内存。
-  static const List<double> sizeLadder = <double>[
-    compactSize,
-    defaultSize,
-    tallNoteSize,
-  ];
+  static const List<double> sizeLadder = <double>[defaultSize, tallNoteSize];
 
-  /// 最小档，正文只有一两行时用。
+  /// 小档，同时是**下限**和**测量与预热的参照尺寸**（[reservedWidth] 的默认值、
+  /// 折叠排版的第一趟测量都用它）。
   ///
-  /// 同时是下限：正文比它还矮也停在这里，再小就看不出是张什么照片了。剩下的
+  /// 正文比它还矮也停在这里。试过更小的 56：一行字的卡片确实又矮了 16，但那张
+  /// 图小到看不出拍的是什么，而带图的笔记里照片往往才是内容本身。多出来的
   /// 高度差由 Row 的居中对齐平分到上下，不会堆成一整块空白。
-  static const double compactSize = 56.0;
-
-  /// 中间档，也是**测量与预热的参照尺寸**：[reservedWidth] 的默认值、折叠排版的
-  /// 第一趟测量都用它。
   static const double defaultSize = 72.0;
 
-  /// 最大档，正文排满折叠盒时用。
+  /// 大档，正文排满折叠盒时用。
   ///
   /// 上限压在 96：再大就要从正文列里割走一大块宽度，长笔记每行少排两三个字，
   /// 折叠预览能给的信息反而变少。
@@ -68,8 +62,8 @@ class CollapsedMediaThumbnail extends StatelessWidget {
   /// 缩略图与正文之间的间距。
   static const double gap = 12.0;
 
-  /// 按实测正文高度挑一档：取**不超过正文高度的最大档**，比最小档还矮就停在
-  /// [compactSize]。
+  /// 按实测正文高度挑一档：取**不超过正文高度的最大档**，比小档还矮就停在
+  /// [defaultSize]。
   ///
   /// 方向不能反过来（正文越短图越大）——那正是「一行字的卡片上下各空一大截」的
   /// 来源：空白是图撑出来的，正文再怎么排都填不满。

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -615,6 +615,7 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
     required Quote quote,
     required bool isExpanded,
     required Color primaryTextColor,
+    required Color secondaryTextColor,
     required bool paperRulesDisabled,
     required AppLocalizations l10n,
   }) {
@@ -659,12 +660,25 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
           // 只算一次，同时喂给正文栈和动画层：两处一旦给出不同答案，
           // AnimatedSize 与 AnimatedSwitcher 的挂载就会错配。
           final bool canToggle = needsExpansion || isExpanded;
+
+          // 折叠提示优先**并进来源行**，不自己占一整行。
+          //
+          // 提示是右对齐的一小行灰字，来源行是左对齐的一行灰字，两者从来不会
+          // 争同一段横向空间；分成两行等于为了几个字多撑出一整行的高度，而这条
+          // 卡片本来就是「内容多到放不下」的那种，最不该再浪费纵向空间。
+          //
+          // 没有来源的笔记仍然走自己的提示行（`_buildQuoteContentStack` 里那条）：
+          // 硬凑一行空的来源出来，反而比提示自己占一行还高。
+          final String? sourceLine = _sourceLineFor(quote);
+          final bool showHint = textTruncated && !isExpanded;
+          final bool hintInSourceRow = showHint && sourceLine != null;
+
           final contentChild = _buildQuoteContentStack(
             canToggle: canToggle,
             quote: quote,
             showFullContent: showFullContent,
             needsExpansion: needsExpansion,
-            textTruncated: textTruncated,
+            textTruncated: textTruncated && !hintInSourceRow,
             isExpanded: isExpanded,
             contentStyle: contentStyle,
             innerTheme: innerTheme,
@@ -698,14 +712,87 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
             // topInset + spacing 起画，而正文首行的行盒顶就是 y=0），后面每一条都
             // 落在行与行之间。圆角传 zero：这里已经在卡片的圆角裁切之内了。
             // 正文里的图片和展开蒙层都画在 painter 之上，会自然盖住横线。
-            child: paperRulesDisabled
-                ? animatedContent
-                : PaperRuleBackground(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // 纸张横线只裹正文，不裹来源行：来源行的行高和正文不是一套，
+                // 横线接着往下画会和它错位。
+                if (paperRulesDisabled)
+                  animatedContent
+                else
+                  PaperRuleBackground(
                     borderRadius: BorderRadius.zero,
                     child: animatedContent,
                   ),
+                if (sourceLine != null || hintInSourceRow)
+                  _buildSourceRow(
+                    sourceLine: sourceLine,
+                    showHint: hintInSourceRow,
+                    innerTheme: innerTheme,
+                    secondaryTextColor: secondaryTextColor,
+                    l10n: l10n,
+                  ),
+              ],
+            ),
           );
         },
+      ),
+    );
+  }
+
+  /// 来源与出处那一行的文本；没有来源时为 null。
+  String? _sourceLineFor(Quote quote) {
+    final author = quote.sourceAuthor ?? '';
+    final work = quote.sourceWork ?? '';
+    if (author.isNotEmpty || work.isNotEmpty) {
+      return _formatSource(author, work);
+    }
+    final source = quote.source;
+    if (source != null && source.isNotEmpty) return source;
+    return null;
+  }
+
+  /// 来源行，右端可以搭一条折叠提示。
+  ///
+  /// 上边距 12 = 原来「正文区下内边距 8 + 来源行上内边距 4」，来源行搬进内容区
+  /// 之后这两段合成一处，卡片的间距和以前逐像素相同。
+  Widget _buildSourceRow({
+    required String? sourceLine,
+    required bool showHint,
+    required ThemeData innerTheme,
+    required Color secondaryTextColor,
+    required AppLocalizations l10n,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12),
+      child: Row(
+        // 来源长到要折行时，提示跟着落在最后一行，不吊在半空。
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          // Expanded 而不是 Flexible：来源短的时候也要把剩下的宽度吃掉，
+          // 否则提示会紧贴在来源右边，而不是卡片右缘。
+          Expanded(
+            child: sourceLine == null
+                ? const SizedBox.shrink()
+                : Text(
+                    sourceLine,
+                    style: innerTheme.textTheme.bodyMedium?.copyWith(
+                      color: secondaryTextColor,
+                    ),
+                  ),
+          ),
+          if (showHint) ...[
+            const SizedBox(width: 8),
+            Text(
+              l10n.doubleTapToViewFull,
+              style: innerTheme.textTheme.labelSmall?.copyWith(
+                color: innerTheme.colorScheme.onSurfaceVariant
+                    .withValues(alpha: 0.8),
+              ),
+            ),
+          ],
+        ],
       ),
     );
   }
@@ -1534,36 +1621,14 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
             quote: quote,
             isExpanded: isExpanded,
             primaryTextColor: primaryTextColor,
+            secondaryTextColor: secondaryTextColor,
             paperRulesDisabled: visualEffectsDisabled,
             l10n: l10n,
           ),
 
-          // 来源信息（如果有）
-          if ((quote.sourceAuthor != null && quote.sourceAuthor!.isNotEmpty) ||
-              (quote.sourceWork != null && quote.sourceWork!.isNotEmpty)) ...[
-            Padding(
-              padding: const EdgeInsets.fromLTRB(4, 4, 4, 8), // 减少左右边距从16到4
-              child: Text(
-                _formatSource(
-                  quote.sourceAuthor ?? '',
-                  quote.sourceWork ?? '',
-                ),
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: secondaryTextColor,
-                ),
-              ),
-            ),
-          ] else if (quote.source != null && quote.source!.isNotEmpty) ...[
-            Padding(
-              padding: const EdgeInsets.fromLTRB(4, 4, 4, 8), // 减少左右边距从16到4
-              child: Text(
-                quote.source!,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: secondaryTextColor,
-                ),
-              ),
-            ),
-          ],
+          // 来源行画在 `_buildQuoteContentSection` 里面，不在这里：折叠提示要和它
+          // 并成一行（见那边的说明），而「正文是否真的被截断」只有内容区的
+          // `LayoutBuilder` 里才量得出来。
 
           // 底部工具栏 - 标签、心形和更多按钮在同一行
           Padding(

--- a/lib/widgets/quote_item_widget.dart
+++ b/lib/widgets/quote_item_widget.dart
@@ -729,6 +729,7 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                   _buildSourceRow(
                     sourceLine: sourceLine,
                     showHint: hintInSourceRow,
+                    rowMaxWidth: constraints.maxWidth,
                     innerTheme: innerTheme,
                     secondaryTextColor: secondaryTextColor,
                     l10n: l10n,
@@ -740,6 +741,9 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
       ),
     );
   }
+
+  /// 来源行与右端折叠提示之间的间距。
+  static const double _sourceHintGap = 8.0;
 
   /// 来源与出处那一行的文本；没有来源时为 null。
   String? _sourceLineFor(Quote quote) {
@@ -760,10 +764,21 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
   Widget _buildSourceRow({
     required String? sourceLine,
     required bool showHint,
+    required double rowMaxWidth,
     required ThemeData innerTheme,
     required Color secondaryTextColor,
     required AppLocalizations l10n,
   }) {
+    // 提示是 Row 里的非 flex 子项，会一直保留自己的固有宽度：窄卡片（分屏、
+    // Windows 小窗）碰上大字号缩放时，它加上 8 的间距就能超过整行，`Expanded`
+    // 分到负宽度，RenderFlex 当场溢出。所以给它封一个上界让它自己折行。
+    //
+    // 上界取半行：正常字号下提示只占六七十像素，离这条线远得很，版式一点不变；
+    // 只有极端缩放才会碰到，那时两边各折各的，谁也挤不掉谁。
+    final double halfRow = (rowMaxWidth - _sourceHintGap) / 2;
+    final double hintMaxWidth =
+        !rowMaxWidth.isFinite ? double.infinity : (halfRow > 0 ? halfRow : 0.0);
+
     return Padding(
       padding: const EdgeInsets.only(top: 12),
       child: Row(
@@ -783,12 +798,16 @@ class _QuoteItemWidgetState extends State<QuoteItemWidget>
                   ),
           ),
           if (showHint) ...[
-            const SizedBox(width: 8),
-            Text(
-              l10n.doubleTapToViewFull,
-              style: innerTheme.textTheme.labelSmall?.copyWith(
-                color: innerTheme.colorScheme.onSurfaceVariant
-                    .withValues(alpha: 0.8),
+            const SizedBox(width: _sourceHintGap),
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: hintMaxWidth),
+              child: Text(
+                l10n.doubleTapToViewFull,
+                textAlign: TextAlign.end,
+                style: innerTheme.textTheme.labelSmall?.copyWith(
+                  color: innerTheme.colorScheme.onSurfaceVariant
+                      .withValues(alpha: 0.8),
+                ),
               ),
             ),
           ],

--- a/test/widget/widgets/collapsed_media_thumbnail_test.dart
+++ b/test/widget/widgets/collapsed_media_thumbnail_test.dart
@@ -240,40 +240,34 @@ void main() {
     test('取不超过正文高度的最大档', () {
       expect(
         CollapsedMediaThumbnail.sizeForContentHeight(0),
-        CollapsedMediaThumbnail.compactSize,
+        CollapsedMediaThumbnail.defaultSize,
       );
-      // 一两行正文：比最小档还矮也停在最小档，再小就看不清是什么照片了。
+      // 一两行正文：比小档还矮也停在小档，再小就看不清是什么照片了。
       expect(
         CollapsedMediaThumbnail.sizeForContentHeight(24),
-        CollapsedMediaThumbnail.compactSize,
+        CollapsedMediaThumbnail.defaultSize,
       );
       expect(
         CollapsedMediaThumbnail.sizeForContentHeight(
-          CollapsedMediaThumbnail.defaultSize - 0.5,
-        ),
-        CollapsedMediaThumbnail.compactSize,
-      );
-      // 边界取等号：正好够一档就用那一档，图和正文齐平。
-      expect(
-        CollapsedMediaThumbnail.sizeForContentHeight(
-          CollapsedMediaThumbnail.defaultSize,
+          CollapsedMediaThumbnail.tallNoteSize - 0.5,
         ),
         CollapsedMediaThumbnail.defaultSize,
       );
+      // 边界取等号：正好够一档就用那一档，图和正文齐平。
       expect(
         CollapsedMediaThumbnail.sizeForContentHeight(
           CollapsedMediaThumbnail.tallNoteSize,
         ),
         CollapsedMediaThumbnail.tallNoteSize,
       );
-      // 正文排满折叠盒（160）也不再往上走：上限就是最大档。
+      // 正文排满折叠盒（160）也不再往上走：上限就是大档。
       expect(
         CollapsedMediaThumbnail.sizeForContentHeight(160),
         CollapsedMediaThumbnail.tallNoteSize,
       );
     });
 
-    test('档位递增，且挑出来的档永远不高于正文（最小档除外）', () {
+    test('档位递增，且挑出来的档永远不高于正文（小档除外）', () {
       // 这两条不变量是「图不比字高」的全部依据：档位乱序或多出一个大于
       // 160 的档，都会让长笔记的图重新撑出卡片。
       for (var i = 1; i < CollapsedMediaThumbnail.sizeLadder.length; i++) {
@@ -282,7 +276,7 @@ void main() {
           greaterThan(CollapsedMediaThumbnail.sizeLadder[i - 1]),
         );
       }
-      for (var height = CollapsedMediaThumbnail.compactSize;
+      for (var height = CollapsedMediaThumbnail.defaultSize;
           height <= 200;
           height += 4) {
         expect(

--- a/test/widget/widgets/quote_item_widget_test.dart
+++ b/test/widget/widgets/quote_item_widget_test.dart
@@ -74,6 +74,7 @@ Quote _buildQuote({
   String editSource = 'fullscreen',
   String? date,
   String? lastModified,
+  String? sourceAuthor,
 }) {
   return Quote(
     id: id,
@@ -83,6 +84,7 @@ Quote _buildQuote({
     editSource: editSource,
     dayPeriod: 'morning',
     lastModified: lastModified,
+    sourceAuthor: sourceAuthor,
   );
 }
 
@@ -410,6 +412,68 @@ void main() {
       expect(hintRect.right, closeTo(contentRect.right, 8.0));
     });
 
+    testWidgets('有来源时折叠提示并进来源行，不再自己占一行', (tester) async {
+      // 提示是右对齐的一小行灰字，来源行是左对齐的一行灰字，两者从来不会争同一段
+      // 横向空间。分成两行等于为几个字多撑出一整行——而这种卡片本来就是「内容多到
+      // 放不下」的那类，最不该再浪费纵向空间。
+      final quote = _buildQuote(
+        id: 'truncated-with-source',
+        content: List.filled(6, _longContentChunk).join('\n'),
+        editSource: 'inline',
+        sourceAuthor: '示例作者',
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: _FakeSettingsService(),
+          child: MaterialApp(
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+            home: Material(
+              child: Center(
+                child: SizedBox(
+                  width: 400,
+                  child: QuoteItemWidget(
+                    quote: quote,
+                    tagMap: const {},
+                    isExpanded: false,
+                    onToggleExpanded: (_) {},
+                    onEdit: () {},
+                    onDelete: () {},
+                    onAskAI: () {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final hintRect = tester.getRect(find.text('双击查看全文'));
+      final sourceRect = tester.getRect(find.text('——示例作者'));
+
+      // 同一行：两个矩形在纵向上必须相交，而不是一上一下。
+      expect(hintRect.top, lessThan(sourceRect.bottom));
+      expect(sourceRect.top, lessThan(hintRect.bottom));
+      // 来源贴左、提示贴右，中间不重叠。
+      expect(sourceRect.right, lessThan(hintRect.left));
+    });
+
+    testWidgets('没有来源的笔记，折叠提示仍然自己占一行', (tester) async {
+      // 硬凑一行空来源出来反而比提示自己占一行还高，所以这条路径要留着。
+      await pumpShortLineCard(tester);
+
+      expect(find.text('双击查看全文'), findsOneWidget);
+      expect(find.textContaining('——'), findsNothing);
+    });
+
     testWidgets('折叠提示画在正文下方，不压在正文上', (tester) async {
       // 这一条守的是这次改动的核心：提示不再是盖在正文最后一行上的浮层。
       // 只断言「不在内容区上方」是不够的——压在正文上同样满足那个条件。
@@ -421,7 +485,7 @@ void main() {
       expect(hintRect.top, greaterThanOrEqualTo(bodyRect.bottom - 1.0));
     });
 
-    // 右侧缩略图按正文高度分档：短笔记收到 56，正文排满折叠盒的长笔记放到 96，
+    // 右侧缩略图按正文高度分档：短笔记用小档 72，正文排满折叠盒的长笔记放到 96，
     // 一个字都没有的纯图笔记用 132 的居中方图。三条各测一种，共用这份夹具。
     Future<CollapsedMediaThumbnail> pumpMediaCard(
       WidgetTester tester, {
@@ -480,7 +544,7 @@ void main() {
       );
     }
 
-    testWidgets('正文只有一行时右侧缩略图收到最小档，且不显示折叠提示', (tester) async {
+    testWidgets('正文只有一行时右侧缩略图用小档，且不显示折叠提示', (tester) async {
       // 带媒体的笔记一律可展开，但正文一个字都没少——这种卡片不该有提示。
       // 图也不该反过来撑高卡片：一行字配一张大方图，上下各空一截谁也填不满。
       final thumbnail = await pumpMediaCard(
@@ -489,7 +553,7 @@ void main() {
         text: '只有一行字的笔记',
       );
 
-      expect(thumbnail.size, CollapsedMediaThumbnail.compactSize);
+      expect(thumbnail.size, CollapsedMediaThumbnail.defaultSize);
       expect(find.text('双击查看全文'), findsNothing);
     });
 
@@ -506,8 +570,8 @@ void main() {
 
     testWidgets('正文越长缩略图越大，不会倒过来', (tester) async {
       // 这一条守的是方向本身：正文短的那张卡片，缩略图不能比正文长的那张还大。
-      // 旧版式正好相反（短笔记 96、长笔记 72），卡片列表看上去就是「越没内容的
-      // 笔记占的地方越大」。
+      // 最早的版式正好相反（短笔记 96、长笔记 72），卡片列表看上去就是「越没内容
+      // 的笔记占的地方越大」。
       final short = await pumpMediaCard(
         tester,
         id: 'direction-short',

--- a/test/widget/widgets/quote_item_widget_test.dart
+++ b/test/widget/widgets/quote_item_widget_test.dart
@@ -466,6 +466,64 @@ void main() {
       expect(sourceRect.right, lessThan(hintRect.left));
     });
 
+    testWidgets('窄卡片配大字号缩放时来源行不溢出', (tester) async {
+      // 提示是 Row 里的非 flex 子项，会保留固有宽度：不给它封上界的话，窄卡片
+      // （分屏、Windows 小窗）碰上大字号缩放时它就能挤爆整行，Expanded 分到负
+      // 宽度，RenderFlex 当场溢出。这组参数实测就是临界点——去掉上界会得到
+      // 「overflowed by 23 pixels on the right」。
+      //
+      // 缩放停在 2.0 是有意的：3.0 会另外撞上卡片自己在极端字号下的纵向溢出，
+      // 那个在这次改动之前就有，不该由这条测试来盯。
+      final quote = _buildQuote(
+        id: 'narrow-overflow',
+        content: List.filled(6, _longContentChunk).join('\n'),
+        editSource: 'inline',
+        sourceAuthor: '示例作者',
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SettingsService>.value(
+          value: _FakeSettingsService(),
+          child: MaterialApp(
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+            home: MediaQuery(
+              data: const MediaQueryData(
+                textScaler: TextScaler.linear(2.0),
+              ),
+              child: Material(
+                child: Center(
+                  child: SizedBox(
+                    width: 180,
+                    child: QuoteItemWidget(
+                      quote: quote,
+                      tagMap: const {},
+                      isExpanded: false,
+                      onToggleExpanded: (_) {},
+                      onEdit: () {},
+                      onDelete: () {},
+                      onAskAI: () {},
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('双击查看全文'), findsOneWidget);
+      expect(find.text('——示例作者'), findsOneWidget);
+    });
+
     testWidgets('没有来源的笔记，折叠提示仍然自己占一行', (tester) async {
       // 硬凑一行空来源出来反而比提示自己占一行还高，所以这条路径要留着。
       await pumpShortLineCard(tester);


### PR DESCRIPTION
接 #534 的实机反馈，两处调整。

## 1. 折叠提示不再自己占一行

「双击查看全文」是右对齐的一小行灰字，「——作者」是左对齐的一行灰字，两者从来不会争同一段横向空间。分成两行等于为几个字多撑出一整行 —— 而这种卡片本来就是「内容多到放不下」的那类，最不该再浪费纵向空间。

并成一行后长笔记卡片实测 **326 → 308**。

没有来源的笔记仍然走原来那条独立提示行：硬凑一行空来源出来，反而比提示自己占一行还高。两条路径各有测试。

实现上来源行从外层 Column 搬进了 `_buildQuoteContentSection` 的 `LayoutBuilder` —— 「正文是否真的被截断」只有那里量得出来（需要内容区的 `constraints.maxWidth`）。几个细节：

- 上边距 12 = 原来「正文区下内边距 8 + 来源行上内边距 4」，卡片各段间距和以前逐像素相同。
- 纸张横线仍然只裹正文，不裹来源行：来源行的行高和正文不是一套，横线接着往下画会错位。
- `Expanded` 而不是 `Flexible`：来源短的时候也要把剩余宽度吃掉，否则提示会紧贴在来源右边而不是卡片右缘。
- **副作用**：双击区域现在也盖住来源行，双击作者名同样能展开笔记。提示本身留在双击区域内（这点必须保住，否则「双击查看全文」这几个字自己不可双击）。

## 2. 短笔记缩略图 56 → 72

56 确实让一行字的卡片又矮了 16，但图小到看不出拍的是什么 —— 而带图的笔记里照片往往才是内容本身。

档位表因此简化成两档 **72 / 96**，`compactSize` 删除（下限就是 `defaultSize`，同时仍是测量与预热的参照尺寸）。

## 卡片高度实测

| 卡片 | #534 前 | #534 后 | 本 PR |
|---|---|---|---|
| 一行字 + 图 | 260 | 220 | **236** |
| 三行字 + 图 | 260 | 236 | **236** |
| 正文排满 + 图（有来源） | 326 | 326 | **308** |
| 纯图无正文 | 296 | 296 | 296 |

## 测试

- 新增 `有来源时折叠提示并进来源行，不再自己占一行`：断言提示与来源两个矩形在纵向相交（同一行）、来源贴左提示贴右且不重叠。
- 新增 `没有来源的笔记，折叠提示仍然自己占一行`。
- 分档单测与 `quote_item_widget_test` 的尺寸断言跟着两档改写。
- `test/widget/` 全量 311 例通过（改动前基线），改后 `quote_item_widget_test` 30 例、`collapsed_media_thumbnail_test` 10 例、`quote_content_widget_test` 31 例全绿；`flutter analyze` 无问题。

## 环境提醒（同 #534，不在本 PR 范围）

锁定的 `flutter_quill 11.5.0` 在 Flutter 3.47.x 下编译不过（`QuillRawEditorState` 缺 `TextInputClient.onFocusReceived`）。本地临时升到 11.5.1 才跑通测试，跑完已还原 `pubspec.lock`，本 PR **不含依赖变更**。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XocSXKMzAXad9UhYZHgZuV)_

## Sourcery 摘要

通过合并来源和展开元数据，并优化缩略图尺寸，在保持媒体缩略图清晰可读的同时减少折叠笔记卡片的高度。

改进：
- 当笔记包含来源时，将折叠内容提示与来源行合并；对于没有来源的笔记，保留独立的提示。
- 将折叠媒体缩略图的最小尺寸从 56px 增加到 72px，并将缩略图尺寸梯度简化为 72px 和 96px。

测试：
- 添加用于覆盖来源行提示位置和独立提示的小部件测试，并更新缩略图尺寸断言，以适配两种尺寸的梯度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化折叠笔记卡片布局，在节省长笔记垂直空间的同时提升短笔记缩略图的可读性。

Enhancements:
- 将有来源笔记的折叠提示合并到来源行，同时保留无来源笔记的独立提示布局。
- 将折叠媒体缩略图尺寸档位简化为 72px 和 96px，提升短笔记图片的可辨识度并优化卡片高度。

Tests:
- 新增来源提示布局、无来源提示布局及窄卡片大字号场景的小部件测试，并更新缩略图尺寸断言。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化折叠笔记卡片布局，在节省长笔记垂直空间的同时提升短笔记缩略图的可读性。

Enhancements:
- 将有来源笔记的折叠提示合并到来源行，同时保留无来源笔记的独立提示布局。
- 将折叠媒体缩略图尺寸档位简化为 72px 和 96px，提升短笔记图片的可辨识度并优化卡片高度。

Tests:
- 新增来源提示布局、无来源提示布局及窄卡片大字号场景的小部件测试，并更新缩略图尺寸断言。

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
接 #534 的实机反馈调整三处：有来源时折叠提示并进来源行，短笔记缩略图从 56 回到 72，并给来源行的提示封了宽度上界，窄卡片大字号不再溢出。

**行为变化**

- 有来源的笔记，折叠提示与来源同排，长笔记卡片 326 → 308；无来源笔记仍走独立提示行。
- 缩略图档位简化为 72/96，删除 `compactSize`；一行字带图卡片 220 → 236。
- 提示在分屏或小窗配大字号时可能撑爆行，现封半行宽上界，正常字号版式不变。
- 来源行搬进内容区 `LayoutBuilder`，上边距 12；双击展开区域现在覆盖来源行。
- 测试新增有来源并行、无来源独立、窄卡片溢出回归三例，尺寸断言随档位改写。

<sup>Written for commit 271f0f016f82e41f60864ccc58d009853779fd3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated collapsed media thumbnails to use a simpler two-size layout, improving consistency for smaller previews.
  - Repositioned quote source information beneath the quote content.
  - Combined the “double-tap to view full text” hint with the source line when attribution is present, while preserving the existing layout for quotes without a source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->