### PR TITLE
🧪 test: add unit tests for Quote.safeDeltaOps edge cases

### DIFF
--- a/test/unit/models/quote_model_test.dart
+++ b/test/unit/models/quote_model_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/utils/quill_delta_builder.dart';
 import '../../test_harness.dart';
 
 void main() {
@@ -299,12 +300,10 @@ void main() {
           deltaContent: delta,
         );
 
-        final ops = quote.safeDeltaOps;
-        expect(ops, isNotEmpty);
-        expect(ops.first['insert'], equals('纯文本内容\n'));
-
-        final safeJson = quote.safeDeltaContent;
-        expect(safeJson, contains('纯文本内容\\n'));
+        final expectedOps = DeltaBuilder.textToDelta(quote.content);
+        expect(quote.safeDeltaOps, equals(expectedOps));
+        expect(quote.safeDeltaContent,
+            equals(DeltaBuilder.deltaToJson(expectedOps)));
       }
     });
 
@@ -318,12 +317,10 @@ void main() {
         deltaContent: '{"invalid": json syntax ...}',
       );
 
-      final ops = quote.safeDeltaOps;
-      expect(ops, isNotEmpty);
-      expect(ops.first['insert'], equals('语法错误降级\n'));
-
-      final safeJson = quote.safeDeltaContent;
-      expect(safeJson, contains('语法错误降级\\n'));
+      final expectedOps = DeltaBuilder.textToDelta(quote.content);
+      expect(quote.safeDeltaOps, equals(expectedOps));
+      expect(quote.safeDeltaContent,
+          equals(DeltaBuilder.deltaToJson(expectedOps)));
     });
 
     test(
@@ -337,9 +334,10 @@ void main() {
           deltaContent: primitiveJson,
         );
 
-        final ops = quote.safeDeltaOps;
-        expect(ops, isNotEmpty);
-        expect(ops.first['insert'], equals('标量JSON降级\n'));
+        final expectedOps = DeltaBuilder.textToDelta(quote.content);
+        expect(quote.safeDeltaOps, equals(expectedOps));
+        expect(quote.safeDeltaContent,
+            equals(DeltaBuilder.deltaToJson(expectedOps)));
       }
     });
 
@@ -352,7 +350,8 @@ void main() {
         date: '2026-08-23T09:00:00.000',
         deltaContent: '{"otherKey": 123}',
       );
