### PR TITLE
🗃️ 黑匣: [完善 ApiService 模块的结构化日志]

### DIFF
--- a/.jules/blackbox.md
+++ b/.jules/blackbox.md
@@ -53,3 +53,6 @@
 ## 2024-05-24 - [完善 AddNoteController 中的结构化日志]
 **异常:** [在 `lib/controllers/add_note_controller.dart` 中，发现了多处使用 `catch (e)` 的空捕获或粗糙的 `logDebug('xxx失败: $e')` 打印，这些异常捕获不仅吞噬了关键的异常堆栈（StackTrace），并且严重依赖字符串拼接，未能利用已有的结构化日志系统，使得定位位置获取、天气抓取及标签创建等关键业务失败原因变得困难。]
 **拦截:** [将 `catch (e)` 改写为 `catch (e, stackTrace)`，并引入全局的 `logError`，传入 error、stackTrace，并指明 source: 'AddNoteController'，将原有的粗糙拼接替换为带有上下文的规范日志上报。]
+## 2026-09-02 - [完善 ApiService 远程请求异常日志]
+**异常:** `api_service_daily_quote_remote.dart` 中针对各种第三方 API（Hitokoto、ZenQuotes、API Ninjas 等）返回数据进行 `json.decode` 时的 `catch (e)` 块直接吞掉了报错堆栈，并且仅使用 `logDebug` 进行极其粗糙的记录，难以排查具体解析失败的原因。
+**拦截:** 修改所有第三方一言 API 请求方法的 `json.decode` 异常捕获块，使用 `catch (e, stackTrace)` 完整捕获异常及堆栈，并调用 `logError` 带上 `stackTrace` 和 `source: 'ApiService'` 参数上报结构化日志，确保发生响应结构变更或解析错误时留下完整的堆栈线索。

