### PR TITLE
⚡ Bolt: [优化 AI 命令助手中字符串分割造成的 GC 压力]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -160,3 +160,6 @@ Updated `importDataFromMap` and `_mergeQuotes` in `lib/services/database_backup_
 ## 2024-11-20 - [Performance] 消除频繁使用的颜色字符串解析中不必要的垃圾回收
 **Learning:** 在高频调用的颜色解析函数中（如富文本转换 `_parseHexColor` 或 SVG 颜色提取），使用 `value.split('').map((char) => '$char$char').join()` 将简写的十六进制颜色代码（如 `#abc`）扩展至完整代码时，会产生大量一次性对象（列表、迭代器），极大增加垃圾回收的压力，造成约数倍的运行耗时差异。
 **Action:** 当目标字符串长度固定且极短（如 3 或 4 个字符的颜色代码）时，使用精确的字符串索引插值，例如 `'${value[0]}${value[0]}${value[1]}${value[1]}...'`，不仅更直接、执行速度更快（~135ms vs 481ms 在百万级循环测试下），而且完全消除了对 GC 的额外负担，这是热路径中的一个典型且高价值的微优化模式。
+## 2024-05-24 - 优化 AI 命令助手中字符串分割造成的 GC 压力
+**Learning:** 在字符串处理中，使用 `String.split('\n')` 或 `String.split(',')` 获取局部内容会创建不必要的中间 `List` 和 `String` 对象，从而增加内存消耗和垃圾回收（GC）压力。
+**Action:** 使用 `String.indexOf` 配合 `substring` 或在循环中逐步提取，可有效避免无谓的内存分配，特别是在高频调用的辅助函数中，此优化能在保持可读性的同时显著提升性能。

--- a/lib/utils/ai_command_helpers.dart
+++ b/lib/utils/ai_command_helpers.dart
@@ -55,8 +55,13 @@ class NoteQueryHelper {
   /// 从内容提取标题
   static String _extractTitle(String content, {int maxLength = 50}) {
     if (content.isEmpty) return '';
-    final lines = content.split('\n');
-    final firstLine = lines.first.trim();
+
+    // 使用 indexOf 代替 split('\n') 以降低频繁创建 String 对象的内存与 GC 压力
+    final newlineIndex = content.indexOf('\n');
+    final firstLineRaw =
+        newlineIndex == -1 ? content : content.substring(0, newlineIndex);
+
+    final firstLine = firstLineRaw.trim();
     if (firstLine.length <= maxLength) {
       return firstLine;
     }
@@ -67,11 +72,19 @@ class NoteQueryHelper {
   static List<String> _parseKeywords(dynamic keywords) {
     if (keywords == null) return [];
     if (keywords is String) {
-      return keywords
-          .split(',')
-          .map((k) => k.trim())
-          .where((k) => k.isNotEmpty)
-          .toList();
+      final result = <String>[];
+      int start = 0;
+      while (start < keywords.length) {
+        final commaIndex = keywords.indexOf(',', start);
+        final endIndex = commaIndex == -1 ? keywords.length : commaIndex;
+        final keyword = keywords.substring(start, endIndex).trim();
+        if (keyword.isNotEmpty) {
+          result.add(keyword);
+        }
+        if (commaIndex == -1) break;
+        start = commaIndex + 1;
+      }
+      return result;
     }
     if (keywords is List) {
       return keywords.map((k) => k.toString().trim()).toList();

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,17 @@
+1.  **Refactor `_extractTitle` in `lib/utils/ai_command_helpers.dart`**:
+    *   Currently, it uses `content.split('\n')` to get the first line of the content, which creates unnecessary intermediate `String` and `List` objects, increasing GC pressure.
+    *   Replace `content.split('\n')` with `content.indexOf('\n')` to find the end of the first line. If found, extract the substring up to that point. If not found, use the entire string.
+2.  **Refactor `_parseKeywords` in `lib/utils/ai_command_helpers.dart`**:
+    *   Currently, it uses `keywords.split(',').map((k) => k.trim()).where((k) => k.isNotEmpty).toList()`. This creates a list of strings and uses closures.
+    *   Replace it with a `while` loop that uses `indexOf(',')` to iterate over the string without creating intermediate lists, reducing GC pressure.
+3.  **Ensure all tests in `test/unit/utils/ai_command_helpers_test.dart` still pass**:
+    *   Run `flutter test test/unit/utils/ai_command_helpers_test.dart` to verify the refactored code works correctly.
+4.  **Format and Analyze**:
+    *   Run `dart format lib/utils/ai_command_helpers.dart`.
+    *   Run `flutter analyze --no-fatal-infos`.
+5.  **Pre-commit steps**:
+    *   Run pre-commit instructions to ensure proper testing, verification, review, and reflection are done.
+6.  **Create PR**:
+    *   Create a PR with the title `⚡ Bolt: [优化 AI 命令助手中字符串分割造成的 GC 压力]`.
+    *   Include `💡 What:`, `🎯 Why:`, `📊 Impact:`, and `🔬 Measurement:` in the description.
+    *   Update `.jules/bolt.md` if necessary.


### PR DESCRIPTION
💡 What: 将 `_extractTitle` 和 `_parseKeywords` 中的 `String.split` 替换为 `String.indexOf` 和 `substring`。
🎯 Why: 原代码通过 `split` 创建完整的中间数组对象，不仅消耗额外的内存，也会增加垃圾回收（GC）的压力，而实际上很多时候只需要第一行或逐个词处理。
📊 Impact: 减少了中间不必要的 `List<String>` 分配，在处理较长文本或高频调用时可显著降低 GC 压力，提升运行效率。
🔬 Measurement: 运行 `flutter test test/unit/utils/ai_command_helpers_test.dart` 确认逻辑无误，并通过静态检查工具验证无潜在风险。

---
*PR created automatically by Jules for task [15987942401320958285](https://jules.google.com/task/15987942401320958285) started by @Shangjin-Xiao*

## Sourcery 总结

增强功能：
- 减少 AI 命令标题和关键词解析过程中的中间字符串及列表分配，以降低垃圾回收压力并提升性能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Reduce intermediate string and list allocations in AI command title and keyword parsing to lower garbage-collection pressure and improve performance.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `_extractTitle` 和 `_parseKeywords` 中的 `String.split` 替换为 `String.indexOf` 和 `substring`，避免创建完整的中间行数组和关键词列表，减少内存分配与 GC 压力，行为和输出保持不变。

<sup>Written for commit 1ac8f5e23082709d3dff4cff8ade0dabf7996800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved command processing efficiency by reducing temporary memory allocations when extracting titles and parsing keywords.
  * Preserved existing title and keyword parsing behavior, including trimming and ignoring empty entries.

* **Documentation**
  * Added development notes describing the optimization and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->