### PR TITLE
🩺 Guardian: 安全防护 restoreSettingsFromBackup 中的 theme_mode 类型强转

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -1,0 +1,3 @@
+## 2026-08-30 - [Stability & Availability] JSON 恢复/反序列化时的枚举索引类型强转陷阱
+**Learning:** 在解析备份数据或 JSON 负载中的 enum 索引（如 `ThemeMode.values[index]`）时，不可直接使用 `as int` 强转。若数据源由 JavaScript/Web 生成（可能将 int 序列化为 double，如 `2.0`），或输入越界索引/非法类型，直接强转会导致 `TypeError` 或 `RangeError` 崩溃。
+**Action:** 使用 `(raw is num) ? raw.toInt() : int.tryParse(raw?.toString() ?? '')` 安全解析，并校验 `index >= 0 && index < Enum.values.length` 范围后再取枚举值。

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1449,9 +1449,16 @@ class SettingsService extends ChangeNotifier {
 
       // 恢复主题模式
       if (backupData.containsKey('theme_mode')) {
-        final themeModeIndex = backupData['theme_mode'] as int;
-        final themeMode = ThemeMode.values[themeModeIndex];
-        await updateThemeMode(themeMode);
+        final rawThemeMode = backupData['theme_mode'];
+        final themeModeIndex = (rawThemeMode is num)
+            ? rawThemeMode.toInt()
+            : int.tryParse(rawThemeMode?.toString() ?? '');
+        if (themeModeIndex != null &&
+            themeModeIndex >= 0 &&
+            themeModeIndex < ThemeMode.values.length) {
+          final themeMode = ThemeMode.values[themeModeIndex];
+          await updateThemeMode(themeMode);
+        }
       }
 
       // 恢复/记录 device_id（不覆盖本地已有，仅在本地不存在时写入，保持源ID可用于审计）

--- a/test/unit/services/settings_service_test.dart
+++ b/test/unit/services/settings_service_test.dart
@@ -631,5 +631,37 @@ void main() {
       final rebuiltService = await SettingsService.create();
       expect(rebuiltService.hasCompletedOnboarding(), isTrue);
     });
+
+    group('restoreAllSettingsFromBackup 类型防护测试', () {
+      test('theme_mode 为 double 浮点数时安全转换不崩溃', () async {
+        await settingsService.updateThemeMode(ThemeMode.light);
+
+        await settingsService.restoreAllSettingsFromBackup({
+          'theme_mode': 2.0, // ThemeMode.dark 的索引是 2
+        });
+
+        expect(settingsService.themeMode, ThemeMode.dark);
+      });
+
+      test('theme_mode 为越界 int 时安全防范不崩溃并保留原有主题', () async {
+        await settingsService.updateThemeMode(ThemeMode.light);
+
+        await settingsService.restoreAllSettingsFromBackup({
+          'theme_mode': 99,
+        });
+
+        expect(settingsService.themeMode, ThemeMode.light);
+      });
+
+      test('theme_mode 为非法 String 时安全防范不崩溃', () async {
+        await settingsService.updateThemeMode(ThemeMode.light);
+
+        await settingsService.restoreAllSettingsFromBackup({
+          'theme_mode': 'invalid_theme_index',
+        });
+
+        expect(settingsService.themeMode, ThemeMode.light);
+      });
+    });
   });
 }


### PR DESCRIPTION
🏷️ 问题类别: 🩺 Stability & Availability (稳定性与可用性)
💡 隐患剖析: 在 `SettingsService.restoreAllSettingsFromBackup` 恢复主题设置时，直接对 JSON 字段进行 `backupData['theme_mode'] as int` 强转。当数据源来自 Web/JS 或非法格式（如 double `2.0`、字符串或超出 `ThemeMode.values` 范围的索引）时，会导致 `TypeError` 或 `RangeError` 崩溃。
🎯 解决方案: 将强转收敛为 `(raw is num) ? raw.toInt() : int.tryParse(...)`，并添加 `0 <= index < ThemeMode.values.length` 范围校验。补充覆盖各种异常类型输入的单元测试。
📊 收益影响: 提升了从备份恢复设置时的健壮度与应用可用性，防止恢复特定设备备份时因类型转换失败而发生应用崩塌。
🔬 验证方式: 运行 `flutter analyze --no-fatal-infos` 和 `flutter test test/unit/services/settings_service_test.dart` 验证通过。

---
*PR created automatically by Jules for task [8070661926711945307](https://jules.google.com/task/8070661926711945307) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `restoreAllSettingsFromBackup` 恢复 `theme_mode` 时直接使用 `as int` 强转可能导致的崩溃。现在会安全解析数值类型并校验索引范围，非法输入（如 double、越界、字符串）会被忽略并保留原有主题。

**测试与记录**
- 新增单元测试覆盖 double 类型、越界索引和非法字符串输入。
- 在 `.jules/guardian.md` 中记录该类型强转陷阱及安全解析方法。

<sup>Written for commit 5a986b6ecb0c1c69aa48235546ed99dc44e370bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Sourcery 总结

增强主题模式恢复功能，使其能够应对格式错误的备份数据；当值无效时，保留现有主题。

Bug 修复：
- 通过安全解析并验证索引，避免从包含浮点数、无效字符串或超出范围的主题模式值的备份中恢复主题设置时发生崩溃。

测试：
- 为备份恢复过程中有效的浮点数、超出范围的值以及无效字符串主题模式输入添加单元测试覆盖。

杂项：
- 记录 JSON 和备份反序列化过程中安全解析枚举索引的指导原则。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden theme mode restoration against malformed backup data while preserving the existing theme when the value is invalid.

Bug Fixes:
- Prevent crashes when restoring theme settings from backups containing floating-point, invalid string, or out-of-range theme mode values by safely parsing and validating the index.

Tests:
- Add unit coverage for valid floating-point, out-of-range, and invalid string theme mode inputs during backup restoration.

Chores:
- Document safe enum-index parsing guidance for JSON and backup deserialization.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme restoration from backups containing decimal-formatted, invalid, or out-of-range values.
  * Prevented backup restoration from crashing when theme settings are malformed.
  * Preserved the existing theme when a backup value cannot be safely applied.

* **Tests**
  * Added coverage for valid decimal indices, invalid strings, and out-of-range values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->