--- a/lib/services/api_service_daily_quote_remote.dart
+++ b/lib/services/api_service_daily_quote_remote.dart
@@ -52,8 +52,8 @@ Future<Map<String, dynamic>?> _fetchFromHitokoto(
   dynamic data;
   try {
     data = json.decode(response.body);
-  } catch (e) {
-    logDebug('一言API返回数据 JSON 解析失败: $e, 响应体: ${response.body}');
+  } catch (e, stackTrace) {
+    logError('一言API返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   if (data is! Map<String, dynamic> || !data.containsKey('hitokoto')) {
@@ -85,8 +85,8 @@ Future<Map<String, dynamic>?> _fetchFromZenQuotes(
   dynamic data;
   try {
     data = json.decode(response.body);
-  } catch (e) {
-    logDebug('ZenQuotes 返回数据 JSON 解析失败: $e, 响应体: ${response.body}');
+  } catch (e, stackTrace) {
+    logError('ZenQuotes 返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   final quote = data is List && data.isNotEmpty ? data.first : data;
@@ -137,8 +137,8 @@ Future<Map<String, dynamic>?> _fetchFromApiNinjas(
   dynamic data;
   try {
     data = json.decode(response.body);
-  } catch (e) {
-    logDebug('API Ninjas 返回数据 JSON 解析失败: $e, 响应体: ${response.body}');
+  } catch (e, stackTrace) {
+    logError('API Ninjas 返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   final quote = data is List && data.isNotEmpty ? data.first : data;
@@ -175,8 +175,8 @@ Future<Map<String, dynamic>?> _fetchFromMeigen(
   dynamic data;
   try {
     data = json.decode(response.body);
-  } catch (e) {
-    logDebug('名言教えるよ 返回数据 JSON 解析失败: $e, 响应体: ${response.body}');
+  } catch (e, stackTrace) {
+    logError('名言教えるよ 返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   final quote = data is List && data.isNotEmpty ? data.first : data;
@@ -210,8 +210,8 @@ Future<Map<String, dynamic>?> _fetchFromKoreanAdvice(
   dynamic data;
   try {
     data = json.decode(response.body);
-  } catch (e) {
-    logDebug('Korean Advice 返回数据 JSON 解析失败: $e, 响应体: ${response.body}');
+  } catch (e, stackTrace) {
+    logError('Korean Advice 返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   if (data is! Map<String, dynamic>) {

--- a/lib/services/api_service_daily_quote_remote.dart
+++ b/lib/services/api_service_daily_quote_remote.dart
@@ -53,7 +53,8 @@ Future<Map<String, dynamic>?> _fetchFromHitokoto(
   try {
     data = json.decode(response.body);
   } catch (e, stackTrace) {
-    logError('一言API返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
+    logError('一言API返回数据 JSON 解析失败: $e, 响应体: ${response.body}',
+        error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   if (data is! Map<String, dynamic> || !data.containsKey('hitokoto')) {
@@ -86,7 +87,8 @@ Future<Map<String, dynamic>?> _fetchFromZenQuotes(
   try {
     data = json.decode(response.body);
   } catch (e, stackTrace) {
-    logError('ZenQuotes 返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
+    logError('ZenQuotes 返回数据 JSON 解析失败: $e, 响应体: ${response.body}',
+        error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   final quote = data is List && data.isNotEmpty ? data.first : data;
@@ -138,7 +140,8 @@ Future<Map<String, dynamic>?> _fetchFromApiNinjas(
   try {
     data = json.decode(response.body);
   } catch (e, stackTrace) {
-    logError('API Ninjas 返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
+    logError('API Ninjas 返回数据 JSON 解析失败: $e, 响应体: ${response.body}',
+        error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   final quote = data is List && data.isNotEmpty ? data.first : data;
@@ -176,7 +179,8 @@ Future<Map<String, dynamic>?> _fetchFromMeigen(
   try {
     data = json.decode(response.body);
   } catch (e, stackTrace) {
-    logError('名言教えるよ 返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
+    logError('名言教えるよ 返回数据 JSON 解析失败: $e, 响应体: ${response.body}',
+        error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   final quote = data is List && data.isNotEmpty ? data.first : data;
@@ -211,7 +215,8 @@ Future<Map<String, dynamic>?> _fetchFromKoreanAdvice(
   try {
     data = json.decode(response.body);
   } catch (e, stackTrace) {
-    logError('Korean Advice 返回数据 JSON 解析失败: $e, 响应体: ${response.body}', error: e, stackTrace: stackTrace, source: 'ApiService');
+    logError('Korean Advice 返回数据 JSON 解析失败: $e, 响应体: ${response.body}',
+        error: e, stackTrace: stackTrace, source: 'ApiService');
     return null;
   }
   if (data is! Map<String, dynamic>) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1168,10 +1168,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -1320,10 +1320,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1336,10 +1336,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -2213,26 +2213,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.18"
   timezone:
     dependency: "direct main"
     description:
@@ -2357,10 +2357,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   video_player:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1168,10 +1168,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.3"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -1320,10 +1320,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1336,10 +1336,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -2213,26 +2213,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.1"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.18"
+    version: "0.6.15"
   timezone:
     dependency: "direct main"
     description:
@@ -2357,10 +2357,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.2.0"
   video_player:
     dependency: "direct main"
     description:


### PR DESCRIPTION
展示封装前后的日志内容差异：
封装前，`api_service_daily_quote_remote.dart` 模块中处理各类第三方 API（如 Hitokoto、ZenQuotes、API Ninjas 等）返回数据进行 `json.decode` 抛出异常时，仅使用了 `catch (e)` 并在 `logDebug` 中拼接了粗糙的文本，丢失了异常的完整堆栈（stackTrace）以及统一的模块来源标识（source）。
封装后，将此类异常的捕获升级为 `catch (e, stackTrace)`，并且使用结构化的 `logError` 方法。日志信息中包含了完整的异常对象（`error: e`）、堆栈轨迹（`stackTrace: stackTrace`）、模块标识（`source: 'ApiService'`），同时通过 `响应体: \${response.body}` 保留了排查 JSON 解析错误所需的最关键原始数据。

声明：本次修改仅仅增强了异常记录的结构与堆栈追踪能力，完全未包含任何用户输入的敏感数据（Token、密码或用户日记文本等隐私信息）。

---
*PR created automatically by Jules for task [2071024720745449081](https://jules.google.com/task/2071024720745449081) started by @Shangjin-Xiao*

## Sourcery 摘要

改进 ApiService 对第三方 API 响应解析失败的可观测性。

增强：
- 将第三方报价 API 的 JSON 解析诊断升级为结构化错误日志，包含完整的异常堆栈跟踪，并使用一致的 ApiService 来源标识符。
- 在解析失败时同时记录响应正文，以便更好地排查意外的 API 响应。

杂项：
- 在黑盒变更日志中记录 ApiService 结构化日志方面的变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve ApiService observability for third-party API response parsing failures.

Enhancements:
- Upgrade third-party quote API JSON parsing diagnostics to structured error logs with complete exception stack traces and a consistent ApiService source identifier.
- Record response bodies alongside parsing failures to improve troubleshooting of unexpected API responses.

Chores:
- Document the ApiService structured logging change in the black-box change log.

</details>

<details>
<summary>Original summary in English</summary>



</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`api_service_daily_quote_remote.dart` 中解析第三方 API 响应失败时，由 `catch (e)` + `logDebug` 升级为 `catch (e, stackTrace)` + 结构化 `logError`，现在会记录完整异常对象、堆栈和 `source: 'ApiService'`，便于排查响应结构变化。同步更新了 `.jules/blackbox.md` 黑匣记录，解析失败仍返回 `null`，不影响取名言流程。

**注意**
- `pubspec.lock` 中 `intl`、`meta`、`test` 等依赖版本被降级，若与本 PR 无关请确认后单独处理。

<sup>Written for commit 608b979a053cfd96814d517f293ff811663e8078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when quote data cannot be parsed from remote services.
  * Logs now include detailed error information and stack traces, making failures easier to diagnose.
  * The app continues handling invalid responses gracefully without interrupting quote retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->