### PR TITLE
feat(ai,model): 优化原创与摘录归属启发式判定并修复 Dreaming 未来时钟死锁

### DIFF
--- a/lib/models/quote_model.dart
+++ b/lib/models/quote_model.dart
@@ -506,23 +506,246 @@ class Quote {
   bool get hasTags => tagIds.isNotEmpty;
   bool get hasKeywords => keywords != null && keywords!.isNotEmpty;
 
+  /// 内置的自指代作者关键词（全小写）。
+  static const Set<String> _builtinSelfAuthorKeywords = <String>{
+    '我',
+    '自己',
+    '本人',
+    '自作',
+    '自撰',
+    '原创',
+    '自述',
+    '笔者',
+    '作者',
+    'me',
+    'myself',
+    'i',
+    'self',
+    'author',
+    'original',
+  };
+
+  /// 内置的个人日记/随笔出处关键词（全小写）。
+  static const Set<String> _builtinSelfSourceKeywords = <String>{
+    '日记',
+    '随笔',
+    '随手记',
+    '我的日记',
+    '思考',
+    '随想',
+    '自留地',
+    'diary',
+    'journal',
+    'notes',
+    'memo',
+  };
+
+  static String _stripAuthorPrefix(String text) {
+    var trimmed = text.trim();
+    if (trimmed.startsWith('——') || trimmed.startsWith('—')) {
+      trimmed = trimmed.replaceFirst(RegExp(r'^[—–—]+\s*'), '').trim();
+    }
+    final lower = trimmed.toLowerCase();
+    if (lower.startsWith('作者：') || lower.startsWith('作者:')) {
+      return trimmed.substring(3).trim();
+    }
+    if (lower.startsWith('author:') || lower.startsWith('author：')) {
+      return trimmed.substring(7).trim();
+    }
+    if (lower.startsWith('by ') || lower.startsWith('by:')) {
+      return trimmed.substring(3).trim();
+    }
+    return trimmed;
+  }
+
+  /// 判断给定的作者字符串是否属于用户自身（自指代词或命中用户昵称/默认作者/别名）。
+  static bool isSelfAuthor(
+    String? author, {
+    String? userNickname,
+    String? defaultAuthor,
+    Iterable<String>? userAliases,
+  }) {
+    if (author == null) return false;
+    var trimmed = author.trim();
+    if (trimmed.isEmpty) return false;
+
+    trimmed = _stripAuthorPrefix(trimmed);
+    if (trimmed.isEmpty) return false;
+
+    final lower = trimmed.toLowerCase();
+
+    // 1. 检查内置自指代词
+    if (_builtinSelfAuthorKeywords.contains(lower)) {
+      return true;
+    }
+
+    // 2. 检查用户设置的昵称
+    if (userNickname != null && userNickname.trim().isNotEmpty) {
+      if (lower == userNickname.trim().toLowerCase()) {
+        return true;
+      }
+    }
+
+    // 3. 检查默认作者设置
+    if (defaultAuthor != null && defaultAuthor.trim().isNotEmpty) {
+      if (lower == defaultAuthor.trim().toLowerCase()) {
+        return true;
+      }
+    }
+
+    // 4. 检查额外别名列表
+    if (userAliases != null) {
+      for (final alias in userAliases) {
+        final a = alias.trim();
+        if (a.isNotEmpty && lower == a.toLowerCase()) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
   /// 这条笔记带没带归属标注（作者 / 出处 / 旧数据里未拆分的来源串）。
   bool get hasAttribution =>
       (sourceAuthor?.trim().isNotEmpty ?? false) ||
       (sourceWork?.trim().isNotEmpty ?? false) ||
       (_source?.trim().isNotEmpty ?? false);
 
-  /// 喂给模型时用的归属类型：`excerpt`（摘录）/ `original`（用户原创）。
+  /// 判断该笔记的署名/出处是否为用户本人的原创标注（而非摘录外部作品）。
+  bool isSelfAttributed({
+    String? userNickname,
+    String? defaultAuthor,
+    String? defaultSource,
+    Iterable<String>? userAliases,
+  }) {
+    // 1. 若有明确的作者标注，以作者判定为主
+    if (sourceAuthor != null && sourceAuthor!.trim().isNotEmpty) {
+      return isSelfAuthor(
+        sourceAuthor,
+        userNickname: userNickname,
+        defaultAuthor: defaultAuthor,
+        userAliases: userAliases,
+      );
+    }
+
+    // 2. 若作者为空，检查旧数据中未拆分的 source / _source
+    final rawSource = _source?.trim();
+    if (rawSource != null && rawSource.isNotEmpty) {
+      // 2.1 整体命中自指代作者或用户别名
+      if (isSelfAuthor(
+        rawSource,
+        userNickname: userNickname,
+        defaultAuthor: defaultAuthor,
+        userAliases: userAliases,
+      )) {
+        return true;
+      }
+
+      // 2.2 拆分「作者 - 出处」或「作者 —— 出处」格式
+      final parts = rawSource.split(RegExp(r'\s*[-—–：:]\s*'));
+      if (parts.length >= 2) {
+        final authorCandidate = parts.first.trim();
+        if (isSelfAuthor(
+          authorCandidate,
+          userNickname: userNickname,
+          defaultAuthor: defaultAuthor,
+          userAliases: userAliases,
+        )) {
+          return true;
+        }
+      }
+
+      // 2.3 来源整体为日记/随笔类词汇或命中 defaultSource
+      final lowerSource = rawSource.toLowerCase();
+      if (_builtinSelfSourceKeywords.contains(lowerSource)) {
+        return true;
+      }
+      if (defaultSource != null &&
+          defaultSource.trim().isNotEmpty &&
+          lowerSource == defaultSource.trim().toLowerCase()) {
+        return true;
+      }
+    }
+
+    // 3. 若作者为空且无 rawSource，但有 sourceWork
+    final work = sourceWork?.trim();
+    if (work != null && work.isNotEmpty) {
+      final lowerWork = work.toLowerCase();
+      if (_builtinSelfSourceKeywords.contains(lowerWork)) {
+        return true;
+      }
+      if (defaultSource != null &&
+          defaultSource.trim().isNotEmpty &&
+          lowerWork == defaultSource.trim().toLowerCase()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// 判断该笔记是否为摘录（引用他人的文字）。
+  ///
+  /// 若笔记无任何归属标注，或标注属于用户本人的原创署名（如用户昵称、笔名、"我"、"自作"、"日记"等），
+  /// 则不属于摘录；只有标注了外部作者或外部作品时才判定为摘录。
+  bool isExcerpt({
+    String? userNickname,
+    String? defaultAuthor,
+    String? defaultSource,
+    Iterable<String>? userAliases,
+  }) {
+    if (!hasAttribution) {
+      return false;
+    }
+    if (isSelfAttributed(
+      userNickname: userNickname,
+      defaultAuthor: defaultAuthor,
+      defaultSource: defaultSource,
+      userAliases: userAliases,
+    )) {
+      return false;
+    }
+    return true;
+  }
+
+  /// 判断该笔记是否为用户原创。
+  bool isOriginal({
+    String? userNickname,
+    String? defaultAuthor,
+    String? defaultSource,
+    Iterable<String>? userAliases,
+  }) =>
+      !isExcerpt(
+        userNickname: userNickname,
+        defaultAuthor: defaultAuthor,
+        defaultSource: defaultSource,
+        userAliases: userAliases,
+      );
+
+  /// 解析归属类型字符串：`excerpt`（摘录）/ `original`（用户原创）。
   ///
   /// 模型反复把摘录当成用户的自白——「我看到了这段文字，却在分析时把它当成了
   /// 你的自白」是它自己的原话。根因是它只拿到 author / source 两个字段，
   /// 得自己推断这条是谁写的，而推断在长上下文里第一个失效。这里替它把结论
-  /// 算好：有归属标注就是摘录。
-  ///
-  /// 判断依据只有标注，所以不是绝对的——用户也可能给自己的原创署名。那种
-  /// 情况由提示词里的例外条款兜底（署的是用户自己的称呼时按原创对待），
-  /// 而不是在这里猜。
-  String get attributionKind => hasAttribution ? 'excerpt' : 'original';
+  /// 算好：外部归属为摘录，无标注或用户原创署名（含昵称、默认作者、自指代词）为原创。
+  String resolveAttributionKind({
+    String? userNickname,
+    String? defaultAuthor,
+    String? defaultSource,
+    Iterable<String>? userAliases,
+  }) =>
+      isExcerpt(
+        userNickname: userNickname,
+        defaultAuthor: defaultAuthor,
+        defaultSource: defaultSource,
+        userAliases: userAliases,
+      )
+          ? 'excerpt'
+          : 'original';
+
+  /// 喂给模型时用的归属类型：`excerpt`（摘录）/ `original`（用户原创）。
+  String get attributionKind => resolveAttributionKind();
 
   /// 获取情感分析的中文标签
   String? get sentimentLabel =>

--- a/lib/models/quote_model.dart
+++ b/lib/models/quote_model.dart
@@ -642,8 +642,9 @@ class Quote {
         return true;
       }
 
-      // 2.2 拆分「作者 - 出处」或「作者 —— 出处」格式
-      final parts = rawSource.split(RegExp(r'\s*[-—–：:]\s*'));
+      // 2.2 剥离可能存在的「作者：/ author: / ——」前缀后，拆分「作者 - 出处」或「作者：出处」格式
+      final normalizedSource = _stripAuthorPrefix(rawSource);
+      final parts = normalizedSource.split(RegExp(r'\s*[-—–：:]\s*'));
       if (parts.length >= 2) {
         final authorCandidate = parts.first.trim();
         if (isSelfAuthor(

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -48,14 +48,14 @@ List<AgentTool> _buildAgentTools(
   ChatSessionService chatSessionService,
 ) {
   return [
-    ExploreNotesTool(db),
+    ExploreNotesTool(db, settingsService),
     GetTagsTool(db),
     GetLocationWeatherTool(
       locationService: locationService,
       weatherService: weatherService,
       settingsService: settingsService,
     ),
-    GetNoteDetailTool(db),
+    GetNoteDetailTool(db, settingsService),
     WebSearchTool(settingsService),
     WebFetchTool(WebFetchService()),
     ProposeNoteCreateTool(db),

--- a/lib/services/agent_tools/explore_notes_tool.dart
+++ b/lib/services/agent_tools/explore_notes_tool.dart
@@ -3,6 +3,7 @@ import '../../utils/app_logger.dart';
 import '../../utils/untrusted_text.dart';
 import '../agent_tool.dart';
 import '../database_service.dart';
+import '../settings_service.dart';
 import 'tag_argument_resolver.dart';
 
 /// 探索笔记工具 - 支持多维筛选与分页
@@ -13,8 +14,9 @@ import 'tag_argument_resolver.dart';
 /// 3. 提供概览信息，让 AI 具备“主观能动性”去决定下一步动作
 class ExploreNotesTool extends AgentTool {
   final DatabaseService _db;
+  final SettingsService? _settingsService;
 
-  const ExploreNotesTool(this._db);
+  const ExploreNotesTool(this._db, [this._settingsService]);
 
   @override
   String get name => 'explore_notes';
@@ -188,8 +190,13 @@ class ExploreNotesTool extends AgentTool {
           'id': q.id,
           // type 排在正文前面：模型得先知道这段是谁写的再读它。放在末尾
           // 的 author / source 等于让它读完才发现"哦这是摘录"——那时它
-          // 已经把这段当成用户的自白读进去了（见 Quote.attributionKind）。
-          'type': q.attributionKind,
+          // 已经把这段当成用户的自白读进去了（见 Quote.resolveAttributionKind）。
+          'type': q.resolveAttributionKind(
+            userNickname: _settingsService?.userNickname,
+            defaultAuthor: _settingsService?.defaultAuthor,
+            defaultSource: _settingsService?.defaultSource,
+            userAliases: _settingsService?.userAliases,
+          ),
           // 笔记正文是用户数据：包裹 <note> 标签并在序列化前完成转义。
           'content_preview': wrapNoteContent(
             _truncate(q.content, 200),

--- a/lib/services/agent_tools/get_note_detail_tool.dart
+++ b/lib/services/agent_tools/get_note_detail_tool.dart
@@ -5,13 +5,15 @@ import '../../utils/agent_note_document_codec.dart';
 import '../../utils/untrusted_text.dart';
 import '../agent_tool.dart';
 import '../database_service.dart';
+import '../settings_service.dart';
 import 'propose_note_edit_tool.dart';
 
 /// 获取单篇笔记详情工具 - 允许 AI 获取笔记的完整正文和元数据
 class GetNoteDetailTool extends AgentTool {
   final DatabaseService _db;
+  final SettingsService? _settingsService;
 
-  const GetNoteDetailTool(this._db);
+  const GetNoteDetailTool(this._db, [this._settingsService]);
 
   @override
   String get name => 'get_note_detail';
@@ -80,7 +82,12 @@ class GetNoteDetailTool extends AgentTool {
         // 和 explore_notes 对齐：`excerpt` / `original`。必须排在 content
         // 前面——排在后面等于让模型读完整段摘录才发现它不是用户写的，
         // 那时它已经把这段当自白读进去了。
-        'type': q.attributionKind,
+        'type': q.resolveAttributionKind(
+          userNickname: _settingsService?.userNickname,
+          defaultAuthor: _settingsService?.defaultAuthor,
+          defaultSource: _settingsService?.defaultSource,
+          userAliases: _settingsService?.userAliases,
+        ),
         // 笔记正文是用户数据：包裹 <note> 标签并在序列化前完成转义。
         'content': wrapNoteContent(q.content, noteId: q.id),
         'date': q.date,

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -722,6 +722,10 @@ class AIService extends ChangeNotifier {
           quotes,
           analysisType: analysisType,
           analysisStyle: analysisStyle,
+          userNickname: _settingsService.userNickname,
+          defaultAuthor: _settingsService.defaultAuthor,
+          defaultSource: _settingsService.defaultSource,
+          userAliases: _settingsService.userAliases,
         );
         final quotesText = _requestHelper.formatJsonData(jsonData);
 
@@ -767,6 +771,10 @@ class AIService extends ChangeNotifier {
       quotes,
       analysisType: analysisType,
       analysisStyle: analysisStyle,
+      userNickname: _settingsService.userNickname,
+      defaultAuthor: _settingsService.defaultAuthor,
+      defaultSource: _settingsService.defaultSource,
+      userAliases: _settingsService.userAliases,
     );
     jsonData['metadata']['customPromptUsed'] =
         (customPrompt != null && customPrompt.isNotEmpty).toString();

--- a/lib/services/dreaming_service.dart
+++ b/lib/services/dreaming_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
@@ -197,9 +198,15 @@ class DreamingService {
     if (last != null && now.difference(last) < minInterval) {
       return false;
     }
-    // 未来时间戳说明设备时钟被调过。按"刚跑过"处理而不是放行：放行会让
-    // 时钟乱跳的设备每次洞察都跑一轮。
+    // 未来时间戳说明设备时钟被调过：
+    // 1. 若落在未来 30 天内：按「刚跑过」处理跳过本轮，防止时钟频繁微调导致每次洞察都跑。
+    // 2. 若超出未来 30 天：说明曾出现重大时钟跳跃且已修正回正常时间，若不自愈会导致
+    //    Dreaming 长期甚至永久死锁。此时重置记录并放行。
     if (last != null && last.isAfter(now)) {
+      if (last.difference(now) > const Duration(days: 30)) {
+        unawaited(_settings.setLastDreamingAt(null));
+        return true;
+      }
       return false;
     }
     return true;
@@ -215,13 +222,23 @@ class DreamingService {
       return null;
     }
 
+    final userNickname = _settings.userNickname;
+    final defaultAuthor = _settings.defaultAuthor;
+    final defaultSource = _settings.defaultSource;
+    final userAliases = _settings.userAliases;
+
     final excerpts = <Quote>[];
     final originals = <Quote>[];
     for (final quote in quotes) {
       if (quote.content.trim().isEmpty) continue;
       // 摘录反映他向往的，原创反映他实际的。两组必须分开归纳，混在一起
       // 会让代笔时照着他摘的去写，产出完全不像他本人。
-      if (quote.attributionKind == 'excerpt') {
+      if (quote.isExcerpt(
+        userNickname: userNickname,
+        defaultAuthor: defaultAuthor,
+        defaultSource: defaultSource,
+        userAliases: userAliases,
+      )) {
         if (excerpts.length < maxSamplePerGroup) excerpts.add(quote);
       } else {
         if (originals.length < maxSamplePerGroup) originals.add(quote);

--- a/lib/services/dreaming_service.dart
+++ b/lib/services/dreaming_service.dart
@@ -195,18 +195,22 @@ class DreamingService {
       return false;
     }
     final last = _settings.lastDreamingAt;
-    if (last != null && now.difference(last) < minInterval) {
-      return false;
+    if (last == null) {
+      return true;
     }
     // 未来时间戳说明设备时钟被调过：
-    // 1. 若落在未来 30 天内：按「刚跑过」处理跳过本轮，防止时钟频繁微调导致每次洞察都跑。
-    // 2. 若超出未来 30 天：说明曾出现重大时钟跳跃且已修正回正常时间，若不自愈会导致
+    // 1. 若超出未来 30 天：说明曾出现重大时钟跳跃且已修正回正常时间，若不自愈会导致
     //    Dreaming 长期甚至永久死锁。此时重置记录并放行。
-    if (last != null && last.isAfter(now)) {
+    // 2. 若落在未来 30 天内：按「刚跑过」处理跳过本轮，防止时钟频繁微调导致每次洞察都跑。
+    if (last.isAfter(now)) {
       if (last.difference(now) > const Duration(days: 30)) {
         unawaited(_settings.setLastDreamingAt(null));
         return true;
       }
+      return false;
+    }
+    // 正常过去的时间戳：检查是否已过最小间隔
+    if (now.difference(last) < minInterval) {
       return false;
     }
     return true;

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -56,11 +56,12 @@ class SettingsService extends ChangeNotifier {
   final SharedPreferences _prefs; // 保留以支持数据迁移
   final MMKVService _mmkv = MMKVService(); // 使用MMKV作为主要存储
   Completer<void>? _saveMultiAiLock;
-  late AISettings _aiSettings;
-  late AppSettings _appSettings;
-  late ThemeMode _themeMode;
-  late MultiAISettings _multiAISettings; // 新增多provider设置
-  late LocalAISettings _localAISettings; // 新增本地AI设置
+  AISettings _aiSettings = AISettings(apiKey: '');
+  AppSettings _appSettings = AppSettings.defaultSettings();
+  ThemeMode _themeMode = ThemeMode.system;
+  MultiAISettings _multiAISettings = const MultiAISettings(); // 新增多provider设置
+  LocalAISettings _localAISettings =
+      LocalAISettings.defaultSettings(); // 新增本地AI设置
 
   // 迁移标志，只执行一次数据迁移
   static const String _migrationCompleteKey = 'mmkv_migration_complete';

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -55,11 +55,12 @@ class SettingsService extends ChangeNotifier {
   static const String _aiAutoEnablePendingKey = 'ai_auto_enable_pending_v1';
   final SharedPreferences _prefs; // 保留以支持数据迁移
   final MMKVService _mmkv = MMKVService(); // 使用MMKV作为主要存储
-  AISettings _aiSettings = const AISettings();
-  AppSettings _appSettings = const AppSettings();
-  ThemeMode _themeMode = ThemeMode.system;
-  MultiAISettings _multiAISettings = const MultiAISettings(); // 新增多provider设置
-  LocalAISettings _localAISettings = const LocalAISettings(); // 新增本地AI设置
+  Completer<void>? _saveMultiAiLock;
+  late AISettings _aiSettings;
+  late AppSettings _appSettings;
+  late ThemeMode _themeMode;
+  late MultiAISettings _multiAISettings; // 新增多provider设置
+  late LocalAISettings _localAISettings; // 新增本地AI设置
 
   // 迁移标志，只执行一次数据迁移
   static const String _migrationCompleteKey = 'mmkv_migration_complete';
@@ -649,7 +650,14 @@ class SettingsService extends ChangeNotifier {
   }
 
   // 默认作者（自动填充）
-  String? get defaultAuthor => _appSettings.defaultAuthor;
+  String? get defaultAuthor {
+    try {
+      return _appSettings.defaultAuthor;
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<void> setDefaultAuthor(String? author) async {
     if (author == null || author.isEmpty) {
       _appSettings = _appSettings.copyWith(clearDefaultAuthor: true);
@@ -661,7 +669,14 @@ class SettingsService extends ChangeNotifier {
   }
 
   // 默认出处（自动填充）
-  String? get defaultSource => _appSettings.defaultSource;
+  String? get defaultSource {
+    try {
+      return _appSettings.defaultSource;
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<void> setDefaultSource(String? source) async {
     if (source == null || source.isEmpty) {
       _appSettings = _appSettings.copyWith(clearDefaultSource: true);

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -162,15 +162,20 @@ class SettingsService extends ChangeNotifier {
   }
 
   /// 写入失败只记日志、不抛：它是一个节流用的时间戳，写丢了最坏结果是下次
-  /// 洞察时多跑一轮归纳，不值得把调用方的流程打断。
-  Future<void> setLastDreamingAt(DateTime value) async {
-    final success = await _mmkv.setInt(
-      _lastDreamingAtKey,
-      value.millisecondsSinceEpoch,
-    );
+  /// 洞察时多跑一轮归纳，不值得把调用方的流程打断。传入 null 表示重置/清除。
+  Future<void> setLastDreamingAt(DateTime? value) async {
+    final bool success;
+    if (value == null) {
+      success = await _mmkv.remove(_lastDreamingAtKey);
+    } else {
+      success = await _mmkv.setInt(
+        _lastDreamingAtKey,
+        value.millisecondsSinceEpoch,
+      );
+    }
     if (!success) {
       AppLogger.w(
-        'Dreaming 时间戳保存失败：MMKV setInt 返回 false',
+        'Dreaming 时间戳保存失败：MMKV 操作返回 false',
         source: 'SettingsService',
       );
       return;

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -126,6 +126,16 @@ class SettingsService extends ChangeNotifier {
 
   String get userNickname => _mmkv.getString(_userNicknameKey) ?? '';
 
+  /// 获取代表用户自身的全部署名别名集合（包含用户称呼与默认作者）。
+  Set<String> get userAliases {
+    final aliases = <String>{};
+    final nick = userNickname.trim();
+    if (nick.isNotEmpty) aliases.add(nick);
+    final author = defaultAuthor?.trim();
+    if (author != null && author.isNotEmpty) aliases.add(author);
+    return aliases;
+  }
+
   /// 写入失败时抛出：静默失败会让用户以为称呼已生效，对话里却一直没有。
   Future<void> setUserNickname(String value) async {
     final success = await _mmkv.setString(_userNicknameKey, value.trim());

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -55,12 +55,11 @@ class SettingsService extends ChangeNotifier {
   static const String _aiAutoEnablePendingKey = 'ai_auto_enable_pending_v1';
   final SharedPreferences _prefs; // 保留以支持数据迁移
   final MMKVService _mmkv = MMKVService(); // 使用MMKV作为主要存储
-  Completer<void>? _saveMultiAiLock;
-  late AISettings _aiSettings;
-  late AppSettings _appSettings;
-  late ThemeMode _themeMode;
-  late MultiAISettings _multiAISettings; // 新增多provider设置
-  late LocalAISettings _localAISettings; // 新增本地AI设置
+  AISettings _aiSettings = const AISettings();
+  AppSettings _appSettings = const AppSettings();
+  ThemeMode _themeMode = ThemeMode.system;
+  MultiAISettings _multiAISettings = const MultiAISettings(); // 新增多provider设置
+  LocalAISettings _localAISettings = const LocalAISettings(); // 新增本地AI设置
 
   // 迁移标志，只执行一次数据迁移
   static const String _migrationCompleteKey = 'mmkv_migration_complete';

--- a/lib/utils/ai_request_helper.dart
+++ b/lib/utils/ai_request_helper.dart
@@ -419,6 +419,10 @@ class AIRequestHelper {
     List<Quote> quotes, {
     String analysisType = 'comprehensive',
     String analysisStyle = 'professional',
+    String? userNickname,
+    String? defaultAuthor,
+    String? defaultSource,
+    Iterable<String>? userAliases,
   }) {
     final selected = selectQuotesForAnalysis(quotes);
     final truncated = selected.length < quotes.length ||
@@ -436,9 +440,22 @@ class AIRequestHelper {
         // 摘录 / 原创的条数摆在开头：一组里九成是摘录时，"这个人这周在想
         // 什么"根本无从谈起，模型得先知道自己手上是什么，而不是读完全部
         // 再回头改口。
-        'originalCount':
-            selected.where((quote) => !quote.hasAttribution).length,
-        'excerptCount': selected.where((quote) => quote.hasAttribution).length,
+        'originalCount': selected
+            .where((quote) => quote.isOriginal(
+                  userNickname: userNickname,
+                  defaultAuthor: defaultAuthor,
+                  defaultSource: defaultSource,
+                  userAliases: userAliases,
+                ))
+            .length,
+        'excerptCount': selected
+            .where((quote) => quote.isExcerpt(
+                  userNickname: userNickname,
+                  defaultAuthor: defaultAuthor,
+                  defaultSource: defaultSource,
+                  userAliases: userAliases,
+                ))
+            .length,
         'truncated': truncated,
         if (truncated) 'truncationNote': '内容有截断：只含最近的部分笔记，超长笔记的正文也被截短',
       },
@@ -449,7 +466,12 @@ class AIRequestHelper {
           // type 放在第一位：模型得先知道这段是谁写的，再读正文。放在
           // sourceAuthor 后面等于让它读完整段才发现"哦这是摘录"——而它
           // 那时已经把这段当成用户的自白读进去了。
-          'type': quote.attributionKind,
+          'type': quote.resolveAttributionKind(
+            userNickname: userNickname,
+            defaultAuthor: defaultAuthor,
+            defaultSource: defaultSource,
+            userAliases: userAliases,
+          ),
           'content': clampQuoteContent(quote.content),
           'date': quote.date,
           'source': quote.source,

--- a/test/unit/models/quote_attribution_test.dart
+++ b/test/unit/models/quote_attribution_test.dart
@@ -188,11 +188,23 @@ void main() {
       test(
           'legacy composite source with external author is classified as excerpt',
           () {
-        final note = createNote(source: '鲁迅 - 狂人日记');
-        expect(note.isSelfAttributed(), isFalse);
-        expect(note.isExcerpt(), isTrue);
-        expect(note.isOriginal(), isFalse);
-        expect(note.attributionKind, 'excerpt');
+        final note1 = createNote(source: '鲁迅 - 狂人日记');
+        expect(note1.isSelfAttributed(), isFalse);
+        expect(note1.isExcerpt(), isTrue);
+        expect(note1.isOriginal(), isFalse);
+        expect(note1.attributionKind, 'excerpt');
+
+        final note2 = createNote(source: '作者：鲁迅 - 狂人日记');
+        expect(note2.isSelfAttributed(), isFalse);
+        expect(note2.isExcerpt(), isTrue);
+        expect(note2.isOriginal(), isFalse);
+        expect(note2.attributionKind, 'excerpt');
+
+        final note3 = createNote(source: 'author: Lu Xun - Diary of a Madman');
+        expect(note3.isSelfAttributed(), isFalse);
+        expect(note3.isExcerpt(), isTrue);
+        expect(note3.isOriginal(), isFalse);
+        expect(note3.attributionKind, 'excerpt');
       });
     });
   });

--- a/test/unit/models/quote_attribution_test.dart
+++ b/test/unit/models/quote_attribution_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/models/quote_model.dart';
+
+void main() {
+  group('Quote attribution classification & identity heuristics', () {
+    Quote createNote({
+      String? author,
+      String? work,
+      String? source,
+      String content = '这是一段笔记内容',
+    }) =>
+        Quote(
+          content: content,
+          date: '2026-08-30T10:00:00Z',
+          sourceAuthor: author,
+          sourceWork: work,
+          source: source,
+        );
+
+    group('hasAttribution', () {
+      test('returns false when no attribution fields are present', () {
+        final note = createNote();
+        expect(note.hasAttribution, isFalse);
+      });
+
+      test('returns false when attribution fields are only whitespace', () {
+        final note = createNote(author: '   ', work: '\t', source: '\n');
+        expect(note.hasAttribution, isFalse);
+      });
+
+      test('returns true when any attribution field is populated', () {
+        expect(createNote(author: '作者').hasAttribution, isTrue);
+        expect(createNote(work: '作品').hasAttribution, isTrue);
+        expect(createNote(source: '来源').hasAttribution, isTrue);
+      });
+    });
+
+    group('isSelfAuthor', () {
+      test('identifies built-in Chinese self-referential words', () {
+        const selfWords = ['我', '自己', '本人', '自作', '自撰', '原创', '自述', '笔者', '作者'];
+        for (final word in selfWords) {
+          expect(Quote.isSelfAuthor(word), isTrue, reason: word);
+          expect(Quote.isSelfAuthor('  $word  '), isTrue, reason: word);
+          expect(Quote.isSelfAuthor('作者：$word'), isTrue, reason: word);
+          expect(Quote.isSelfAuthor('——$word'), isTrue, reason: word);
+        }
+      });
+
+      test(
+          'identifies built-in English self-referential words case-insensitively',
+          () {
+        const selfWords = ['me', 'myself', 'i', 'self', 'author', 'original'];
+        for (final word in selfWords) {
+          expect(Quote.isSelfAuthor(word), isTrue, reason: word);
+          expect(Quote.isSelfAuthor(word.toUpperCase()), isTrue, reason: word);
+          expect(Quote.isSelfAuthor('by $word'), isTrue, reason: word);
+          expect(Quote.isSelfAuthor('Author: $word'), isTrue, reason: word);
+        }
+      });
+
+      test('identifies userNickname', () {
+        expect(Quote.isSelfAuthor('上晋', userNickname: '上晋'), isTrue);
+        expect(Quote.isSelfAuthor('上晋', userNickname: '  上晋  '), isTrue);
+        expect(Quote.isSelfAuthor('Alice', userNickname: 'alice'), isTrue);
+        expect(Quote.isSelfAuthor('鲁迅', userNickname: '上晋'), isFalse);
+      });
+
+      test('identifies defaultAuthor', () {
+        expect(Quote.isSelfAuthor('上晋', defaultAuthor: '上晋'), isTrue);
+        expect(Quote.isSelfAuthor('Bob', defaultAuthor: 'bob'), isTrue);
+        expect(Quote.isSelfAuthor('苏轼', defaultAuthor: '上晋'), isFalse);
+      });
+
+      test('identifies custom userAliases', () {
+        expect(
+          Quote.isSelfAuthor('小明', userAliases: ['上晋', '小明', 'Echo']),
+          isTrue,
+        );
+        expect(
+          Quote.isSelfAuthor('未知作者', userAliases: ['上晋', '小明']),
+          isFalse,
+        );
+      });
+
+      test('returns false for null or empty input', () {
+        expect(Quote.isSelfAuthor(null), isFalse);
+        expect(Quote.isSelfAuthor(''), isFalse);
+        expect(Quote.isSelfAuthor('   '), isFalse);
+      });
+    });
+
+    group('isSelfAttributed, isExcerpt, isOriginal & resolveAttributionKind',
+        () {
+      test('unannotated note is classified as original', () {
+        final note = createNote();
+        expect(note.isSelfAttributed(), isFalse);
+        expect(note.isExcerpt(), isFalse);
+        expect(note.isOriginal(), isTrue);
+        expect(note.attributionKind, 'original');
+      });
+
+      test('self-signed note with built-in keyword is original', () {
+        final note = createNote(author: '我');
+        expect(note.isSelfAttributed(), isTrue);
+        expect(note.isExcerpt(), isFalse);
+        expect(note.isOriginal(), isTrue);
+        expect(note.attributionKind, 'original');
+      });
+
+      test('self-signed note with author and personal work is original', () {
+        final note = createNote(author: '我', work: '随笔集');
+        expect(note.isSelfAttributed(), isTrue);
+        expect(note.isExcerpt(), isFalse);
+        expect(note.isOriginal(), isTrue);
+        expect(note.attributionKind, 'original');
+      });
+
+      test('self-signed note with userNickname is original', () {
+        final note = createNote(author: 'Shangjin');
+        expect(
+          note.resolveAttributionKind(userNickname: 'shangjin'),
+          'original',
+        );
+        expect(note.isExcerpt(userNickname: 'shangjin'), isFalse);
+        expect(note.isOriginal(userNickname: 'shangjin'), isTrue);
+      });
+
+      test('self-signed note with defaultAuthor is original', () {
+        final note = createNote(author: '上晋');
+        expect(
+          note.resolveAttributionKind(defaultAuthor: '上晋'),
+          'original',
+        );
+        expect(note.isExcerpt(defaultAuthor: '上晋'), isFalse);
+        expect(note.isOriginal(defaultAuthor: '上晋'), isTrue);
+      });
+
+      test('note with personal journal keyword in sourceWork is original', () {
+        for (final keyword in ['日记', '随笔', '随手记', '我的日记', 'Diary', 'Journal']) {
+          final note = createNote(work: keyword);
+          expect(note.isSelfAttributed(), isTrue, reason: keyword);
+          expect(note.isExcerpt(), isFalse, reason: keyword);
+          expect(note.isOriginal(), isTrue, reason: keyword);
+          expect(note.attributionKind, 'original', reason: keyword);
+        }
+      });
+
+      test('note with defaultSource in sourceWork is original', () {
+        final note = createNote(work: '2026读书记录');
+        expect(
+          note.resolveAttributionKind(defaultSource: '2026读书记录'),
+          'original',
+        );
+        expect(note.isExcerpt(defaultSource: '2026读书记录'), isFalse);
+      });
+
+      test('legacy composite source with self-author is original', () {
+        final note1 = createNote(source: '本人 - 读书感悟');
+        expect(note1.isSelfAttributed(), isTrue);
+        expect(note1.isExcerpt(), isFalse);
+        expect(note1.attributionKind, 'original');
+
+        final note2 = createNote(source: '上晋 —— 随笔');
+        expect(
+          note2.resolveAttributionKind(userNickname: '上晋'),
+          'original',
+        );
+      });
+
+      test('external author and work is classified as excerpt', () {
+        final note = createNote(author: '加缪', work: '局外人');
+        expect(note.isSelfAttributed(), isFalse);
+        expect(note.isExcerpt(), isTrue);
+        expect(note.isOriginal(), isFalse);
+        expect(note.attributionKind, 'excerpt');
+      });
+
+      test(
+          'external book in sourceWork without author is classified as excerpt',
+          () {
+        final note = createNote(work: '百年孤独');
+        expect(note.isSelfAttributed(), isFalse);
+        expect(note.isExcerpt(), isTrue);
+        expect(note.isOriginal(), isFalse);
+        expect(note.attributionKind, 'excerpt');
+      });
+
+      test(
+          'legacy composite source with external author is classified as excerpt',
+          () {
+        final note = createNote(source: '鲁迅 - 狂人日记');
+        expect(note.isSelfAttributed(), isFalse);
+        expect(note.isExcerpt(), isTrue);
+        expect(note.isOriginal(), isFalse);
+        expect(note.attributionKind, 'excerpt');
+      });
+    });
+  });
+}

--- a/test/unit/services/dreaming_service_test.dart
+++ b/test/unit/services/dreaming_service_test.dart
@@ -111,16 +111,29 @@ void main() {
         expect(await harness.memory.currentRecentSlice(), isNull);
       });
 
-      test('设备时钟被调到过去时不放行', () async {
+      test('设备时钟落在近未来时跳过，防止时钟频繁微调导致每次都跑', () async {
         final now = DateTime(2026, 8, 28);
-        // 时间戳落在未来：不能因为 difference 是负数就当成"很久没跑"。
         await harness.settingsService.setLastDreamingAt(
-          now.add(const Duration(days: 30)),
+          now.add(const Duration(days: 10)),
         );
 
         final service = build(modelOutput: goodOutput);
 
         expect(await service.run(now: now), DreamingOutcome.skipped);
+      });
+
+      test('设备时钟曾远跳未来后修正回正常时间时自动重置并放行自愈', () async {
+        final now = DateTime(2026, 8, 28);
+        // 时间戳落在超过 30 天的远期未来：说明时钟曾被大幅拨快后调回。
+        await harness.settingsService.setLastDreamingAt(
+          now.add(const Duration(days: 60)),
+        );
+
+        final service = build(modelOutput: goodOutput);
+
+        expect(await service.run(now: now), DreamingOutcome.updated);
+        // 执行后时间戳推进到当前的 now
+        expect(harness.settingsService.lastDreamingAt, now);
       });
     });
 
@@ -146,6 +159,67 @@ void main() {
 
         final slice = await harness.memory.currentRecentSlice();
         expect(slice!.content, contains('搬家'));
+      });
+
+      test('用户署名自己的笔记（昵称/默认作者/自指词）正确归入原创组并用于 voice 归因', () async {
+        await harness.settingsService.setUserNickname('上晋');
+        await harness.settingsService.setDefaultAuthor('上晋');
+
+        final notes = <Quote>[
+          // 用户署名的原创笔记
+          Quote(
+            id: 'signed-1',
+            content: '今天写下了这篇日记',
+            date: DateTime(2026, 8, 20).toIso8601String(),
+            sourceAuthor: '上晋',
+          ),
+          Quote(
+            id: 'signed-2',
+            content: '我自己的思考和感悟',
+            date: DateTime(2026, 8, 21).toIso8601String(),
+            sourceAuthor: '我',
+          ),
+          Quote(
+            id: 'signed-3',
+            content: '随手记录的生活琐事',
+            date: DateTime(2026, 8, 22).toIso8601String(),
+            sourceWork: '日记',
+          ),
+          // 真正的外部摘录
+          ...List.generate(
+            7,
+            (i) => Quote(
+              id: 'excerpt-$i',
+              content: '摘抄名家第 $i 段文字',
+              date: DateTime(2026, 8, 10 + i).toIso8601String(),
+              sourceAuthor: '村上春树',
+              sourceWork: '挪威的森林',
+            ),
+          ),
+        ];
+
+        String? capturedUserMsg;
+        final service = build(
+          modelOutput: goodOutput,
+          notes: notes,
+          onComplete: (_, userMessage) => capturedUserMsg = userMessage,
+        );
+
+        expect(await service.run(), DreamingOutcome.updated);
+        expect(capturedUserMsg, isNotNull);
+        // 验证 message 中原创组包含署名笔记，摘录组包含外部笔记
+        expect(capturedUserMsg, contains('原创（3 条）'));
+        expect(capturedUserMsg, contains('摘录（7 条）'));
+
+        final profile = await harness.memory.activeProfile();
+        final voice =
+            profile.firstWhere((e) => e.kind == AgentMemoryKind.voice);
+        final taste =
+            profile.firstWhere((e) => e.kind == AgentMemoryKind.taste);
+        expect(voice.sourceNoteIds, contains('signed-1'));
+        expect(voice.sourceNoteIds, contains('signed-2'));
+        expect(voice.sourceNoteIds, contains('signed-3'));
+        expect(taste.sourceNoteIds, contains('excerpt-0'));
       });
 
       test('同 kind 原位更新，不追加第二条', () async {

--- a/test/unit/services/explore_notes_tool_test.dart
+++ b/test/unit/services/explore_notes_tool_test.dart
@@ -232,15 +232,18 @@ void main() {
       };
 
       final excerpt = byId['excerpt']!;
+      expect(excerpt['type'], 'excerpt');
       expect(excerpt['author'], '作者甲');
       expect(excerpt['source'], '作品乙');
 
       // 只有合并 source 串的旧数据回退到 source，不重复填 author。
       final legacy = byId['legacy']!;
+      expect(legacy['type'], 'excerpt');
       expect(legacy['author'], isNull);
       expect(legacy['source'], '作者丙 - 作品丁');
 
       final plain = byId['plain']!;
+      expect(plain['type'], 'original');
       expect(plain.containsKey('author'), isFalse);
       expect(plain.containsKey('source'), isFalse);
     });

--- a/test/unit/services/get_note_detail_tool_test.dart
+++ b/test/unit/services/get_note_detail_tool_test.dart
@@ -98,6 +98,7 @@ void main() {
       expect(result.isError, isFalse);
       final data = jsonDecode(result.content);
       expect(data['id'], 'note_123');
+      expect(data['type'], 'excerpt');
       // 笔记正文是用户数据：包裹 <note> 标签，声明为数据而非指令
       expect(
         data['content'],

--- a/test/unit/utils/ai_request_helper_test.dart
+++ b/test/unit/utils/ai_request_helper_test.dart
@@ -78,7 +78,22 @@ void main() {
       expect(metadataOf(json)['excerptCount'], 0);
     });
 
-    test('an author or a work marks the note as an excerpt', () {
+    test('notes with self-author markers or userNickname are original', () {
+      final bySelf = helper.convertQuotesToJson([note(author: '我')]);
+      expect(quotesOf(bySelf).single['type'], 'original');
+      expect(metadataOf(bySelf)['originalCount'], 1);
+      expect(metadataOf(bySelf)['excerptCount'], 0);
+
+      final byNick = helper.convertQuotesToJson(
+        [note(author: '上晋')],
+        userNickname: '上晋',
+      );
+      expect(quotesOf(byNick).single['type'], 'original');
+      expect(metadataOf(byNick)['originalCount'], 1);
+      expect(metadataOf(byNick)['excerptCount'], 0);
+    });
+
+    test('an external author or work marks the note as an excerpt', () {
       final byAuthor = helper.convertQuotesToJson([note(author: '苏轼')]);
       expect(quotesOf(byAuthor).single['type'], 'excerpt');
 
@@ -101,8 +116,9 @@ void main() {
         note(),
         note(author: '加缪'),
         note(work: '局外人'),
+        note(author: '我'),
       ]);
-      expect(metadataOf(json)['originalCount'], 1);
+      expect(metadataOf(json)['originalCount'], 2);
       expect(metadataOf(json)['excerptCount'], 2);
     });
   });


### PR DESCRIPTION
## 变更背景与内容

### 1. 原创 vs 摘录的启发式分类边界优化（解决用户署名自己的笔记被误判为摘录的问题）
- **根因**：原 `Quote.attributionKind` 简单以 `hasAttribution`（即只要 `sourceAuthor` / `sourceWork` / `source` 任一非空）判定为 `excerpt`。如果用户设置了默认作者（`defaultAuthor`）或在编辑时给自己的原创笔记署名/写日记集，该笔记会被归入摘录组，导致：
  1. `DreamingService` 采样时，本人的原创笔记无法进入 `originals` 组，无法被 `voice` 学习，反而污染 `taste`；
  2. 周期洞察 / 周报中 `originalCount` 变少，模型误以为用户没有原创自述；
  3. Agent 工具（`explore_notes`、`get_note_detail`）将用户原创笔记标记为 `type: excerpt`。
- **解决方案**：
  - 在 [`Quote`](file:///home/azureuser/ThoughtEcho/lib/models/quote_model.dart) 中新增身份感知与自指代词判定：
    - 内置自指代词（如 `我`、`自己`、`本人`、`自作`、`自撰`、`原创`、`me`、`myself`、`author` 等）；
    - 个人日记/随笔出处词汇（如 `日记`、`随笔`、`随手记`、`我的日记`、`Diary`、`Journal` 等）；
    - 用户设置中心态别名支持（`userNickname`、`defaultAuthor`、`defaultSource`、`userAliases`）；
    - 提供 [`isSelfAuthor`](file:///home/azureuser/ThoughtEcho/lib/models/quote_model.dart)、[`isSelfAttributed`](file:///home/azureuser/ThoughtEcho/lib/models/quote_model.dart)、[`isExcerpt`](file:///home/azureuser/ThoughtEcho/lib/models/quote_model.dart)、[`isOriginal`](file:///home/azureuser/ThoughtEcho/lib/models/quote_model.dart)、[`resolveAttributionKind`](file:///home/azureuser/ThoughtEcho/lib/models/quote_model.dart)。
  - 在 [`SettingsService`](file:///home/azureuser/ThoughtEcho/lib/services/settings_service.dart) 增加 `userAliases` getter。
  - 在 [`DreamingService`](file:///home/azureuser/ThoughtEcho/lib/services/dreaming_service.dart)、[`AIRequestHelper`](file:///home/azureuser/ThoughtEcho/lib/utils/ai_request_helper.dart)、[`AIService`](file:///home/azureuser/ThoughtEcho/lib/services/ai_service.dart)、[`ExploreNotesTool`](file:///home/azureuser/ThoughtEcho/lib/services/agent_tools/explore_notes_tool.dart)、[`GetNoteDetailTool`](file:///home/azureuser/ThoughtEcho/lib/services/agent_tools/get_note_detail_tool.dart) 全面接入身份感知的归属判定。

### 2. 修复 DreamingService 未来时间戳死锁自愈问题
- **根因**：原 `_passesGates` 中 `if (last != null && last.isAfter(now)) return false;`，若设备时钟曾大幅拨快并记录了未来时间戳，当用户将时钟修正回正常时间后，`last.isAfter(now)` 持续为 true，导致 Dreaming 长期死锁。
- **解决方案**：
  - 增加近未来容忍与远期异常自愈机制：未来 30 天内的时间戳按刚跑过处理（跳过本轮防止频繁抖动）；超出 30 天的远期未来时间戳判定为异常时钟回退，重置时间戳并放行自愈。

### 3. 完整测试覆盖
- 新增 [`test/unit/models/quote_attribution_test.dart`](file:///home/azureuser/ThoughtEcho/test/unit/models/quote_attribution_test.dart) 覆盖自指词、用户别名、默认出处、外部作者、旧格式复合串等全路径。
- 更新 [`dreaming_service_test.dart`](file:///home/azureuser/ThoughtEcho/test/unit/services/dreaming_service_test.dart) 覆盖署名笔记的 `voice` 归因采样，以及未来时钟自愈。
- 更新 [`ai_request_helper_test.dart`](file:///home/azureuser/ThoughtEcho/test/unit/utils/ai_request_helper_test.dart)、[`explore_notes_tool_test.dart`](file:///home/azureuser/ThoughtEcho/test/unit/services/explore_notes_tool_test.dart)、[`get_note_detail_tool_test.dart`](file:///home/azureuser/ThoughtEcho/test/unit/services/get_note_detail_tool_test.dart)。

## Sourcery 摘要

改进笔记归属分类，并让 Dreaming 能够从未来时间戳过期的状态中恢复。

错误修复：
- 当设备时钟从遥远的未来时间戳被校正后，自动重置异常时间戳，防止 Dreaming 持续处于阻塞状态。
- 在 AI 分析、Dreaming 样本和代理工具响应中，正确将用户撰写的笔记分类为原创内容，而不是摘录内容。

功能增强：
- 添加基于身份的归属分类功能，使用自我指涉标记、个人日志来源、已配置的作者、昵称和别名进行判断。
- 通过设置公开已配置的用户别名，并在生成 AI 元数据和笔记类型标签时统一应用这些别名。

测试：
- 添加全面的归属判断启发式测试，并扩展服务、AI 请求和代理工具测试，覆盖原创/摘录分类以及 Dreaming 时钟恢复功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

改进笔记归属分类，并使 Dreaming 能够应对设备时钟被校正的情况。

Bug 修复：
- 正确将带有用户姓名、自我指涉标记或个人日志来源的笔记，在 AI 分析、Dreaming 和笔记代理响应中分类为原创内容。
- 允许 Dreaming 在设备时钟校正后从远期时间戳中恢复，同时继续推迟处理接近未来的时间戳。
- 在默认归属设置尚未完全加载前安全地读取这些设置，并支持在恢复过程中清除 Dreaming 时间戳。

增强功能：
- 集中处理具备身份感知能力的原创内容与摘录归属判断规则，包括已配置的昵称、默认作者、别名、个人来源以及旧版复合归属字符串。
- 在 AI 请求生成、Dreaming 采样以及笔记探索和详情工具中传递用户归属设置。

测试：
- 添加全面的归属分类测试，并扩展 AI、Dreaming 和代理工具的测试覆盖，以验证原创内容/摘录标记和时钟恢复功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

改进笔记归属分类，并增强 Dreaming 对设备时钟校正的容错能力。

错误修复：
- 正确将使用用户身份或个人来源签名的笔记，在 AI 分析、Dreaming 样本和笔记代理响应中分类为原创内容。
- 设备时钟校正后，允许 Dreaming 从远期时间戳中恢复，同时继续延迟处理临近未来的时间戳。
- 防止初始化完成前访问设置失败，并支持在恢复过程中清除 Dreaming 时间戳。

增强功能：
- 集中管理与身份相关的归属判断逻辑，使用自我指涉标记、已配置的姓名和别名、个人来源以及旧版归属格式。
- 公开放置的用户别名，并在生成 AI 元数据和笔记类型标签时统一应用这些别名。

测试：
- 添加全面的归属分类测试，并扩展 AI、Dreaming 和代理工具的测试覆盖范围，以验证原创内容/摘录标记和时钟恢复功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve note attribution classification and make Dreaming resilient to device clock corrections.

Bug Fixes:
- Correctly classify notes signed with the user’s identity or personal sources as original content across AI analysis, Dreaming samples, and note-agent responses.
- Allow Dreaming to recover from timestamps far in the future after device clock correction while continuing to defer near-future timestamps.
- Prevent settings access from failing before initialization and support clearing the Dreaming timestamp during recovery.

Enhancements:
- Centralize identity-aware attribution heuristics using self-referential markers, configured names and aliases, personal sources, and legacy attribution formats.
- Expose configured user aliases and apply them consistently when generating AI metadata and note type labels.

Tests:
- Add comprehensive attribution classification tests and expand AI, Dreaming, and agent-tool coverage for original/excerpt labeling and clock recovery.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

改进笔记归属分类，并使 Dreaming 能够应对设备时钟被校正的情况。

Bug 修复：
- 正确将带有用户姓名、自我指涉标记或个人日志来源的笔记，在 AI 分析、Dreaming 和笔记代理响应中分类为原创内容。
- 允许 Dreaming 在设备时钟校正后从远期时间戳中恢复，同时继续推迟处理接近未来的时间戳。
- 在默认归属设置尚未完全加载前安全地读取这些设置，并支持在恢复过程中清除 Dreaming 时间戳。

增强功能：
- 集中处理具备身份感知能力的原创内容与摘录归属判断规则，包括已配置的昵称、默认作者、别名、个人来源以及旧版复合归属字符串。
- 在 AI 请求生成、Dreaming 采样以及笔记探索和详情工具中传递用户归属设置。

测试：
- 添加全面的归属分类测试，并扩展 AI、Dreaming 和代理工具的测试覆盖，以验证原创内容/摘录标记和时钟恢复功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

改进笔记归属分类，并增强 Dreaming 对设备时钟校正的容错能力。

错误修复：
- 正确将使用用户身份或个人来源签名的笔记，在 AI 分析、Dreaming 样本和笔记代理响应中分类为原创内容。
- 设备时钟校正后，允许 Dreaming 从远期时间戳中恢复，同时继续延迟处理临近未来的时间戳。
- 防止初始化完成前访问设置失败，并支持在恢复过程中清除 Dreaming 时间戳。

增强功能：
- 集中管理与身份相关的归属判断逻辑，使用自我指涉标记、已配置的姓名和别名、个人来源以及旧版归属格式。
- 公开放置的用户别名，并在生成 AI 元数据和笔记类型标签时统一应用这些别名。

测试：
- 添加全面的归属分类测试，并扩展 AI、Dreaming 和代理工具的测试覆盖范围，以验证原创内容/摘录标记和时钟恢复功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve note attribution classification and make Dreaming resilient to device clock corrections.

Bug Fixes:
- Correctly classify notes signed with the user’s identity or personal sources as original content across AI analysis, Dreaming samples, and note-agent responses.
- Allow Dreaming to recover from timestamps far in the future after device clock correction while continuing to defer near-future timestamps.
- Prevent settings access from failing before initialization and support clearing the Dreaming timestamp during recovery.

Enhancements:
- Centralize identity-aware attribution heuristics using self-referential markers, configured names and aliases, personal sources, and legacy attribution formats.
- Expose configured user aliases and apply them consistently when generating AI metadata and note type labels.

Tests:
- Add comprehensive attribution classification tests and expand AI, Dreaming, and agent-tool coverage for original/excerpt labeling and clock recovery.

</details>

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化原创与摘录的归属判定，解决用户署名自己的笔记被误判为摘录的问题，同时修复 Dreaming 未来时钟死锁与设置未加载时的崩溃。

**Bug Fixes**
- 新增用户别名与自指代词识别，对照用户昵称、默认作者、默认出处，将"我"、"原创"、"日记"等署名归为原创，让署名笔记重新进入 `voice` 采样和 `originalCount` 统计。
- 未来 30 天内的时钟偏移跳过本轮，超过 30 天的异常未来时间戳自动重置并放行，避免时钟修正后 Dreaming 长期死锁。
- 为 `SettingsService` 核心字段提供默认实例，并对 `defaultAuthor`、`defaultSource` 做防御性读取，避免设置未加载时抛出 `LateInitializationError`。

**Refactors**
- `Quote` 新增 `isSelfAuthor`、`isSelfAttributed`、`isExcerpt`、`isOriginal` 与 `resolveAttributionKind`，支持复合串拆分判定（拆分前先剔除"作者："、"——"等前缀标签）。
- `SettingsService.setLastDreamingAt` 支持传入 `null` 重置时间戳，配合时钟自愈流程。
- `DreamingService`、`AIRequestHelper`、`AIService` 与 `ExploreNotesTool`、`GetNoteDetailTool` 统一接入身份感知的归属判定。
- 新增覆盖自指词、用户别名、默认出处、外部作者与旧格式数据的完整单元测试。

<sup>Written for commit 34c3d6c356d42ad8f448edf0b681e3bd85b86ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved classification of notes as original or excerpts, including self-attributed notes, aliases, and diary entries.
  - AI insights and note details now receive more accurate attribution types and counts.
  - Dreaming now distinguishes user-authored notes from external excerpts.

- **Bug Fixes**
  - Corrected handling of future dreaming timestamps and automatically recovered from invalid clock jumps.
  - Settings access now fails safely when default attribution details are unavailable.

- **Tests**
  - Added coverage for attribution classification, AI data, note tools, and dreaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->