### PR TITLE
⚡ Bolt: 优化 AddNoteController 一言标签预载入与 N+1 查询

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -163,3 +163,8 @@ Updated `importDataFromMap` and `_mergeQuotes` in `lib/services/database_backup_
 ## 2024-05-24 - 优化 AI 命令助手中字符串分割造成的 GC 压力
 **Learning:** 在字符串处理中，使用 `String.split('\n')` 或 `String.split(',')` 获取局部内容会创建不必要的中间 `List` 和 `String` 对象，从而增加内存消耗和垃圾回收（GC）压力。
 **Action:** 使用 `String.indexOf` 配合 `substring` 或在循环中逐步提取，可有效避免无谓的内存分配，特别是在高频调用的辅助函数中，此优化能在保持可读性的同时显著提升性能。
+
+## 2026-08-17 - 消除 AddNoteController 中 ensureTagExists 的 N+1 数据库查询
+
+**Learning:** 在初始化或批量生成笔记标签（如添加一言默认标签）时，如果在循环体内逐个通过 `db.getTagById(fixedId)` 查询数据库，会造成 N+1 查询模式。将标签类别列表预先加载或更新至内存缓存（`allCategoriesCache`），并在内存中基于 `fixedId` 或 `name` 进行匹配，可消除循环内的数据库 I/O 交互。
+**Action:** 修改 `lib/controllers/add_note_controller.dart` 中 `ensureTagExists` 和 `addDefaultHitokotoTagsAsync`，在处理标签前统一使用 `db.getTags()` 填充 `allCategoriesCache`，并在内存中进行 ID/名称匹配和副分类 ID 获取，将 `getTagById` 查询次数降为 0。

--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -200,7 +200,10 @@ class AddNoteController extends ChangeNotifier {
   }) {
     locationService = locService ?? locationService;
     weatherService = weaService ?? weatherService;
-    databaseService = dbService ?? databaseService;
+    if (dbService != null && dbService != databaseService) {
+      databaseService = dbService;
+      allCategoriesCache = null;
+    }
   }
 
   void _clearNewLocation() {
@@ -533,14 +536,17 @@ class AddNoteController extends ChangeNotifier {
       }
 
       if (subtypeTagId != null) {
-        final category = allCategoriesCache?.firstWhere(
-          (tag) => tag.id == subtypeTagId,
-          orElse: () => NoteTag(id: '', name: ''),
-        );
+        NoteTag? category;
+        if (allCategoriesCache != null) {
+          for (final tag in allCategoriesCache!) {
+            if (tag.id == subtypeTagId) {
+              category = tag;
+              break;
+            }
+          }
+        }
         if (_isDisposed) return;
-        final selected = (category != null && category.id.isNotEmpty)
-            ? category
-            : await db.getTagById(subtypeTagId);
+        final selected = category ?? await db.getTagById(subtypeTagId);
         if (_isDisposed) return;
         selectedCategory = selected;
         if (selected != null) {
@@ -585,29 +591,26 @@ class AddNoteController extends ChangeNotifier {
       final categories = allCategoriesCache!;
 
       if (fixedId != null) {
-        final existingTagById = categories.firstWhere(
-          (tag) => tag.id == fixedId,
-          orElse: () => NoteTag(id: '', name: ''),
-        );
-        if (existingTagById.id.isNotEmpty) {
-          return existingTagById.id;
+        for (final tag in categories) {
+          if (tag.id == fixedId) {
+            return tag.id;
+          }
         }
       }
 
-      final existingTagByName = categories.firstWhere(
-        (tag) => tag.name.toLowerCase() == name.toLowerCase(),
-        orElse: () => NoteTag(id: '', name: ''),
-      );
-
-      if (existingTagByName.id.isNotEmpty) {
-        return existingTagByName.id;
+      for (final tag in categories) {
+        if (tag.name.toLowerCase() == name.toLowerCase()) {
+          return tag.id;
+        }
       }
 
       if (fixedId != null) {
         try {
           await db.addTagWithId(fixedId, name, iconName: iconName);
           if (_isDisposed) return null;
-          allCategoriesCache = await db.getTags();
+          final fetchedCategories = await db.getTags();
+          if (_isDisposed) return null;
+          allCategoriesCache = fetchedCategories;
           return fixedId;
         } catch (e, stackTrace) {
           logError(
@@ -628,12 +631,13 @@ class AddNoteController extends ChangeNotifier {
       final updatedCategories = await db.getTags();
       if (_isDisposed) return null;
       allCategoriesCache = updatedCategories;
-      final newTag = updatedCategories.firstWhere(
-        (tag) => tag.name.toLowerCase() == name.toLowerCase(),
-        orElse: () => NoteTag(id: '', name: ''),
-      );
+      for (final tag in updatedCategories) {
+        if (tag.name.toLowerCase() == name.toLowerCase()) {
+          return tag.id;
+        }
+      }
 
-      return newTag.id.isNotEmpty ? newTag.id : null;
+      return null;
     } catch (e, stackTrace) {
       logError(
         '确保标签"$name"存在时出错',

--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -507,6 +507,7 @@ class AddNoteController extends ChangeNotifier {
       if (allCategoriesCache == null) {
         final fetchedCategories = await db.getTags();
         if (_isDisposed) return;
+        if (databaseService != db) return;
         allCategoriesCache = fetchedCategories;
       }
 
@@ -586,6 +587,7 @@ class AddNoteController extends ChangeNotifier {
       if (allCategoriesCache == null) {
         final fetchedCategories = await db.getTags();
         if (_isDisposed) return null;
+        if (databaseService != db) return null;
         allCategoriesCache = fetchedCategories;
       }
       final categories = allCategoriesCache!;
@@ -630,7 +632,9 @@ class AddNoteController extends ChangeNotifier {
 
       final updatedCategories = await db.getTags();
       if (_isDisposed) return null;
-      allCategoriesCache = updatedCategories;
+      if (databaseService == db) {
+        allCategoriesCache = updatedCategories;
+      }
       for (final tag in updatedCategories) {
         if (tag.name.toLowerCase() == name.toLowerCase()) {
           return tag.id;

--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -501,6 +501,12 @@ class AddNoteController extends ChangeNotifier {
         }
       }
 
+      if (allCategoriesCache == null) {
+        final fetchedCategories = await db.getTags();
+        if (_isDisposed) return;
+        allCategoriesCache = fetchedCategories;
+      }
+
       final List<String> tagIds = [];
       String? subtypeTagId;
       for (final tagInfo in tagsToEnsure) {
@@ -527,10 +533,19 @@ class AddNoteController extends ChangeNotifier {
       }
 
       if (subtypeTagId != null) {
-        final category = await db.getTagById(subtypeTagId);
+        final category = allCategoriesCache?.firstWhere(
+          (tag) => tag.id == subtypeTagId,
+          orElse: () => NoteTag(id: '', name: ''),
+        );
         if (_isDisposed) return;
-        selectedCategory = category;
-        onCategoryUpdated(category);
+        final selected = (category != null && category.id.isNotEmpty)
+            ? category
+            : await db.getTagById(subtypeTagId);
+        if (_isDisposed) return;
+        selectedCategory = selected;
+        if (selected != null) {
+          onCategoryUpdated(selected);
+        }
       }
     } catch (e, stackTrace) {
       logError(
@@ -562,14 +577,6 @@ class AddNoteController extends ChangeNotifier {
         }
       }
 
-      if (fixedId != null) {
-        final category = await db.getTagById(fixedId);
-        if (_isDisposed) return null;
-        if (category != null) {
-          return category.id;
-        }
-      }
-
       if (allCategoriesCache == null) {
         final fetchedCategories = await db.getTags();
         if (_isDisposed) return null;
@@ -577,20 +584,30 @@ class AddNoteController extends ChangeNotifier {
       }
       final categories = allCategoriesCache!;
 
-      final existingTag = categories.firstWhere(
+      if (fixedId != null) {
+        final existingTagById = categories.firstWhere(
+          (tag) => tag.id == fixedId,
+          orElse: () => NoteTag(id: '', name: ''),
+        );
+        if (existingTagById.id.isNotEmpty) {
+          return existingTagById.id;
+        }
+      }
+
+      final existingTagByName = categories.firstWhere(
         (tag) => tag.name.toLowerCase() == name.toLowerCase(),
         orElse: () => NoteTag(id: '', name: ''),
       );
 
-      if (existingTag.id.isNotEmpty) {
-        return existingTag.id;
+      if (existingTagByName.id.isNotEmpty) {
+        return existingTagByName.id;
       }
 
       if (fixedId != null) {
         try {
           await db.addTagWithId(fixedId, name, iconName: iconName);
           if (_isDisposed) return null;
-          allCategoriesCache = null;
+          allCategoriesCache = await db.getTags();
           return fixedId;
         } catch (e, stackTrace) {
           logError(
@@ -608,9 +625,9 @@ class AddNoteController extends ChangeNotifier {
         if (_isDisposed) return null;
       }
 
-      allCategoriesCache = null;
       final updatedCategories = await db.getTags();
       if (_isDisposed) return null;
+      allCategoriesCache = updatedCategories;
       final newTag = updatedCategories.firstWhere(
         (tag) => tag.name.toLowerCase() == name.toLowerCase(),
         orElse: () => NoteTag(id: '', name: ''),

--- a/lib/controllers/add_note_controller.dart
+++ b/lib/controllers/add_note_controller.dart
@@ -587,7 +587,11 @@ class AddNoteController extends ChangeNotifier {
       if (allCategoriesCache == null) {
         final fetchedCategories = await db.getTags();
         if (_isDisposed) return null;
-        if (databaseService != db) return null;
+        if (databaseService == null) {
+          databaseService = db;
+        } else if (databaseService != db) {
+          return null;
+        }
         allCategoriesCache = fetchedCategories;
       }
       final categories = allCategoriesCache!;
@@ -612,7 +616,9 @@ class AddNoteController extends ChangeNotifier {
           if (_isDisposed) return null;
           final fetchedCategories = await db.getTags();
           if (_isDisposed) return null;
-          allCategoriesCache = fetchedCategories;
+          if (databaseService == db) {
+            allCategoriesCache = fetchedCategories;
+          }
           return fixedId;
         } catch (e, stackTrace) {
           logError(

--- a/test/unit/controllers/add_note_controller_test.dart
+++ b/test/unit/controllers/add_note_controller_test.dart
@@ -116,11 +116,9 @@ void main() {
       )..updateServices(dbService: db);
 
       NoteTag? updatedCategory;
-      final stopwatch = Stopwatch()..start();
       await controller.addDefaultHitokotoTagsAsync((cat) {
         updatedCategory = cat;
       });
-      stopwatch.stop();
 
       // Ensure correctness
       expect(controller.selectedTagIds,

--- a/test/unit/controllers/add_note_controller_test.dart
+++ b/test/unit/controllers/add_note_controller_test.dart
@@ -134,6 +134,28 @@ void main() {
       expect(db.getTagsCallCount, lessThanOrEqualTo(1),
           reason: 'getTags should be called at most once to prefetch tags');
     });
+
+    test(
+        'updateServices with a new dbService resets allCategoriesCache and reloads from new db',
+        () async {
+      final db1 = _CountingDatabaseService();
+      final db2 = _CountingDatabaseService();
+
+      final controller = AddNoteController(context: FakeBuildContext())
+        ..updateServices(dbService: db1);
+
+      await controller.ensureTagExists(db1, '每日一言', '💭');
+      expect(controller.allCategoriesCache, isNotNull);
+      expect(db1.getTagsCallCount, equals(1));
+
+      controller.updateServices(dbService: db2);
+      expect(controller.allCategoriesCache, isNull,
+          reason:
+              'allCategoriesCache should be reset when switching databaseService');
+
+      await controller.ensureTagExists(db2, '每日一言', '💭');
+      expect(db2.getTagsCallCount, equals(1));
+    });
   });
 }
 

--- a/test/unit/controllers/add_note_controller_test.dart
+++ b/test/unit/controllers/add_note_controller_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:thoughtecho/controllers/add_note_controller.dart';
+import 'package:thoughtecho/models/note_tag.dart';
 import 'package:thoughtecho/models/quote_model.dart';
+import 'package:thoughtecho/services/database_service.dart';
 import 'package:thoughtecho/services/location_service.dart';
 
 class FakeBuildContext extends Fake implements BuildContext {}
@@ -98,4 +100,80 @@ void main() {
       expect(controller.isFetchingWeather, isFalse);
     });
   });
+
+  group(
+      'AddNoteController.addDefaultHitokotoTagsAsync performance & query count',
+      () {
+    test('addDefaultHitokotoTagsAsync adds tags correctly and batches DB reads',
+        () async {
+      final db = _CountingDatabaseService();
+      final controller = AddNoteController(
+        context: FakeBuildContext(),
+        hitokotoData: {
+          'type': 'a',
+          'provider': 'hitokoto',
+        },
+      )..updateServices(dbService: db);
+
+      NoteTag? updatedCategory;
+      final stopwatch = Stopwatch()..start();
+      await controller.addDefaultHitokotoTagsAsync((cat) {
+        updatedCategory = cat;
+      });
+      stopwatch.stop();
+
+      // Ensure correctness
+      expect(controller.selectedTagIds,
+          containsAll(['default_hitokoto', 'default_anime']));
+      expect(updatedCategory?.id, equals('default_anime'));
+      expect(controller.selectedCategory?.id, equals('default_anime'));
+
+      // Check query counts
+      // Under optimized implementation, db.getTagById should NOT be called N times in a loop.
+      expect(db.getTagByIdCallCount, equals(0),
+          reason:
+              'getTagById should not be called inside loop when cached/batched tags are used');
+      expect(db.getTagsCallCount, lessThanOrEqualTo(1),
+          reason: 'getTags should be called at most once to prefetch tags');
+    });
+  });
+}
+
+class _CountingDatabaseService extends DatabaseService {
+  _CountingDatabaseService() : super.forTesting();
+
+  int getTagByIdCallCount = 0;
+  int getTagsCallCount = 0;
+
+  final Map<String, NoteTag> _tags = {
+    'default_hitokoto':
+        NoteTag(id: 'default_hitokoto', name: '每日一言', iconName: '💭'),
+    'default_anime': NoteTag(id: 'default_anime', name: '动画', iconName: '🎬'),
+  };
+
+  @override
+  Future<NoteTag?> getTagById(String id) async {
+    getTagByIdCallCount++;
+    return _tags[id];
+  }
+
+  @override
+  Future<List<NoteTag>> getTags() async {
+    getTagsCallCount++;
+    return _tags.values.toList();
+  }
+
+  @override
+  Future<void> addTagWithId(String id, String name, {String? iconName}) async {
+    _tags[id] = NoteTag(id: id, name: name, iconName: iconName ?? '');
+  }
+
+  @override
+  Future<void> addTag(String name, {String? iconName}) async {
+    final id = name;
+    _tags[id] = NoteTag(id: id, name: name, iconName: iconName ?? '');
+  }
+
+  @override
+  bool get isInitialized => true;
 }

--- a/test/unit/controllers/add_note_controller_test.dart
+++ b/test/unit/controllers/add_note_controller_test.dart
@@ -156,6 +156,20 @@ void main() {
       await controller.ensureTagExists(db2, '每日一言', '💭');
       expect(db2.getTagsCallCount, equals(1));
     });
+
+    test(
+        'ensureTagExists binds databaseService when initially null and returns existing tag',
+        () async {
+      final db = _CountingDatabaseService();
+      final controller = AddNoteController(context: FakeBuildContext());
+      expect(controller.databaseService, isNull);
+
+      final tagId = await controller.ensureTagExists(db, '每日一言', '💭');
+      expect(tagId, equals('default_hitokoto'));
+      expect(controller.databaseService, equals(db));
+      expect(controller.allCategoriesCache, isNotNull);
+      expect(db.getTagsCallCount, equals(1));
+    });
   });
 }
 


### PR DESCRIPTION
⚡ Bolt: 优化 AddNoteController 一言标签预载入与 N+1 查询

💡 **What:**
在 `AddNoteController.ensureTagExists` 和 `addDefaultHitokotoTagsAsync` 中，优化了默认标签与固定 ID 标签的查找与预载入逻辑。通过在批量检测标签存在性之前预先载入并更新 `allCategoriesCache`，在内存中直接根据固定 ID (`fixedId`) 或标签名称寻找已有分类，并在解析 `subtypeTagId` 时优先复用缓存中的标签模型。

🎯 **Why:**
之前在 `addDefaultHitokotoTagsAsync` 循环调用 `ensureTagExists` 时，每次均会调用 `db.getTagById(fixedId)`，且在循环完成后又单独调用了一次 `db.getTagById(subtypeTagId)`，忽略了已有 `allCategoriesCache` 的情况，从而触发典型的 N+1 数据库查询，增加了数据库 I/O 交互与微任务调度开销。

📊 **Measured Improvement:**
在 `test/unit/controllers/add_note_controller_test.dart` 中新增的基准查询计数测试中：
- 优化前：处理 2 个一言标签时触发 3 次 `db.getTagById` 查询；
- 优化后：`db.getTagById` 调用次数降为 **0** 次，全部转换为对 `allCategoriesCache` 内存的查找，全量标签仅需在起始时获取 1 次（或已有缓存时 0 次），消除了 N+1 数据库查询损耗。

---
*PR created automatically by Jules for task [10121477001616836601](https://jules.google.com/task/10121477001616836601) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
优化 `AddNoteController` 中一言标签的查找逻辑，用内存缓存 `allCategoriesCache` 替代循环内的 `db.getTagById` 调用，消除了批量添加标签时的 N+1 数据库查询，并修复了标签查找回退时的断言崩溃。

**修复与性能影响**
- 标签查找回退改为可空匹配，避免构造 `NoteTag(id: '', name: '')` 触发断言崩溃。
- `updateServices` 切换数据库服务时重置 `allCategoriesCache`；异步拉取标签后校验 `databaseService == db`（`ensureTagExists` 在初始为 null 时绑定当前 db），防止陈旧缓存写入。
- 处理 2 个一言标签时，`db.getTagById` 调用次数从 3 次降为 0 次；`db.getTags` 最多 1 次用于预载入缓存，已有缓存时为 0 次。

<sup>Written for commit c055b0be2c9d6598dc10213f3dc45da8d5f33e78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Sourcery 摘要

通过批量加载分类并从内存缓存中解析标签，消除初始化默认 Hitokoto 标签时冗余的数据库查询。

改进：
- 优化 AddNoteController 的标签初始化逻辑，复用预加载的分类缓存来查询固定 ID 和子类型标签，消除重复的数据库读取。

测试：
- 添加查询计数覆盖，验证默认 Hitokoto 标签能够正确添加，且不会产生 N+1 次 getTagById 调用。

杂项：
- 记录默认标签初始化过程中移除 N+1 数据库查询的改动。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过批量预加载并复用分类缓存，消除默认一言标签初始化中的 N+1 数据库查询。

改进：
- 优化 AddNoteController 的默认一言标签初始化，通过复用预加载的分类缓存减少重复数据库查询。

测试：
- 新增查询计数测试，验证默认一言标签添加正确且不会产生循环内的 getTagById 查询。

杂项：
- 在数据库服务切换时重置分类缓存，并记录此次 N+1 查询优化。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过复用缓存的分类，并在数据库服务发生变化时安全地刷新分类，消除默认 Hitokoto 标签初始化期间冗余的数据库查询。

错误修复：
- 防止标签查找回退逻辑构造无效的空标签，避免触发断言失败。
- 切换数据库服务实例时重置分类缓存，并防止异步更新作用于过期或已释放的服务。

改进：
- 初始化默认 Hitokoto 标签时，复用预加载的分类缓存进行 ID 和名称匹配，消除冗余的数据库查询。

测试：
- 添加查询次数测试，验证默认标签能够正确初始化且不会重复调用 getTagById，并验证数据库服务变更后的缓存重新加载行为。

杂务：
- 在项目性能说明中记录 N+1 查询优化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Eliminate redundant database queries during default Hitokoto tag initialization by reusing cached categories and safely refreshing them when database services change.

Bug Fixes:
- Prevent tag lookup fallbacks from constructing invalid empty tags that could trigger assertion failures.
- Reset the category cache when switching database service instances and guard asynchronous updates against stale or disposed services.

Enhancements:
- Eliminate redundant database lookups when initializing default Hitokoto tags by reusing a preloaded category cache for ID and name matching.

Tests:
- Add query-count coverage verifying correct default tag initialization without repeated getTagById calls and cache reload behavior after database service changes.

Chores:
- Record the N+1 query optimization in the project performance notes.

</details>

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced database lookups when adding default and existing tags by reusing cached category data.
  - Improved tag matching efficiency, especially when processing multiple tags.

- **Bug Fixes**
  - Ensured category data refreshes appropriately after tags are created or the database service changes.
  - Preserved correct assignment of default Hitokoto and anime tags while reducing repeated database queries.

- **Tests**
  - Added coverage verifying default tag assignment and batched database access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->