### PR TITLE
⚡ Bolt: 优化 AIProviderSettings 中的正则表达式编译性能

### DIFF
--- a/lib/models/ai_provider_settings.dart
+++ b/lib/models/ai_provider_settings.dart
@@ -41,6 +41,18 @@ class AIProviderSettings implements AIConfig {
     'claude-3-5',
   ];
 
+  // 提取为静态成员，避免每次调用 supportsThinking 和 resolveRequestUrl 时重复编译正则表达式
+  static final RegExp _oSeriesRegex = RegExp(r'(^|[/\-_])(o1|o3|o4)\b');
+  static final RegExp _gpt5PlusRegex = RegExp(r'gpt-?[5-9]');
+  static final RegExp _gemini25PlusRegex =
+      RegExp(r'gemini[-_.]?(2[-.]5|[3-9])');
+  static final RegExp _deepseekV3Regex = RegExp(r'v3[-.][1-9]');
+  static final RegExp _qwen3PlusRegex = RegExp(r'qwen[-_]?[3-9]');
+  static final RegExp _gemma4PlusRegex = RegExp(r'gemma[-_.]?[4-9]');
+  static final RegExp _glm45PlusRegex = RegExp(r'glm-?(4[-.][5-9]|[5-9])');
+  static final RegExp _minimaxMRegex = RegExp(r'minimax[-_.]?m[1-9]');
+  static final RegExp _versionPathRegex = RegExp(r'^v\d+[a-z]*$');
+
   /// 判断当前模型是否支持思考/推理模式。
   ///
   /// 只用来决定「深度思考」开关是否出现、以及未显式配置时的默认值；
@@ -63,41 +75,40 @@ class AIProviderSettings implements AIConfig {
     }
 
     // OpenAI o 系列（允许 azure/o1、openai/o3 这类命名空间前缀）与 GPT-5 起的推理模型
-    if (RegExp(r'(^|[/\-_])(o1|o3|o4)\b').hasMatch(m)) {
+    if (_oSeriesRegex.hasMatch(m)) {
       return true;
     }
-    if (RegExp(r'gpt-?[5-9]').hasMatch(m)) {
+    if (_gpt5PlusRegex.hasMatch(m)) {
       return true;
     }
 
     // Gemini：2.5 起默认带 thinking，1.5/2.0 不带
-    if (m.contains('gemini') &&
-        RegExp(r'gemini[-_.]?(2[-.]5|[3-9])').hasMatch(m)) {
+    if (m.contains('gemini') && _gemini25PlusRegex.hasMatch(m)) {
       return true;
     }
 
     // DeepSeek：R1 / Reasoner，以及 V3.1 起的混合推理
     if (m.contains('deepseek') &&
-        (m.contains('r1') || RegExp(r'v3[-.][1-9]').hasMatch(m))) {
+        (m.contains('r1') || _deepseekV3Regex.hasMatch(m))) {
       return true;
     }
 
     // Qwen QwQ / Qwen3 起的推理系列
-    if (m.contains('qwq') || RegExp(r'qwen[-_]?[3-9]').hasMatch(m)) {
+    if (m.contains('qwq') || _qwen3PlusRegex.hasMatch(m)) {
       return true;
     }
 
     // Gemma 4 起带思考。它和上面几家不同：默认不吐 reasoning，要在请求里
     // 明确要（见 AgentService 的 reasoning_effort），所以更要认出来。
-    if (RegExp(r'gemma[-_.]?[4-9]').hasMatch(m)) {
+    if (_gemma4PlusRegex.hasMatch(m)) {
       return true;
     }
 
     // 智谱 GLM-4.5 起、MiniMax M 系列
-    if (RegExp(r'glm-?(4[-.][5-9]|[5-9])').hasMatch(m)) {
+    if (_glm45PlusRegex.hasMatch(m)) {
       return true;
     }
-    if (RegExp(r'minimax[-_.]?m[1-9]').hasMatch(m)) {
+    if (_minimaxMRegex.hasMatch(m)) {
       return true;
     }
 
@@ -186,7 +197,7 @@ class AIProviderSettings implements AIConfig {
     final segments = path.split('/').where((s) => s.isNotEmpty).toList();
     if (segments.isEmpty) return false;
     final last = segments.last.toLowerCase();
-    return last == 'openai' || RegExp(r'^v\d+[a-z]*$').hasMatch(last);
+    return last == 'openai' || _versionPathRegex.hasMatch(last);
   }
 
   Map<String, dynamic> toJson() {


### PR DESCRIPTION
💡 What: 优化 AIProviderSettings 中模型能力判断与 URL 规范化逻辑中的正则表达式编译。
🎯 Why: 每次调用 supportsThinking 或 resolveRequestUrl 时内联实例化 RegExp 对象会导致重复解析和编译正则表达式。
📊 Impact: 将正则表达式提取为 static final 静态变量，只在类加载时编译一次，消除重复实例化与正则编译的 CPU 与 GC 开销。
🔬 Measurement: 已通过 flutter test test/unit/models/ai_provider_settings_test.dart 与 flutter analyze 验证。

---
*PR created automatically by Jules for task [15328190974206688698](https://jules.google.com/task/15328190974206688698) started by @Shangjin-Xiao*

## Sourcery 摘要

增强功能：
- 重用静态初始化的正则表达式，用于模型能力检测和请求 URL 规范化，从而避免重复编译并减少运行时分配开销。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Reuse statically initialized regular expressions for model capability detection and request URL normalization to avoid repeated compilation and reduce runtime allocation overhead.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `AIProviderSettings` 中 `supportsThinking` 和 `_looksLikeOpenAIBaseUrl` 内联创建的正则表达式提取为 `static final` 字段，改为类加载时编译一次。消除了每次调用时的重复解析和编译开销，行为不变。

<sup>Written for commit 1fb5de3bab231b079696529f8bd100d565107079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved the efficiency of AI provider capability and URL detection by reusing compiled pattern matching rules.
* **Behavior**
  * Preserved existing matching logic and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->