### PR TITLE
🎨 Fresco: 改造标签管理页 UI/UX 规范与设计 Token 接入

### DIFF
--- a/lib/pages/tag_settings_page.dart
+++ b/lib/pages/tag_settings_page.dart
@@ -5,9 +5,12 @@ import '../extensions/note_tag_localization_extension.dart';
 import '../services/database_service.dart';
 import '../models/note_tag.dart';
 import '../utils/icon_utils.dart';
-import '../constants/app_constants.dart';
 import '../gen_l10n/app_localizations.dart';
 import '../theme/theme_style.dart';
+import '../widgets/app_snackbar.dart';
+import '../widgets/app_loading_view.dart';
+import '../widgets/app_empty_view.dart';
+import '../widgets/app_error_view.dart';
 
 class TagSettingsPage extends StatefulWidget {
   const TagSettingsPage({super.key});
@@ -32,6 +35,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final shapeTokens = AppShapeTokens.of(context);
 
     return Scaffold(
       appBar: AppBar(title: Text(l10n.tagManagement)),
@@ -46,177 +50,168 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
             ),
             const SizedBox(height: 16),
             // 输入与添加区域卡片化
-            Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(
-                    AppShapeTokens.of(context).cardRadius),
-                border: Border.all(
+            Card(
+              elevation: 0,
+              margin: EdgeInsets.zero,
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+                side: BorderSide(
                   color: Theme.of(context).colorScheme.outlineVariant,
                 ),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Expanded(
-                        child: TextField(
-                          controller: _categoryController,
-                          maxLength: 50,
-                          decoration: InputDecoration(
-                            labelText: l10n.newTagName,
-                            hintText: l10n.enterTagNameHint,
-                            counterText: '',
-                            border: OutlineInputBorder(
-                              borderRadius: BorderRadius.circular(
-                                  AppShapeTokens.of(context).inputRadius),
-                            ),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      Tooltip(
-                        message: l10n.selectIcon,
-                        child: InkWell(
-                          onTap: () => _showIconSelector(context),
-                          borderRadius: BorderRadius.circular(
-                            AppShapeTokens.of(context).cardRadius,
-                          ),
-                          child: Container(
-                            padding: const EdgeInsets.all(10),
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.outlineVariant,
-                              ),
-                              borderRadius: BorderRadius.circular(
-                                AppShapeTokens.of(context).cardRadius,
-                              ),
-                            ),
-                            child: _selectedIconName != null
-                                ? (IconUtils.isEmoji(_selectedIconName)
-                                    ? Text(
-                                        IconUtils.getDisplayIcon(
-                                          _selectedIconName!,
-                                        ),
-                                        style: const TextStyle(fontSize: 20),
-                                      )
-                                    : Icon(
-                                        IconUtils.getIconData(
-                                          _selectedIconName,
-                                        ),
-                                      ))
-                                : const Icon(Icons.add_circle_outline),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      FilledButton.icon(
-                        icon: _isLoading
-                            ? const SizedBox(
-                                width: 16,
-                                height: 16,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              )
-                            : const Icon(Icons.check),
-                        label: Text(_isLoading ? l10n.adding : l10n.add),
-                        onPressed: _isLoading
-                            ? null
-                            : () async {
-                                final text = _categoryController.text.trim();
-                                if (text.isEmpty) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text(l10n.pleaseEnterTagName),
-                                      duration:
-                                          AppConstants.snackBarDurationNormal,
-                                    ),
-                                  );
-                                  return;
-                                }
-                                final messenger = ScaffoldMessenger.of(context);
-                                setState(() => _isLoading = true);
-                                try {
-                                  final db = context.read<DatabaseService>();
-                                  await db.addTag(
-                                    text,
-                                    iconName: _selectedIconName,
-                                  );
-                                  if (mounted) {
-                                    messenger.showSnackBar(
-                                      SnackBar(
-                                        content: Text(l10n.tagAddedSuccess),
-                                        duration:
-                                            AppConstants.snackBarDurationNormal,
-                                      ),
-                                    );
-                                    _categoryController.clear();
-                                    setState(() => _selectedIconName = null);
-                                  }
-                                } catch (e) {
-                                  if (mounted) {
-                                    messenger.showSnackBar(
-                                      SnackBar(
-                                        content: Text(
-                                          l10n.addTagFailed(e.toString()),
-                                        ),
-                                        duration:
-                                            AppConstants.snackBarDurationError,
-                                      ),
-                                    );
-                                  }
-                                } finally {
-                                  if (mounted) {
-                                    setState(() => _isLoading = false);
-                                  }
-                                }
-                              },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 8),
-                  AnimatedOpacity(
-                    opacity: _selectedIconName != null ? 1 : 0.6,
-                    duration: const Duration(milliseconds: 200),
-                    child: Row(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
                       children: [
-                        Icon(
-                          _selectedIconName != null &&
-                                  !IconUtils.isEmoji(_selectedIconName)
-                              ? IconUtils.getIconData(_selectedIconName)
-                              : Icons.info_outline,
-                          size: 16,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                        const SizedBox(width: 4),
                         Expanded(
-                          child: Text(
-                            _selectedIconName == null
-                                ? l10n.iconSelectionHint
-                                : l10n.iconSelected(_selectedIconName!),
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onSurfaceVariant,
+                          child: TextField(
+                            controller: _categoryController,
+                            maxLength: 50,
+                            decoration: InputDecoration(
+                              labelText: l10n.newTagName,
+                              hintText: l10n.enterTagNameHint,
+                              counterText: '',
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(
+                                  shapeTokens.inputRadius,
+                                ),
+                              ),
                             ),
                           ),
                         ),
-                        if (_selectedIconName != null)
-                          TextButton(
-                            onPressed: () =>
-                                setState(() => _selectedIconName = null),
-                            child: Text(l10n.clear),
+                        const SizedBox(width: 8),
+                        Tooltip(
+                          message: l10n.selectIcon,
+                          child: InkWell(
+                            onTap: () => _showIconSelector(context),
+                            borderRadius: BorderRadius.circular(
+                              shapeTokens.cardRadius,
+                            ),
+                            child: Container(
+                              padding: const EdgeInsets.all(10),
+                              decoration: BoxDecoration(
+                                border: Border.all(
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.outlineVariant,
+                                ),
+                                borderRadius: BorderRadius.circular(
+                                  shapeTokens.cardRadius,
+                                ),
+                              ),
+                              child: _selectedIconName != null
+                                  ? (IconUtils.isEmoji(_selectedIconName)
+                                      ? Text(
+                                          IconUtils.getDisplayIcon(
+                                            _selectedIconName!,
+                                          ),
+                                          style: const TextStyle(
+                                            fontSize: 20,
+                                          ),
+                                        )
+                                      : Icon(
+                                          IconUtils.getIconData(
+                                            _selectedIconName,
+                                          ),
+                                        ))
+                                  : const Icon(Icons.add_circle_outline),
+                            ),
                           ),
+                        ),
+                        const SizedBox(width: 8),
+                        FilledButton.icon(
+                          icon: _isLoading
+                              ? const AppInlineLoadingIndicator(
+                                  size: 16,
+                                  strokeWidth: 2,
+                                )
+                              : const Icon(Icons.check),
+                          label: Text(_isLoading ? l10n.adding : l10n.add),
+                          onPressed: _isLoading
+                              ? null
+                              : () async {
+                                  final text = _categoryController.text.trim();
+                                  if (text.isEmpty) {
+                                    AppSnackBar.warning(
+                                      context,
+                                      l10n.pleaseEnterTagName,
+                                    );
+                                    return;
+                                  }
+                                  setState(() => _isLoading = true);
+                                  try {
+                                    final db = context.read<DatabaseService>();
+                                    await db.addTag(
+                                      text,
+                                      iconName: _selectedIconName,
+                                    );
+                                    if (context.mounted) {
+                                      AppSnackBar.success(
+                                        context,
+                                        l10n.tagAddedSuccess,
+                                      );
+                                      _categoryController.clear();
+                                      setState(() => _selectedIconName = null);
+                                    }
+                                  } catch (e) {
+                                    if (context.mounted) {
+                                      AppSnackBar.error(
+                                        context,
+                                        l10n.addTagFailed(e.toString()),
+                                      );
+                                    }
+                                  } finally {
+                                    if (mounted) {
+                                      setState(() => _isLoading = false);
+                                    }
+                                  }
+                                },
+                        ),
                       ],
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 8),
+                    AnimatedOpacity(
+                      opacity: _selectedIconName != null ? 1 : 0.6,
+                      duration: const Duration(milliseconds: 200),
+                      child: Row(
+                        children: [
+                          Icon(
+                            _selectedIconName != null &&
+                                    !IconUtils.isEmoji(_selectedIconName)
+                                ? IconUtils.getIconData(_selectedIconName)
+                                : Icons.info_outline,
+                            size: 16,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                          const SizedBox(width: 4),
+                          Expanded(
+                            child: Text(
+                              _selectedIconName == null
+                                  ? l10n.iconSelectionHint
+                                  : l10n.iconSelected(_selectedIconName!),
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ),
+                          if (_selectedIconName != null)
+                            TextButton(
+                              onPressed: () =>
+                                  setState(() => _selectedIconName = null),
+                              child: Text(l10n.clear),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
             const SizedBox(height: 16),
@@ -224,17 +219,17 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
               stream: context.read<DatabaseService>().watchTags(),
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const Center(child: CircularProgressIndicator());
+                  return const AppLoadingView(size: 60);
                 }
 
                 if (snapshot.hasError) {
-                  return Center(
-                    child: Text(l10n.loadTagsFailed(snapshot.error.toString())),
+                  return AppErrorView(
+                    text: l10n.loadTagsFailed(snapshot.error.toString()),
                   );
                 }
 
                 if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                  return Center(child: Text(l10n.noTags));
+                  return AppEmptyView(text: l10n.noTags);
                 }
 
                 final categories = snapshot.data!;
@@ -242,8 +237,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                   elevation: 0,
                   margin: EdgeInsets.zero,
                   shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(
-                        AppShapeTokens.of(context).cardRadius),
+                    borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
                     side: BorderSide(
                       color: Theme.of(context).colorScheme.outlineVariant,
                     ),
@@ -279,6 +273,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
     final TextEditingController emojiSearchController = TextEditingController();
     String searchQuery = '';
     final l10n = AppLocalizations.of(context);
+    final shapeTokens = AppShapeTokens.of(context);
     Map<String, bool> expandedTags = {
       l10n.emotion: true,
       l10n.thinking: false,
@@ -294,31 +289,29 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
       context: context,
       builder: (context) => StatefulBuilder(
         builder: (context, setState) {
-          // 获取emoji分类
           final emojiCategories = IconUtils.getCategorizedEmojis();
 
-          // 过滤emoji
           Map<String, List<String>> filteredEmojis = {};
           if (searchQuery.isEmpty) {
             filteredEmojis = emojiCategories;
           } else {
-            // 简单过滤，实际应用中可能需要更复杂的过滤逻辑
             emojiCategories.forEach((category, emojis) {
               filteredEmojis[category] = emojis;
             });
           }
 
-          // Material图标列表，仅在搜索为空时显示
           final materialIcons = IconUtils.categoryIcons.entries.toList();
 
           return AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+            ),
             title: Text(l10n.selectIcon),
             content: SizedBox(
               width: MediaQuery.of(context).size.width * 0.8,
               height: MediaQuery.of(context).size.height * 0.6,
               child: Column(
                 children: [
-                  // 搜索框和自定义emoji输入
                   TextField(
                     controller: emojiSearchController,
                     decoration: InputDecoration(
@@ -336,7 +329,8 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                           : null,
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(
-                            AppShapeTokens.of(context).inputRadius),
+                          shapeTokens.inputRadius,
+                        ),
                       ),
                     ),
                     onChanged: (value) {
@@ -344,8 +338,6 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                     },
                   ),
                   const SizedBox(height: 8),
-
-                  // 显示用户输入的emoji (如果是单个字符)
                   if (emojiSearchController.text.isNotEmpty &&
                       emojiSearchController.text.characters.length == 1)
                     Padding(
@@ -372,15 +364,11 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                         ],
                       ),
                     ),
-
                   const SizedBox(height: 8),
-
-                  // emoji分类和系统图标列表
                   Expanded(
                     child: SingleChildScrollView(
                       child: Column(
                         children: [
-                          // emoji分类列表
                           ...filteredEmojis.entries.map((entry) {
                             final category = entry.key;
                             final emojis = entry.value;
@@ -388,12 +376,12 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                             return Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                // 分类标题
                                 ListTile(
                                   title: Text(
                                     category,
-                                    style:
-                                        Theme.of(context).textTheme.titleSmall,
+                                    style: Theme.of(
+                                      context,
+                                    ).textTheme.titleSmall,
                                   ),
                                   trailing: Icon(
                                     expandedTags[category] ?? false
@@ -407,8 +395,6 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                                     });
                                   },
                                 ),
-
-                                // 分类内的 emoji
                                 if (expandedTags[category] ?? false)
                                   Padding(
                                     padding: const EdgeInsets.symmetric(
@@ -427,6 +413,9 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                                             );
                                             Navigator.of(context).pop();
                                           },
+                                          borderRadius: BorderRadius.circular(
+                                            shapeTokens.cardRadius,
+                                          ),
                                           child: Container(
                                             width: 48,
                                             height: 48,
@@ -438,8 +427,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                                                   : Colors.transparent,
                                               borderRadius:
                                                   BorderRadius.circular(
-                                                AppShapeTokens.of(context)
-                                                    .cardRadius,
+                                                shapeTokens.cardRadius,
                                               ),
                                               border: Border.all(
                                                 color: isSelected
@@ -465,13 +453,10 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                                       }).toList(),
                                     ),
                                   ),
-
                                 const Divider(),
                               ],
                             );
                           }),
-
-                          // 系统图标部分
                           ListTile(
                             title: Text(
                               l10n.systemIcons,
@@ -489,7 +474,6 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                               });
                             },
                           ),
-
                           if (expandedTags[l10n.systemIcons] ?? false)
                             Padding(
                               padding: const EdgeInsets.symmetric(
@@ -514,6 +498,9 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                                         );
                                         Navigator.of(context).pop();
                                       },
+                                      borderRadius: BorderRadius.circular(
+                                        shapeTokens.cardRadius,
+                                      ),
                                       child: Column(
                                         mainAxisAlignment:
                                             MainAxisAlignment.center,
@@ -528,8 +515,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                                                   : Colors.transparent,
                                               borderRadius:
                                                   BorderRadius.circular(
-                                                AppShapeTokens.of(context)
-                                                    .cardRadius,
+                                                shapeTokens.cardRadius,
                                               ),
                                               border: Border.all(
                                                 color: isSelected
@@ -583,17 +569,28 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
     final nameController = TextEditingController(text: category.name);
     String? selectedIcon = category.iconName;
     final l10n = AppLocalizations.of(context);
+    final shapeTokens = AppShapeTokens.of(context);
     showDialog(
       context: context,
       builder: (dialogContext) {
         return AlertDialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+          ),
           title: Text(l10n.editTagTitle),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               TextField(
                 controller: nameController,
-                decoration: InputDecoration(labelText: l10n.tagNameLabel),
+                decoration: InputDecoration(
+                  labelText: l10n.tagNameLabel,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(
+                      shapeTokens.inputRadius,
+                    ),
+                  ),
+                ),
               ),
               const SizedBox(height: 12),
               Row(
@@ -629,7 +626,6 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                 final newName = nameController.text.trim();
                 if (newName.isEmpty) return;
 
-                // 获取必要的context相关对象
                 final dbService = Provider.of<DatabaseService>(
                   context,
                   listen: false,
@@ -640,7 +636,6 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                   iconName: selectedIcon,
                 );
 
-                // 修复内存泄露：在异步操作后检查mounted状态
                 if (!mounted) return;
                 if (dialogContext.mounted) {
                   Navigator.pop(dialogContext);
@@ -657,7 +652,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
   Widget _buildCategoryItem(NoteTag category, int index, int total) {
     final isDefault = category.isDefault;
     final l10n = AppLocalizations.of(context);
-    // 检查是否是隐藏标签
+    final shapeTokens = AppShapeTokens.of(context);
     final bool isHiddenTag = category.id == DatabaseService.hiddenTagId;
     final String displayName = category.localizedName(l10n);
 
@@ -675,9 +670,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
               height: 40,
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(
-                  AppShapeTokens.of(context).cardRadius,
-                ),
+                borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
               ),
               child: Center(
                 child: IconUtils.getCategoryIcon(category.iconName),
@@ -707,7 +700,9 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                             color: Theme.of(
                               context,
                             ).colorScheme.primaryContainer,
-                            borderRadius: BorderRadius.circular(8),
+                            borderRadius: BorderRadius.circular(
+                              shapeTokens.buttonRadius,
+                            ),
                           ),
                           child: Text(
                             isHiddenTag ? l10n.systemTag : l10n.defaultTag,
@@ -761,9 +756,13 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
 
   void _deleteCategory(BuildContext context, NoteTag category) {
     final l10n = AppLocalizations.of(context);
+    final shapeTokens = AppShapeTokens.of(context);
     showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+        ),
         title: Text(l10n.confirmDelete),
         content: Text(l10n.deleteTagConfirmation(category.localizedName(l10n))),
         actions: [
@@ -783,26 +782,14 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
           final dbService = context.read<DatabaseService>();
           await dbService.deleteTag(category.id);
 
-          // 修复内存泄露：在异步操作后检查mounted状态
           if (!mounted) return;
           if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(l10n.tagDeletedSuccess),
-                duration: AppConstants.snackBarDurationNormal,
-              ),
-            );
+            AppSnackBar.success(context, l10n.tagDeletedSuccess);
           }
         } catch (e) {
-          // 修复内存泄露：在异步操作后检查mounted状态
           if (!mounted) return;
           if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(l10n.deleteTagFailed(e.toString())),
-                duration: AppConstants.snackBarDurationError,
-              ),
-            );
+            AppSnackBar.error(context, l10n.deleteTagFailed(e.toString()));
           }
         }
       }
@@ -849,6 +836,7 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final shapeTokens = AppShapeTokens.of(context);
     final emojiCategories = IconUtils.getCategorizedEmojis();
     final materialIcons = IconUtils.categoryIcons.entries.toList();
     Map<String, List<String>> filteredEmojis = {};
@@ -860,6 +848,9 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
       });
     }
     return AlertDialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+      ),
       title: Text(l10n.selectIcon),
       content: SizedBox(
         width: MediaQuery.of(context).size.width * 0.8,
@@ -882,8 +873,7 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
                       )
                     : null,
                 border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(
-                      AppShapeTokens.of(context).inputRadius),
+                  borderRadius: BorderRadius.circular(shapeTokens.inputRadius),
                 ),
               ),
               onChanged: (value) {
@@ -955,6 +945,9 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
                                     onTap: () {
                                       Navigator.of(context).pop(emoji);
                                     },
+                                    borderRadius: BorderRadius.circular(
+                                      shapeTokens.cardRadius,
+                                    ),
                                     child: Container(
                                       padding: const EdgeInsets.all(8),
                                       decoration: BoxDecoration(
@@ -963,7 +956,9 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
                                                 context,
                                               ).colorScheme.primaryContainer
                                             : Colors.transparent,
-                                        borderRadius: BorderRadius.circular(8),
+                                        borderRadius: BorderRadius.circular(
+                                          shapeTokens.cardRadius,
+                                        ),
                                         border: Border.all(
                                           color: isSelected
                                               ? Theme.of(
@@ -1020,6 +1015,9 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
                                 onTap: () {
                                   Navigator.of(context).pop(iconName);
                                 },
+                                borderRadius: BorderRadius.circular(
+                                  shapeTokens.cardRadius,
+                                ),
                                 child: Column(
                                   mainAxisAlignment: MainAxisAlignment.center,
                                   children: [
@@ -1031,7 +1029,9 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
                                                 context,
                                               ).colorScheme.primaryContainer
                                             : Colors.transparent,
-                                        borderRadius: BorderRadius.circular(8),
+                                        borderRadius: BorderRadius.circular(
+                                          shapeTokens.cardRadius,
+                                        ),
                                         border: Border.all(
                                           color: isSelected
                                               ? Theme.of(

--- a/lib/pages/tag_settings_page.dart
+++ b/lib/pages/tag_settings_page.dart
@@ -140,7 +140,6 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                                       context,
                                       l10n.pleaseEnterTagName,
                                     );
-                                    setState(() => _selectedIconName = null);
                                     return;
                                   }
                                   setState(() => _isLoading = true);

--- a/lib/pages/tag_settings_page.dart
+++ b/lib/pages/tag_settings_page.dart
@@ -140,6 +140,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
                                       context,
                                       l10n.pleaseEnterTagName,
                                     );
+                                    setState(() => _selectedIconName = null);
                                     return;
                                   }
                                   setState(() => _isLoading = true);
@@ -219,7 +220,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
               stream: context.read<DatabaseService>().watchTags(),
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const AppLoadingView(size: 60);
+                  return const AppLoadingView(size: 80);
                 }
 
                 if (snapshot.hasError) {
@@ -304,7 +305,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
 
           return AlertDialog(
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+              borderRadius: BorderRadius.circular(shapeTokens.dialogRadius),
             ),
             title: Text(l10n.selectIcon),
             content: SizedBox(
@@ -575,7 +576,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
       builder: (dialogContext) {
         return AlertDialog(
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+            borderRadius: BorderRadius.circular(shapeTokens.dialogRadius),
           ),
           title: Text(l10n.editTagTitle),
           content: Column(
@@ -761,7 +762,7 @@ class _CategorySettingsPageState extends State<TagSettingsPage> {
       context: context,
       builder: (context) => AlertDialog(
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+          borderRadius: BorderRadius.circular(shapeTokens.dialogRadius),
         ),
         title: Text(l10n.confirmDelete),
         content: Text(l10n.deleteTagConfirmation(category.localizedName(l10n))),
@@ -849,7 +850,7 @@ class _IconSelectorDialogState extends State<_IconSelectorDialog> {
     }
     return AlertDialog(
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(shapeTokens.cardRadius),
+        borderRadius: BorderRadius.circular(shapeTokens.dialogRadius),
       ),
       title: Text(l10n.selectIcon),
       content: SizedBox(


### PR DESCRIPTION
💡 改动组件: `lib/pages/tag_settings_page.dart` (标签管理页面与图标选择弹窗)

🎯 改进原因:
1. 输入与新增区域使用手写 Container，未统一使用 Material 3 Card 组件。
2. 内部硬编码 `BorderRadius.circular(8)`，缺乏对主题 Shape Tokens (`AppShapeTokens`) 的统合。
3. Stream 加载/空/异常状态使用裸 `CircularProgressIndicator` 与纯文本，反馈缺乏一致性。
4. 提示反馈使用裸 `ScaffoldMessenger.of(context).showSnackBar` 交互不够统一。

📊 视觉与交互变化:
1. 替换输入区域 Container 为 `Card`，圆角接入 `shapeTokens.cardRadius` 与 `shapeTokens.inputRadius`。
2. 按钮内部 `CircularProgressIndicator` 替换为符合视觉比重的 `AppInlineLoadingIndicator`。
3. 提示反馈统一转换为 `AppSnackBar` (`warning`, `success`, `error`)。
4. 加载、空列表与错误状态统一转换为 `AppLoadingView`、`AppEmptyView`、`AppErrorView`。
5. 图标选择弹窗与编辑/删除确认框圆角统一接入 Design Tokens。

🔬 验证方式:
1. 执行 `flutter gen-l10n` 与 `dart format`。
2. 执行 `flutter analyze --no-fatal-infos` 结果通过 (0 issues)。
3. 执行单元测试全部通过。

---
*PR created automatically by Jules for task [175923634535731173](https://jules.google.com/task/175923634535731173) started by @Shangjin-Xiao*

## Sourcery 总结

使标签管理体验与应用的设计系统保持一致，并提供统一的视觉和交互反馈。

增强功能：
- 使用 Material 3 卡片、共享形状令牌和统一的圆角控件，规范标签管理页面和图标选择对话框。
- 使用应用共享的反馈组件，统一加载、空状态、错误和内联按钮状态。
- 用一致的警告、成功和错误反馈替代页面专属的 Snackbar，覆盖所有标签操作。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使用共享的设计系统组件和令牌，统一标签管理 UI 样式和用户反馈。

增强功能：
- 使标签管理页面和图标选择对话框与应用的 Material 3 设计系统及共享形状令牌保持一致。
- 统一标签管理交互中的加载、空状态、错误、内联进度和操作反馈状态。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

统一标签管理界面的样式和用户反馈，使其与应用程序的共享设计系统保持一致。

改进：
- 使标签管理页面和图标选择对话框与共享的 Material 3 设计系统及形状令牌保持一致。
- 统一标签管理交互中的加载、空状态、错误、内联进度和操作反馈状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify tag management UI styling and user feedback with the application’s shared design system.

Enhancements:
- Align the tag management page and icon selection dialogs with the shared Material 3 design system and shape tokens.
- Standardize loading, empty, error, inline progress, and operation feedback states across tag management interactions.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
重构标签管理页，统一视觉和交互反馈。

**变更细节**
- 输入区改用 `Card`，圆角接入 `shapeTokens.cardRadius`、`inputRadius` 和 `buttonRadius`。
- 图标选择弹窗、编辑与删除确认框圆角统一使用 `shapeTokens.dialogRadius`。
- 按钮内加载指示器改为 `AppInlineLoadingIndicator`。
- 提示反馈改用 `AppSnackBar`（warning/success/error）。
- 加载、空、错误状态改用 `AppLoadingView`、`AppEmptyView`、`AppErrorView`。
- 名称为空时保留已选图标，不再清空选择。

<sup>Written for commit 7ac101640d0a6d47a1f36f1e84f32d6ce5d28b62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the tag settings page with a more consistent visual design using shared components and standardized corner shapes.
  * Improved the appearance of the add-tag card, dialogs, inputs, and interactive elements.

* **Bug Fixes**
  * Improved loading, error, and empty-state presentation.
  * Standardized success, warning, and error notifications across the page.
  * Applied consistent sizing and styling to loading indicators and dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->