### PR TITLE
fix: 新装用户真正拿到信笺主题，AI 功能也不再被引导页关掉

### DIFF
--- a/lib/controllers/onboarding_controller.dart
+++ b/lib/controllers/onboarding_controller.dart
@@ -285,12 +285,7 @@ class OnboardingController extends ChangeNotifier {
         logInfo('位置服务已启用');
       }
 
-      // AI相关快捷开关
-      final todayAI = _state.getPreference<bool>('todayThoughtsUseAI') ?? false;
-      await _settingsService.setTodayThoughtsUseAI(todayAI);
-      final reportAI =
-          _state.getPreference<bool>('reportInsightsUseAI') ?? false;
-      await _settingsService.setReportInsightsUseAI(reportAI);
+      await applyAiTogglePreferences(_settingsService);
 
       // 保存 Sentry 开关设置
       final sentryEnabled =
@@ -301,6 +296,29 @@ class OnboardingController extends ChangeNotifier {
     } catch (e) {
       logError('保存用户偏好设置失败', error: e, source: 'OnboardingController');
       // 不抛出异常，避免阻塞引导流程
+    }
+  }
+
+  /// 把引导页里的 AI 快捷开关落到设置。
+  ///
+  /// **引导页里没有这两个开关**，所以这里读到的几乎总是 null，而 null 只能表示
+  /// 「用户没在引导里表过态」，不能当成「用户要关」。
+  ///
+  /// 曾经是 `?? false`，于是引导一走完就把两个开关无条件写成 false，一次性抹掉
+  /// 两件事：[AppSettings.todayThoughtsUseAI] 的默认开启，以及用户配好 AI 服务时
+  /// [SettingsService.saveMultiAISettings] 做的自动开启。新用户装完什么都没开、
+  /// 只有 AI 卡片生成还在（它兜底写的是 `?? true`）——就是那两行造成的。
+  ///
+  /// 没表过态就别写：保留当前取值（默认值，或自动开启的结果）。
+  @visibleForTesting
+  Future<void> applyAiTogglePreferences(SettingsService settingsService) async {
+    final todayAI = _state.getPreference<bool>('todayThoughtsUseAI');
+    if (todayAI != null) {
+      await settingsService.setTodayThoughtsUseAI(todayAI);
+    }
+    final reportAI = _state.getPreference<bool>('reportInsightsUseAI');
+    if (reportAI != null) {
+      await settingsService.setReportInsightsUseAI(reportAI);
     }
   }
 

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -43,6 +43,16 @@ class SettingsService extends ChangeNotifier {
   // 使用应用安装标记替代版本号
   static const String _appInstalledKey = 'app_installed_v2';
   static const String _appUpgradedKey = 'app_upgraded_v2';
+
+  /// 「这台设备还欠一次 AI 功能自动开启」。首次安装时种下，真正自动开启之后清掉。
+  ///
+  /// 判据不能只看 `hasCompletedOnboarding()`：新用户很多是走完引导、之后才去
+  /// 设置页配 AI 服务的，那时引导已经完成，自动开启就再也轮不到他。用一次性标记
+  /// 记住「这台设备是新装且还没自动开过」，配好 AI 的那一刻不管在哪都能生效。
+  ///
+  /// 只在首次安装时种：老用户没有这个键，行为完全不变——尤其不会把他自己关掉的
+  /// 周期报告 AI 洞察在下次保存 AI 设置时又打开。
+  static const String _aiAutoEnablePendingKey = 'ai_auto_enable_pending_v1';
   final SharedPreferences _prefs; // 保留以支持数据迁移
   final MMKVService _mmkv = MMKVService(); // 使用MMKV作为主要存储
   Completer<void>? _saveMultiAiLock;
@@ -767,6 +777,9 @@ class SettingsService extends ChangeNotifier {
       // 只会推成老用户——#513 的默认值一直没生效就是这个原因。
       await _seedFreshInstallThemeStyle();
 
+      // 新装用户配好 AI 服务后自动开启相关 AI 功能，见 _aiAutoEnablePendingKey。
+      await _mmkv.setBool(_aiAutoEnablePendingKey, true);
+
       // 首次安装时，载入应用默认设置
       _loadAppSettings();
       _appSettings = _appSettings.copyWith(
@@ -1231,7 +1244,7 @@ class SettingsService extends ChangeNotifier {
       final hasActiveAi = settings.providers.any(
         (p) => p.isEnabled && p.apiUrl.trim().isNotEmpty,
       );
-      final candidateAppSettings = (!hasCompletedOnboarding() && hasActiveAi)
+      final candidateAppSettings = (_aiAutoEnablePending && hasActiveAi)
           ? _appSettings.copyWith(
               reportInsightsUseAI: true,
               todayThoughtsUseAI: true,
@@ -1280,6 +1293,9 @@ class SettingsService extends ChangeNotifier {
       _multiAISettings = settings;
       if (candidateAppSettings != null) {
         _appSettings = candidateAppSettings;
+        // 自动开启是一次性的：清掉标记，之后用户自己关掉哪个就是哪个。
+        // 清不掉只会多自动开一次，不值得让整个保存失败，所以只记日志。
+        await _clearAiAutoEnablePending();
       }
       notifyListeners();
     } catch (e, s) {
@@ -1294,6 +1310,46 @@ class SettingsService extends ChangeNotifier {
     } finally {
       _saveMultiAiLock = null;
       completer.complete();
+    }
+  }
+
+  /// 这台设备是否还欠一次 AI 功能自动开启，见 [_aiAutoEnablePendingKey]。
+  /// false 表示已经自动开过一次，null（键不存在）才走下面的旧判据。
+  ///
+  /// 读不到标记时回退到旧判据（引导没走完就算新用户）：这个版本之前装的用户
+  /// 没有这个键，不该因为升级就丢掉引导期间的自动开启。
+  bool get _aiAutoEnablePending {
+    try {
+      return _mmkv.getBool(_aiAutoEnablePendingKey) ??
+          !hasCompletedOnboarding();
+    } catch (e) {
+      logDebug('读取 AI 自动开启标记失败: $e');
+      return !hasCompletedOnboarding();
+    }
+  }
+
+  /// 标记「这次自动开启已经做过了」。
+  ///
+  /// 写 false 而不是删键：删掉之后 [_aiAutoEnablePending] 会退回旧判据
+  /// （引导没走完就算新用户），于是引导期间每存一次 AI 设置都会把用户刚关掉的
+  /// 开关再打开一遍。false 是明确的「做过了」，和「老用户，从来没有过这个键」
+  /// （null）是两回事。
+  Future<void> _clearAiAutoEnablePending() async {
+    try {
+      final ok = await _mmkv.setBool(_aiAutoEnablePendingKey, false);
+      if (!ok) {
+        AppLogger.e(
+          '清除 AI 自动开启标记失败：MMKV setBool 返回 false',
+          source: 'SettingsService',
+        );
+      }
+    } catch (e, s) {
+      AppLogger.e(
+        '清除 AI 自动开启标记异常',
+        error: e,
+        stackTrace: s,
+        source: 'SettingsService',
+      );
     }
   }
 

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -825,8 +825,12 @@ class SettingsService extends ChangeNotifier {
 
   /// 首次安装时把默认主题风格（[ThemeStyle.freshInstallStyle]，信笺）种进存储。
   ///
-  /// **只在键还空着时写。** 从备份恢复、或者主题层因为某些路径先跑了一步，
-  /// 都可能已经有取值，覆盖掉就是替用户改外观。
+  /// **只在键还空着时写。** 主题层因为某些路径先跑了一步就可能已经有取值，
+  /// 覆盖掉就是替用户改外观。
+  ///
+  /// 注意备份**目前不含**主题风格（[getAllSettingsForBackup] 只带 app_settings /
+  /// theme_mode 等几项），所以「换机恢复后风格回到自己选的那套」这件事这里兜不住，
+  /// 那是备份契约的既有缺口，要补也是补在备份那一侧。
   ///
   /// 写失败只记日志：拿不到品牌默认外观是可以接受的降级，让整个设置加载失败不是。
   Future<void> _seedFreshInstallThemeStyle() async {

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -18,6 +18,7 @@ import 'package:thoughtecho/utils/sentry_network_tracing.dart';
 import '../utils/lww_utils.dart';
 
 import '../services/mmkv_service.dart';
+import '../theme/theme_style.dart';
 import 'excerpt_intent_service.dart';
 import 'location_service.dart';
 
@@ -760,6 +761,12 @@ class SettingsService extends ChangeNotifier {
       // 不值得让整个设置加载失败。
       await _writeLastSeenReleaseVersion(ReleaseHighlights.latestVersion);
 
+      // 全新安装的默认主题风格是信笺，种在这里而不是主题层：
+      // AppTheme.initialize() 跑在 SettingsService.create() 之后，那时
+      // app_installed_v2 和 app_settings 都已写好，主题层再反推「是不是全新安装」
+      // 只会推成老用户——#513 的默认值一直没生效就是这个原因。
+      await _seedFreshInstallThemeStyle();
+
       // 首次安装时，载入应用默认设置
       _loadAppSettings();
       _appSettings = _appSettings.copyWith(
@@ -801,6 +808,35 @@ class SettingsService extends ChangeNotifier {
     await _syncExcerptIntentEntryPoint();
 
     notifyListeners();
+  }
+
+  /// 首次安装时把默认主题风格（[ThemeStyle.freshInstallStyle]，信笺）种进存储。
+  ///
+  /// **只在键还空着时写。** 从备份恢复、或者主题层因为某些路径先跑了一步，
+  /// 都可能已经有取值，覆盖掉就是替用户改外观。
+  ///
+  /// 写失败只记日志：拿不到品牌默认外观是可以接受的降级，让整个设置加载失败不是。
+  Future<void> _seedFreshInstallThemeStyle() async {
+    try {
+      if (_mmkv.containsKey(ThemeStyle.storageKey)) return;
+      final success = await _mmkv.setString(
+        ThemeStyle.storageKey,
+        ThemeStyle.freshInstallStyle.name,
+      );
+      if (!success) {
+        logError(
+          '写入全新安装默认主题风格 ${ThemeStyle.freshInstallStyle.name} 返回 false',
+          source: 'SettingsService',
+        );
+      }
+    } catch (e, stack) {
+      logError(
+        '写入全新安装默认主题风格失败',
+        error: e,
+        stackTrace: stack,
+        source: 'SettingsService',
+      );
+    }
   }
 
   Future<void> _syncExcerptIntentEntryPoint() async {

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -359,7 +359,7 @@ class AppTheme with ChangeNotifier {
   static const String _useCustomColorKey = 'use_custom_color';
   static const String _themeModeKey = 'theme_mode';
   static const String _useDynamicColorKey = 'use_dynamic_color'; // 添加动态取色设置键
-  static const String _themeStyleKey = 'theme_style';
+  static const String _themeStyleKey = ThemeStyle.storageKey;
 
   /// 墨色的持久化键前缀，**每套风格一条**（`theme_accent_paper` …）。
   /// 见 [accentFor]：墨色跟着风格走，不是全局一支。
@@ -833,26 +833,32 @@ class AppTheme with ChangeNotifier {
       if (styleName != null) {
         _themeStyle = ThemeStyle.fromName(styleName);
       } else {
-        // 未显式配置过主题风格
-        // 检查是否为全新安装（即未标记 app_installed_v2 且未存过 app_settings）
+        // 没存过风格。正常路径下全新安装的默认值（信笺）已经由
+        // SettingsService 在识别到首次安装的那一刻种进同一个键了，
+        // 所以走到这里的基本都是老用户——他们继续拿 defaultStyle，外观不动。
+        //
+        // 下面这段只是兜底：主题层先于设置层起来（测试、或者将来启动顺序变了）时，
+        // 首次安装的标记还没写，这里仍然认得出全新安装。判据必须同时看
+        // app_installed_v2 和 app_settings：SettingsService 一旦跑过就两个都有，
+        // 那时反推出来的一定是「老用户」，兜底自然让位给种下的值。
         final isNewInstallation =
             (_storage?.getBool('app_installed_v2') != true) &&
                 !(_storage?.containsKey('app_settings') ?? false);
         if (isNewInstallation) {
-          _themeStyle = ThemeStyle.paper;
+          _themeStyle = ThemeStyle.freshInstallStyle;
           try {
             final success = await _storage
-                ?.setString(_themeStyleKey, ThemeStyle.paper.name)
+                ?.setString(_themeStyleKey, ThemeStyle.freshInstallStyle.name)
                 .timeout(const Duration(seconds: 2));
             if (success == false) {
               logError(
-                '写入默认主题风格 ThemeStyle.paper 返回 false',
+                '写入默认主题风格 ${ThemeStyle.freshInstallStyle.name} 返回 false',
                 source: 'AppTheme',
               );
             }
           } catch (e, s) {
             logError(
-              '写入默认主题风格 ThemeStyle.paper 失败',
+              '写入默认主题风格 ${ThemeStyle.freshInstallStyle.name} 失败',
               error: e,
               stackTrace: s,
               source: 'AppTheme',

--- a/lib/theme/theme_style.dart
+++ b/lib/theme/theme_style.dart
@@ -66,6 +66,21 @@ enum ThemeStyle {
   /// 默认值只写在这里一处，其它地方（字段初值、异常兜底）都引用它。
   static const ThemeStyle defaultStyle = ThemeStyle.material;
 
+  /// 全新安装拿到的风格：信笺（[ThemeStyle.paper]）。
+  ///
+  /// 和 [defaultStyle] 分开是刻意的：老用户（升级、以及任何存过设置的安装）继续走
+  /// [defaultStyle]，外观不因升级自己变掉；只有**首次安装**这一次会种下信笺。
+  ///
+  /// 种默认值的时机在 `SettingsService._loadSettings()` 识别到首次安装的那一刻，
+  /// 不在 `AppTheme`：`AppTheme.initialize()` 跑在 `SettingsService.create()` 之后，
+  /// 那时首次安装的标记（`app_installed_v2`）和 `app_settings` 都已写好，主题层再去
+  /// 反推「是不是全新安装」永远会推成老用户——#513 的默认值没生效就是这个原因。
+  static const ThemeStyle freshInstallStyle = ThemeStyle.paper;
+
+  /// 主题风格的持久化键。主题层和设置层都要读写它（见 [freshInstallStyle]），
+  /// 所以键写在这一处，两边引用，不各自写字面量。
+  static const String storageKey = 'theme_style';
+
   static ThemeStyle fromName(String? name) {
     if (name == null) return defaultStyle;
     for (final style in ThemeStyle.values) {

--- a/test/unit/controllers/onboarding_controller_test.dart
+++ b/test/unit/controllers/onboarding_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/controllers/onboarding_controller.dart';
 import 'package:thoughtecho/services/api_service.dart';
+import 'package:thoughtecho/services/settings_service.dart';
 
 import '../../test_harness.dart';
 
@@ -38,6 +39,46 @@ void main() {
         sut.state.getPreference<String>('dailyQuoteProvider'),
         ApiService.zenQuotesProvider,
       );
+    });
+  });
+
+  group('OnboardingController AI 快捷开关', () {
+    late SettingsService settingsService;
+
+    setUp(() async {
+      await TestHarness.initialize();
+      sut = OnboardingController();
+      settingsService = await SettingsService.create();
+    });
+
+    tearDown(() async {
+      sut.dispose();
+      await TestHarness.tearDown();
+    });
+
+    test('引导页没表过态时，不覆盖今日思考 / 周期报告的现有取值', () async {
+      // 新用户在引导里配好 AI 服务后的状态：两个开关都已经开着。
+      await settingsService.setTodayThoughtsUseAI(true);
+      await settingsService.setReportInsightsUseAI(true);
+
+      // 引导页里根本没有这两个开关，所以 preferences 里不会有它们的取值。
+      await sut.applyAiTogglePreferences(settingsService);
+
+      // 曾经这里会被无条件写成 false——新用户装完什么都没开就是这么来的。
+      expect(settingsService.todayThoughtsUseAI, isTrue);
+      expect(settingsService.reportInsightsUseAI, isTrue);
+    });
+
+    test('引导页表过态时，按用户选的写', () async {
+      await settingsService.setTodayThoughtsUseAI(true);
+      await settingsService.setReportInsightsUseAI(true);
+
+      sut.updatePreference('todayThoughtsUseAI', false);
+      sut.updatePreference('reportInsightsUseAI', false);
+      await sut.applyAiTogglePreferences(settingsService);
+
+      expect(settingsService.todayThoughtsUseAI, isFalse);
+      expect(settingsService.reportInsightsUseAI, isFalse);
     });
   });
 }

--- a/test/unit/services/settings_service_test.dart
+++ b/test/unit/services/settings_service_test.dart
@@ -9,6 +9,8 @@ import 'package:thoughtecho/models/app_settings.dart';
 import 'package:thoughtecho/services/api_service.dart';
 import 'package:thoughtecho/services/mmkv_service.dart';
 import 'package:thoughtecho/services/settings_service.dart';
+import 'package:thoughtecho/theme/app_theme.dart';
+import 'package:thoughtecho/theme/theme_style.dart';
 import '../../test_harness.dart';
 
 void main() {
@@ -340,6 +342,51 @@ void main() {
       expect(rebuiltService.sentryDisclosureShown, isTrue);
       expect(rebuiltService.appSettings.sentryEnabled, isTrue);
       expect(rebuiltService.appSettings.sentryDisclosureShown, isTrue);
+    });
+
+    group('全新安装默认主题风格', () {
+      test('首次安装种下信笺', () async {
+        // setUp 里的 create() 走的正是首次安装分支。
+        expect(
+          MMKVService().getString(ThemeStyle.storageKey),
+          ThemeStyle.freshInstallStyle.name,
+        );
+        expect(ThemeStyle.freshInstallStyle, ThemeStyle.paper);
+      });
+
+      test('随后初始化的 AppTheme 读到的就是信笺', () async {
+        // #513 的默认值一直没生效就败在这个顺序上：SettingsService 先跑，
+        // app_installed_v2 / app_settings 已经写好，主题层再反推「是不是全新安装」
+        // 只会推成老用户，于是新装用户看到的还是 material。
+        final appTheme = AppTheme();
+        await appTheme.initialize();
+        expect(appTheme.themeStyle, ThemeStyle.paper);
+      });
+
+      test('老用户不会被种上风格', () async {
+        await MMKVService().remove(ThemeStyle.storageKey);
+        await MMKVService().setBool('app_installed_v2', true);
+
+        await SettingsService.create();
+
+        expect(MMKVService().getString(ThemeStyle.storageKey), isNull);
+      });
+
+      test('已经有风格取值时不覆盖', () async {
+        // 从备份恢复出来的取值也是用户自己选的，覆盖掉就是替他改外观。
+        await MMKVService().setString(
+          ThemeStyle.storageKey,
+          ThemeStyle.plain.name,
+        );
+        await MMKVService().remove('app_installed_v2');
+
+        await SettingsService.create();
+
+        expect(
+          MMKVService().getString(ThemeStyle.storageKey),
+          ThemeStyle.plain.name,
+        );
+      });
     });
 
     group('更新说明已读版本', () {

--- a/test/unit/services/settings_service_test.dart
+++ b/test/unit/services/settings_service_test.dart
@@ -505,6 +505,68 @@ void main() {
       expect(rebuiltService.aiCardGenerationEnabled, isTrue);
     });
 
+    test('新用户走完引导之后才配置 AI，同样自动开启相关 AI 功能', () async {
+      // 新用户很多是先跳过 AI、走完引导，之后才去设置页配服务的。
+      // 旧判据只看 hasCompletedOnboarding，这条路径上自动开启永远轮不到他。
+      //
+      // 存储在同一个 isolate 里是复用的，setUp 的 create() 未必再走首次安装分支，
+      // 所以这里把安装标记清掉重建一次，拿到一个真正「全新安装」的服务。
+      await MMKVService().remove('app_installed_v2');
+      final service = await SettingsService.create();
+
+      await service.setHasCompletedOnboarding(true);
+      await service.setReportInsightsUseAI(false);
+      await service.setTodayThoughtsUseAI(false);
+      await service.setAICardGenerationEnabled(false);
+
+      await service.saveMultiAISettings(
+        service.multiAISettings.copyWith(
+          providers: [
+            const AIProviderSettings(
+              id: 'late_provider',
+              name: 'Late AI',
+              apiUrl: 'https://api.openai.com/v1',
+              model: 'gpt-4o',
+              isEnabled: true,
+            ),
+          ],
+        ),
+      );
+
+      expect(service.reportInsightsUseAI, isTrue);
+      expect(service.todayThoughtsUseAI, isTrue);
+      expect(service.aiCardGenerationEnabled, isTrue);
+    });
+
+    test('自动开启只做一次，用户自己关掉后不会被再打开', () async {
+      await MMKVService().remove('app_installed_v2');
+      final service = await SettingsService.create();
+      await service.setHasCompletedOnboarding(false);
+
+      final providers = [
+        const AIProviderSettings(
+          id: 'once_provider',
+          name: 'Once AI',
+          apiUrl: 'https://api.openai.com/v1',
+          model: 'gpt-4o',
+          isEnabled: true,
+        ),
+      ];
+
+      await service.saveMultiAISettings(
+        service.multiAISettings.copyWith(providers: providers),
+      );
+      expect(service.reportInsightsUseAI, isTrue);
+
+      // 用户看过之后自己把周期报告的 AI 洞察关了——再改 AI 服务不该把它又打开。
+      await service.setReportInsightsUseAI(false);
+      await service.saveMultiAISettings(
+        service.multiAISettings.copyWith(providers: providers),
+      );
+
+      expect(service.reportInsightsUseAI, isFalse);
+    });
+
     test('无效或禁用的 AI 服务不应触发自动开启 AI 功能', () async {
       // Arrange
       await settingsService.setHasCompletedOnboarding(false);


### PR DESCRIPTION
修两件「新用户装完什么都没生效」的事，根因都在写入时机。

## 1. 新装默认主题没生效（#513 的续）

`#513` 把「全新安装默认信笺」写在 `AppTheme._loadThemeStyle()` 里，靠 `app_installed_v2` / `app_settings` **反推**是不是全新安装。但 `main.dart` 的启动顺序是：

1. `SettingsService.create()` —— 它在识别到首次安装时就写好了 `app_installed_v2` 和 `app_settings`；
2. `await appTheme.initialize()` —— 这时再反推，两个键都在，永远推成「老用户」。

于是新装用户落回 `ThemeStyle.defaultStyle`（material）。

改动：

- `ThemeStyle` 新增 `freshInstallStyle`（= `paper`，信笺）和 `storageKey`，默认值和持久化键各只写一处。
- `SettingsService._loadSettings()` 在首次安装分支里种下 `theme_style = paper`，只在键还空着时写；写失败只记日志。
- `AppTheme._loadThemeStyle()` 保留原来那段反推作为兜底（主题层先于设置层起来时仍认得出全新安装），设置层跑过之后它自然让位。

老用户不变：没存过风格仍是 `defaultStyle`（material），升级后外观不会自己变。

## 2. 今日思考 / 周期报告的 AI 开关被引导页关掉

实测新用户装完只有 AI 卡片生成是开的。根因在 `OnboardingController._saveUserPreferences()`：引导页里**根本没有** `todayThoughtsUseAI` / `reportInsightsUseAI` 这两个开关，`getPreference` 永远返回 null，而那两行写的是 `?? false` —— 引导一走完就把它们无条件写成关闭，一次性抹掉 `todayThoughtsUseAI` 的默认开启和 #513 在用户配好 AI 时做的自动开启。`aiCardGenerationEnabled` 兜底写的是 `?? true`，所以只有它活了下来。

改动：

- 没表过态就不写（逻辑抽成 `applyAiTogglePreferences`，便于测试）。
- 另一条路径：#513 的自动开启只在 `hasCompletedOnboarding == false` 时生效，而新用户很多是先跳过 AI、走完引导之后才去设置页配服务的，那时自动开启永远轮不到他。改用一次性标记 `ai_auto_enable_pending_v1`：首次安装时种下，配好有效 AI 服务的那一刻不管在哪都生效，生效后置为 `false`（不是删键——删了会退回旧判据，引导期间每存一次 AI 设置就把用户刚关掉的开关再打开一遍）。老用户没有这个键，回退旧判据，行为不变，尤其不会把他自己关掉的周期报告 AI 洞察又打开。

## 测试

本地装了 Flutter 3.47.2（与 CI 的 `FLUTTER_VERSION: 3.47.x` 一致）实跑：

- `flutter analyze` 全库：只剩 3 条既有的 `cacheExtent` deprecation info，均在未改动文件。
- `flutter test test/unit/services/settings_service_test.dart test/unit/theme/app_theme_test.dart test/unit/controllers/onboarding_controller_test.dart`：全部通过。
- 反向验证：临时去掉种默认风格的调用后，新增的两条主题用例（含按真实启动顺序断言 `AppTheme` 读到信笺的那条）如期失败。

新增用例：

- 首次安装种下信笺；随后初始化的 `AppTheme` 读到的就是信笺；老用户不会被种上风格；已有风格取值时不覆盖。
- 引导页没表过态时不覆盖两个 AI 开关的现有取值；表过态时按用户选的写。
- 新用户走完引导之后才配置 AI，同样自动开启；自动开启只做一次，用户自己关掉后不会被再打开。

> 全量 `flutter test test/unit` 另有 13 个文件在本地加载失败，是本地 stable 分支的 `TextInputClient.onFocusReceived` 与 `flutter_quill 11.5.0` 不兼容（编译期就挂，与本 PR 无关），以 CI 的固定版本为准。

## 已知、未在本 PR 处理

审查指出换机恢复带不回用户选的风格。属实，但 `getAllSettingsForBackup()` 从来就不含 `theme_style`，是备份契约的既有缺口，不是本次改动引入的；本 PR 不扩大范围去动备份格式，只把相关注释的说法改准确。