### PR TITLE
🎨 Fresco: 重构 ImageTextSelector 消除硬编码颜色并使用 AppEmptyView

### DIFF
--- a/lib/widgets/local_ai/image_text_selector.dart
+++ b/lib/widgets/local_ai/image_text_selector.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../gen_l10n/app_localizations.dart';
+import '../app_empty_view.dart';
 
 /// 图片文字区域选择组件
 ///
@@ -48,28 +49,8 @@ class _ImageTextSelectorState extends State<ImageTextSelector> {
             child: Stack(
               children: [
                 // TODO: 显示图片 - 后端实现后添加
-                Center(
-                  child: Container(
-                    color: Colors.grey[300],
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          Icons.image,
-                          size: 64,
-                          color: Colors.grey[600],
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          l10n.featureComingSoon,
-                          style: TextStyle(
-                            color: Colors.grey[600],
-                            fontSize: 16,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
+                AppEmptyView(
+                  text: l10n.featureComingSoon,
                 ),
 
                 // TODO: 文字区域高亮 - 后端实现后添加

--- a/lib/widgets/local_ai/image_text_selector.dart
+++ b/lib/widgets/local_ai/image_text_selector.dart
@@ -65,6 +65,7 @@ class _ImageTextSelectorState extends State<ImageTextSelector> {
                     width: region.width,
                     height: region.height,
                     child: GestureDetector(
+                      key: ValueKey('image_text_region_$index'),
                       onTap: () {
                         setState(() {
                           _selectedRegionIndex = index;

--- a/test/widget/widgets/image_text_selector_test.dart
+++ b/test/widget/widgets/image_text_selector_test.dart
@@ -43,7 +43,7 @@ void main() {
     expect(find.byType(FilledButton), findsNothing);
 
     // Tap on region
-    final regionFinder = find.byType(GestureDetector).first;
+    final regionFinder = find.byKey(const ValueKey('image_text_region_0'));
     await tester.tap(regionFinder);
     await tester.pumpAndSettle();
 

--- a/test/widget/widgets/image_text_selector_test.dart
+++ b/test/widget/widgets/image_text_selector_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:thoughtecho/gen_l10n/app_localizations.dart';
+import 'package:thoughtecho/widgets/app_empty_view.dart';
+import 'package:thoughtecho/widgets/local_ai/image_text_selector.dart';
+
+void main() {
+  Widget buildTestApp({
+    required List<Rect> detectedRegions,
+    Function(Rect)? onRegionSelected,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: ImageTextSelector(
+        imagePath: 'dummy/path.png',
+        detectedRegions: detectedRegions,
+        onRegionSelected: onRegionSelected,
+      ),
+    );
+  }
+
+  testWidgets('renders AppEmptyView and region selection works correctly',
+      (WidgetTester tester) async {
+    Rect? selectedRegion;
+    final regions = [
+      const Rect.fromLTWH(10, 10, 100, 50),
+    ];
+
+    await tester.pumpWidget(
+      buildTestApp(
+        detectedRegions: regions,
+        onRegionSelected: (region) {
+          selectedRegion = region;
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppEmptyView), findsOneWidget);
+
+    // Confirm button is initially not visible
+    expect(find.byType(FilledButton), findsNothing);
+
+    // Tap on region
+    final regionFinder = find.byType(GestureDetector).first;
+    await tester.tap(regionFinder);
+    await tester.pumpAndSettle();
+
+    expect(selectedRegion, equals(regions[0]));
+    expect(find.byType(FilledButton), findsOneWidget);
+  });
+}


### PR DESCRIPTION
💡 改动组件: `lib/widgets/local_ai/image_text_selector.dart` (OCR 图片文字区域选择组件)

🎯 改进原因: 解决组件内手写占位 Container 使用硬编码 `Colors.grey[300]` 和 `Colors.grey[600]` 的问题，统一接入标准 `AppEmptyView` 状态视图与 Design Tokens。

📊 视觉与交互变化:
- 替换自定义 Container 占位为标准 `AppEmptyView`，统一应用内未加载/暂未实现功能的空状态视觉风格。
- 消除硬编码 Material Grey 色值，支持 Material / 纸墨 / 素笺 等多主题动态适配。

🔬 验证方式:
- 新增组件测试 `test/widget/widgets/image_text_selector_test.dart`，验证 `AppEmptyView` 正确渲染及区域点击选中交互。
- 运行 `flutter analyze --no-fatal-infos` 与 `flutter test test/widget/widgets/image_text_selector_test.dart` 全部通过。

---
*PR created automatically by Jules for task [11514979152047903960](https://jules.google.com/task/11514979152047903960) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `ImageTextSelector` 中的硬编码灰色占位容器替换为标准 `AppEmptyView`，统一空状态样式并适配多主题；同时为区域点击交互添加稳定 `ValueKey`，便于测试定位。

- 新增组件测试覆盖空状态渲染、区域点击回调及确认按钮显隐。
- 区域高亮与选中逻辑保持不变。

<sup>Written for commit 8be324339983c12b20644034551ef100d2f33443. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the image area’s “coming soon” state with the standard empty-state presentation while retaining the existing message.
  - Image region highlighting, selection behavior, and confirmation controls remain unchanged.

- **Tests**
  - Added coverage for the empty state, region selection callback, and confirmation button visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->