-      expect(quote1.safeDeltaOps.first['insert'], equals('无ops字段\n'));
+      final expectedOps1 = DeltaBuilder.textToDelta(quote1.content);
+      expect(quote1.safeDeltaOps, equals(expectedOps1));
 
       final quote2 = Quote(
         id: 'test-map-invalid-ops',
@@ -360,7 +359,8 @@ void main() {
         date: '2026-08-23T09:00:00.000',
         deltaContent: '{"ops": "not_a_list"}',
       );
-      expect(quote2.safeDeltaOps.first['insert'], equals('ops非List\n'));
+      final expectedOps2 = DeltaBuilder.textToDelta(quote2.content);
+      expect(quote2.safeDeltaOps, equals(expectedOps2));
 
       final quote3 = Quote(
         id: 'test-map-valid-ops',
@@ -368,7 +368,12 @@ void main() {
         date: '2026-08-23T09:00:00.000',
         deltaContent: '{"ops": [{"insert": "Map格式ops\\n"}]}',
       );
-      expect(quote3.safeDeltaOps.first['insert'], equals('Map格式ops\n'));
+      expect(
+        quote3.safeDeltaOps,
+        equals([
+          {'insert': 'Map格式ops\n'}
+        ]),
+      );
     });
 
     test('should handle edge cases in fromJson', () {

--- a/test/unit/models/quote_model_test.dart
+++ b/test/unit/models/quote_model_test.dart
@@ -288,6 +288,89 @@ void main() {
       expect(ops.first['insert'], equals('测试\n'));
     });
 
+    test(
+        'safeDeltaOps and safeDeltaContent should fallback when deltaContent is null, empty, or whitespace',
+        () {
+      for (final delta in [null, '', '   ', '\n\t']) {
+        final quote = Quote(
+          id: 'test-empty-delta',
+          content: '纯文本内容\n',
+          date: '2026-08-23T09:00:00.000',
+          deltaContent: delta,
+        );
+
+        final ops = quote.safeDeltaOps;
+        expect(ops, isNotEmpty);
+        expect(ops.first['insert'], equals('纯文本内容\n'));
+
+        final safeJson = quote.safeDeltaContent;
+        expect(safeJson, contains('纯文本内容\\n'));
+      }
+    });
+
+    test(
+        'safeDeltaOps should fallback when deltaContent is malformed JSON syntax',
+        () {
+      final quote = Quote(
+        id: 'test-invalid-json-syntax',
+        content: '语法错误降级\n',
+        date: '2026-08-23T09:00:00.000',
+        deltaContent: '{"invalid": json syntax ...}',
+      );
+
+      final ops = quote.safeDeltaOps;
+      expect(ops, isNotEmpty);
+      expect(ops.first['insert'], equals('语法错误降级\n'));
+
+      final safeJson = quote.safeDeltaContent;
+      expect(safeJson, contains('语法错误降级\\n'));
+    });
+
+    test(
+        'safeDeltaOps should fallback when deltaContent decodes to primitive JSON values',
+        () {
+      for (final primitiveJson in ['123', 'true', '"a plain string"']) {
+        final quote = Quote(
+          id: 'test-primitive-json',
+          content: '标量JSON降级\n',
+          date: '2026-08-23T09:00:00.000',
+          deltaContent: primitiveJson,
+        );
+
+        final ops = quote.safeDeltaOps;
+        expect(ops, isNotEmpty);
+        expect(ops.first['insert'], equals('标量JSON降级\n'));
+      }
+    });
+
+    test(
+        'safeDeltaOps should handle Map deltaContent with missing or non-List ops field',
+        () {
+      final quote1 = Quote(
+        id: 'test-map-no-ops',
+        content: '无ops字段\n',
+        date: '2026-08-23T09:00:00.000',
+        deltaContent: '{"otherKey": 123}',
+      );
+      expect(quote1.safeDeltaOps.first['insert'], equals('无ops字段\n'));
+
+      final quote2 = Quote(
+        id: 'test-map-invalid-ops',
+        content: 'ops非List\n',
+        date: '2026-08-23T09:00:00.000',
+        deltaContent: '{"ops": "not_a_list"}',
+      );
+      expect(quote2.safeDeltaOps.first['insert'], equals('ops非List\n'));
+
+      final quote3 = Quote(
+        id: 'test-map-valid-ops',
+        content: '默认文本\n',
+        date: '2026-08-23T09:00:00.000',
+        deltaContent: '{"ops": [{"insert": "Map格式ops\\n"}]}',
+      );
+      expect(quote3.safeDeltaOps.first['insert'], equals('Map格式ops\n'));
+    });
+
     test('should handle edge cases in fromJson', () {
       // 测试空tag_ids
       final json1 = {

--- a/test/unit/models/quote_model_test.dart
+++ b/test/unit/models/quote_model_test.dart
@@ -3,7 +3,6 @@ library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/models/quote_model.dart';
-import 'package:thoughtecho/utils/quill_delta_builder.dart';
 import '../../test_harness.dart';
 
 void main() {
@@ -292,6 +291,13 @@ void main() {
     test(
         'safeDeltaOps and safeDeltaContent should fallback when deltaContent is null, empty, or whitespace',
         () {
+      const expectedFallbackOps = [
+        {'insert': '纯文本内容\n'},
+        {'insert': '\n'}
+      ];
+      const expectedFallbackJson =
+          '{"ops":[{"insert":"纯文本内容\\n"},{"insert":"\\n"}]}';
+
       for (final delta in [null, '', '   ', '\n\t']) {
         final quote = Quote(
           id: 'test-empty-delta',
@@ -300,10 +306,8 @@ void main() {
           deltaContent: delta,
         );
 
-        final expectedOps = DeltaBuilder.textToDelta(quote.content);
-        expect(quote.safeDeltaOps, equals(expectedOps));
-        expect(quote.safeDeltaContent,
-            equals(DeltaBuilder.deltaToJson(expectedOps)));
+        expect(quote.safeDeltaOps, equals(expectedFallbackOps));
+        expect(quote.safeDeltaContent, equals(expectedFallbackJson));
       }
     });
 
@@ -317,15 +321,29 @@ void main() {
         deltaContent: '{"invalid": json syntax ...}',
       );
 
-      final expectedOps = DeltaBuilder.textToDelta(quote.content);
-      expect(quote.safeDeltaOps, equals(expectedOps));
-      expect(quote.safeDeltaContent,
-          equals(DeltaBuilder.deltaToJson(expectedOps)));
+      expect(
+        quote.safeDeltaOps,
+        equals([
+          {'insert': '语法错误降级\n'},
+          {'insert': '\n'}
+        ]),
+      );
+      expect(
+        quote.safeDeltaContent,
+        equals('{"ops":[{"insert":"语法错误降级\\n"},{"insert":"\\n"}]}'),
+      );
     });
 
     test(
         'safeDeltaOps should fallback when deltaContent decodes to primitive JSON values',
         () {
+      const expectedOps = [
+        {'insert': '标量JSON降级\n'},
+        {'insert': '\n'}
+      ];
+      const expectedJson =
+          '{"ops":[{"insert":"标量JSON降级\\n"},{"insert":"\\n"}]}';
+
       for (final primitiveJson in ['123', 'true', '"a plain string"']) {
         final quote = Quote(
           id: 'test-primitive-json',
@@ -334,10 +352,8 @@ void main() {
           deltaContent: primitiveJson,
         );
 
-        final expectedOps = DeltaBuilder.textToDelta(quote.content);
         expect(quote.safeDeltaOps, equals(expectedOps));
-        expect(quote.safeDeltaContent,
-            equals(DeltaBuilder.deltaToJson(expectedOps)));
+        expect(quote.safeDeltaContent, equals(expectedJson));
       }
     });
 
@@ -350,8 +366,17 @@ void main() {
         date: '2026-08-23T09:00:00.000',
         deltaContent: '{"otherKey": 123}',
       );
-      final expectedOps1 = DeltaBuilder.textToDelta(quote1.content);
-      expect(quote1.safeDeltaOps, equals(expectedOps1));
+      expect(
+        quote1.safeDeltaOps,
+        equals([
+          {'insert': '无ops字段\n'},
+          {'insert': '\n'}
+        ]),
+      );
+      expect(
+        quote1.safeDeltaContent,
+        equals('{"ops":[{"insert":"无ops字段\\n"},{"insert":"\\n"}]}'),
+      );
 
       final quote2 = Quote(
         id: 'test-map-invalid-ops',
@@ -359,8 +384,17 @@ void main() {
         date: '2026-08-23T09:00:00.000',
         deltaContent: '{"ops": "not_a_list"}',
       );
-      final expectedOps2 = DeltaBuilder.textToDelta(quote2.content);
-      expect(quote2.safeDeltaOps, equals(expectedOps2));
+      expect(
+        quote2.safeDeltaOps,
+        equals([
+          {'insert': 'ops非List\n'},
+          {'insert': '\n'}
+        ]),
+      );
+      expect(
+        quote2.safeDeltaContent,
+        equals('{"ops":[{"insert":"ops非List\\n"},{"insert":"\\n"}]}'),
+      );
 
       final quote3 = Quote(
         id: 'test-map-valid-ops',
@@ -373,6 +407,10 @@ void main() {
         equals([
           {'insert': 'Map格式ops\n'}
         ]),
+      );
+      expect(
+        quote3.safeDeltaContent,
+        equals('{"ops":[{"insert":"Map格式ops\\n"}]}'),
       );
     });
 


### PR DESCRIPTION
🎯 **What:** Added unit test coverage for `Quote.safeDeltaOps` and `Quote.safeDeltaContent` fallback logic when encountering invalid or malformed JSON formats.
📊 **Coverage:** Covered null, empty, whitespace-only, malformed syntax JSON strings, primitive JSON scalar values, and Map structures without valid `ops` fields.
✨ **Result:** Enhanced unit test suite reliability for the `Quote` model.

---
*PR created automatically by Jules for task [1806715270270612397](https://jules.google.com/task/1806715270270612397) started by @Shangjin-Xiao*

## Sourcery 摘要

测试：
- 扩展 Quote 模型单元测试覆盖范围，测试针对空 JSON、格式错误的 JSON、原始类型 JSON 以及无效的映射结构 JSON 输入的安全 delta 解析回退，同时保留对有效 ops 的处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

测试：
- 扩展 Quote 模型单元测试，验证安全的 delta 解析在 JSON 为空、格式错误、为基本类型或结构无效时会回退到文本内容，同时保留对有效操作的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Expand Quote model unit tests to verify safe delta parsing falls back to text content for empty, malformed, primitive, and invalid-structure JSON while preserving valid ops handling.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `Quote.safeDeltaOps` 和 `Quote.safeDeltaContent` 补充边界情况单元测试，覆盖 `deltaContent` 为 null、空字符串、纯空白、语法错误 JSON、标量 JSON 值，以及 Map 缺失或含非 List 的 `ops` 字段等场景，确保这些情况能正确回退到纯文本内容。

- 新增 4 组测试并断言回退后的 `ops` 与 `safeDeltaContent`，仅修改 `test/unit/models/quote_model_test.dart`，无生产代码变更。

<sup>Written for commit 211e9b2896923628a2d3271183d6bf8e99a7ff8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for quote delta content fallback handling, including null, empty, whitespace-only, malformed, primitive, and object-shaped values.
  * Added assertions for missing or invalid operations data.
  * Expanded validation to confirm complete fallback results and correctly handled valid operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->