### PR TITLE
🔒 [fix] Refactor WebDAV sync rawQuery to structured query

### DIFF
--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -1620,9 +1620,11 @@ class WebDAVSyncService extends ChangeNotifier {
           // 批量查 tag 关联，避免逐条查询
           final ids = page.map((q) => q['id'] as String).toList();
           final placeholders = List.filled(ids.length, '?').join(',');
-          final tagRows = await txn.rawQuery(
-            'SELECT quote_id, tag_id FROM quote_tags WHERE quote_id IN ($placeholders)',
-            ids,
+          final tagRows = await txn.query(
+            'quote_tags',
+            columns: ['quote_id', 'tag_id'],
+            where: 'quote_id IN ($placeholders)',
+            whereArgs: ids,
           );
           final tagsByQuoteId = <String, List<String>>{};
           for (final t in tagRows) {


### PR DESCRIPTION
### 🎯 **What:**
Refactored `txn.rawQuery` to `txn.query` in `WebDAVSyncService._writeLocalDataToTempJson` when querying `quote_tags`.

### ⚠️ **Risk:**
Manual string interpolation in raw SQL queries, even when using `?` placeholders, increases the risk of SQL injection pattern leakage if modified in the future.

### 🛡️ **Solution:**
Replaced `txn.rawQuery('SELECT quote_id, tag_id FROM quote_tags WHERE quote_id IN ($placeholders)', ids)` with structured `txn.query('quote_tags', columns: ['quote_id', 'tag_id'], where: 'quote_id IN ($placeholders)', whereArgs: ids)`.

---
*PR created automatically by Jules for task [18236089670581422789](https://jules.google.com/task/18236089670581422789) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `WebDAVSyncService` 中查询 `quote_tags` 的 `txn.rawQuery` 改为 `txn.query`，避免手动字符串拼接带来的 SQL 注入风险，查询行为与结果不变。

<sup>Written for commit af884bf5ea78dceade587bfb3ca55768d023da0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data synchronization logic to use a structured database query while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->