### PR TITLE
🔒 Fix path traversal vulnerability in WebDAVSyncService

### DIFF
--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -1268,7 +1268,9 @@ class WebDAVSyncService extends ChangeNotifier {
             ? '远端大小不一致，本地=$fileLen, 远端=$remoteSize'
             : '远端不存在';
         logDebug('上传本地附件到云端: $stdPath ($reason)');
-        final uploadUrl = '${_url}thoughtecho/media/$stdPath';
+        final encodedStdPath =
+            stdPath.split('/').map(Uri.encodeComponent).join('/');
+        final uploadUrl = '${_url}thoughtecho/media/$encodedStdPath';
         try {
           await dio.put(
             uploadUrl,
@@ -1307,7 +1309,9 @@ class WebDAVSyncService extends ChangeNotifier {
           if (refCount > 0) {
             // 该云端媒体在本地数据库有笔记引用，需从云端下载（如新设备登录同步）
             logDebug('从云端下载本地缺失且被引用的合法附件: $stdPath');
-            final downloadUrl = '${_url}thoughtecho/media/$stdPath';
+            final encodedStdPath =
+                stdPath.split('/').map(Uri.encodeComponent).join('/');
+            final downloadUrl = '${_url}thoughtecho/media/$encodedStdPath';
             final localTargetFile = File(localFileFullPath);
 
             // 先下载到 .tmp 临时文件 + 哈希校验后再原子改名：中断的下载绝不能留下半截文件——
@@ -1494,11 +1498,28 @@ class WebDAVSyncService extends ChangeNotifier {
     final trimmed = href.trim();
     if (trimmed.isEmpty) return null;
 
+    final uri = Uri.tryParse(trimmed);
+    final rawPath = uri?.path ?? trimmed;
     String decodedPath;
     try {
-      decodedPath = Uri.decodeComponent(trimmed);
+      decodedPath = Uri.decodeComponent(rawPath);
     } catch (_) {
-      decodedPath = Uri.decodeFull(trimmed);
+      decodedPath = Uri.decodeFull(rawPath);
+    }
+
+    // 循环检查或解码，防范多重编码（如 %252e%252e、%252f、%255c）绕过路径遍历检查
+    var current = decodedPath;
+    while (true) {
+      if (RegExp(r'%2[ef]|%5c', caseSensitive: false).hasMatch(current)) {
+        return null;
+      }
+      try {
+        final next = Uri.decodeComponent(current);
+        if (next == current) break;
+        current = next;
+      } catch (_) {
+        break;
+      }
     }
 
     final normalizedPath = decodedPath.replaceAll('\\', '/');

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -1494,31 +1494,44 @@ class WebDAVSyncService extends ChangeNotifier {
     final trimmed = href.trim();
     if (trimmed.isEmpty) return null;
 
-    final uri = Uri.tryParse(trimmed);
-    final rawPath = uri?.path ?? trimmed;
     String decodedPath;
     try {
-      decodedPath = Uri.decodeComponent(rawPath);
+      decodedPath = Uri.decodeComponent(trimmed);
     } catch (_) {
-      decodedPath = Uri.decodeFull(rawPath);
+      decodedPath = Uri.decodeFull(trimmed);
     }
 
     final normalizedPath = decodedPath.replaceAll('\\', '/');
     if (normalizedPath.endsWith('/')) return null;
 
-    final segments = normalizedPath
+    final rawSegments = normalizedPath
         .split('/')
         .where((segment) => segment.isNotEmpty)
         .toList();
-    for (var i = 0; i < segments.length - 1; i++) {
-      if (segments[i] == 'media' &&
-          _mediaSubFolders.contains(segments[i + 1])) {
-        final relativeSegments = segments.sublist(i + 1);
-        if (relativeSegments.any((segment) =>
-            segment == '.' || segment == '..' || segment.contains('\u0000'))) {
+
+    for (var i = 0; i < rawSegments.length - 1; i++) {
+      if (rawSegments[i] == 'media' &&
+          _mediaSubFolders.contains(rawSegments[i + 1])) {
+        final relativeSegments = rawSegments.sublist(i + 1);
+        final rawRelativePath = relativeSegments.join('/');
+        if (rawRelativePath.contains('\u0000') ||
+            p.posix.isAbsolute(rawRelativePath)) {
           return null;
         }
-        return relativeSegments.join('/');
+
+        final normalizedRelative = p.posix.normalize(rawRelativePath);
+        if (normalizedRelative == '.' ||
+            normalizedRelative == '..' ||
+            normalizedRelative.startsWith('../')) {
+          return null;
+        }
+
+        final expectedPrefix = '${rawSegments[i + 1]}/';
+        if (!normalizedRelative.startsWith(expectedPrefix)) {
+          return null;
+        }
+
+        return normalizedRelative;
       }
     }
     return null;

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -1268,9 +1268,7 @@ class WebDAVSyncService extends ChangeNotifier {
             ? '远端大小不一致，本地=$fileLen, 远端=$remoteSize'
             : '远端不存在';
         logDebug('上传本地附件到云端: $stdPath ($reason)');
-        final encodedStdPath =
-            stdPath.split('/').map(Uri.encodeComponent).join('/');
-        final uploadUrl = '${_url}thoughtecho/media/$encodedStdPath';
+        final uploadUrl = '${_url}thoughtecho/media/$stdPath';
         try {
           await dio.put(
             uploadUrl,
@@ -1309,9 +1307,7 @@ class WebDAVSyncService extends ChangeNotifier {
           if (refCount > 0) {
             // 该云端媒体在本地数据库有笔记引用，需从云端下载（如新设备登录同步）
             logDebug('从云端下载本地缺失且被引用的合法附件: $stdPath');
-            final encodedStdPath =
-                stdPath.split('/').map(Uri.encodeComponent).join('/');
-            final downloadUrl = '${_url}thoughtecho/media/$encodedStdPath';
+            final downloadUrl = '${_url}thoughtecho/media/$stdPath';
             final localTargetFile = File(localFileFullPath);
 
             // 先下载到 .tmp 临时文件 + 哈希校验后再原子改名：中断的下载绝不能留下半截文件——
@@ -1498,35 +1494,11 @@ class WebDAVSyncService extends ChangeNotifier {
     final trimmed = href.trim();
     if (trimmed.isEmpty) return null;
 
-    // 剥离 query 参数和 fragment（注意不能用 Uri.tryParse(...).path，因为其会自动规范化并折叠 ../ 路径段，导致越界逃逸校验失效）
-    var rawPath = trimmed.split('?').first.split('#').first;
-    final schemeIndex = rawPath.indexOf('://');
-    if (schemeIndex != -1) {
-      final pathStart = rawPath.indexOf('/', schemeIndex + 3);
-      rawPath = pathStart != -1 ? rawPath.substring(pathStart) : '';
-    }
-    if (rawPath.isEmpty) return null;
-
     String decodedPath;
     try {
-      decodedPath = Uri.decodeComponent(rawPath);
+      decodedPath = Uri.decodeComponent(trimmed);
     } catch (_) {
-      decodedPath = Uri.decodeFull(rawPath);
-    }
-
-    // 循环检查或解码，防范多重编码（如 %252e%252e、%252f、%255c）绕过路径遍历检查
-    var current = decodedPath;
-    while (true) {
-      if (RegExp(r'%2[ef]|%5c', caseSensitive: false).hasMatch(current)) {
-        return null;
-      }
-      try {
-        final next = Uri.decodeComponent(current);
-        if (next == current) break;
-        current = next;
-      } catch (_) {
-        break;
-      }
+      decodedPath = Uri.decodeFull(trimmed);
     }
 
     final normalizedPath = decodedPath.replaceAll('\\', '/');

--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -1498,8 +1498,15 @@ class WebDAVSyncService extends ChangeNotifier {
     final trimmed = href.trim();
     if (trimmed.isEmpty) return null;
 
-    final uri = Uri.tryParse(trimmed);
-    final rawPath = uri?.path ?? trimmed;
+    // 剥离 query 参数和 fragment（注意不能用 Uri.tryParse(...).path，因为其会自动规范化并折叠 ../ 路径段，导致越界逃逸校验失效）
+    var rawPath = trimmed.split('?').first.split('#').first;
+    final schemeIndex = rawPath.indexOf('://');
+    if (schemeIndex != -1) {
+      final pathStart = rawPath.indexOf('/', schemeIndex + 3);
+      rawPath = pathStart != -1 ? rawPath.substring(pathStart) : '';
+    }
+    if (rawPath.isEmpty) return null;
+
     String decodedPath;
     try {
       decodedPath = Uri.decodeComponent(rawPath);

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -209,6 +209,59 @@ void main() {
     expect(files, {'audios/valid.mp3': 456});
   });
 
+  test(
+      'mediaRelativePathFromHref should normalize paths and block path traversal',
+      () {
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/photo.png',
+      ),
+      'images/photo.png',
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/./photo.png',
+      ),
+      'images/photo.png',
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/sub/../photo.png',
+      ),
+      'images/photo.png',
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/../videos/photo.png',
+      ),
+      isNull,
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/../../etc/passwd',
+      ),
+      isNull,
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/photo.png\x00.zip',
+      ),
+      isNull,
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/..\\..\\secret.txt',
+      ),
+      isNull,
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/',
+      ),
+      isNull,
+    );
+  });
+
   test('WebDAV media upload decision should skip files already on remote', () {
     final remoteMediaFiles = {
       'images/existing.png': 1024,

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -260,36 +260,6 @@ void main() {
       ),
       isNull,
     );
-    expect(
-      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
-        '/dav/thoughtecho/media/images/photo.png?token=secret#section',
-      ),
-      'images/photo.png',
-    );
-    expect(
-      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
-        'https://example.com/dav/thoughtecho/media/images/photo.png?token=secret#section',
-      ),
-      'images/photo.png',
-    );
-    expect(
-      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
-        '/dav/thoughtecho/media/images/%252e%252e/secret.txt',
-      ),
-      isNull,
-    );
-    expect(
-      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
-        '/dav/thoughtecho/media/images/%252fetc/passwd',
-      ),
-      isNull,
-    );
-    expect(
-      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
-        '/dav/thoughtecho/media/images/%255csecret.txt',
-      ),
-      isNull,
-    );
   });
 
   test('WebDAV media upload decision should skip files already on remote', () {

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -260,6 +260,30 @@ void main() {
       ),
       isNull,
     );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/photo.png?token=secret#section',
+      ),
+      'images/photo.png',
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/%252e%252e/secret.txt',
+      ),
+      isNull,
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/%252fetc/passwd',
+      ),
+      isNull,
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        '/dav/thoughtecho/media/images/%255csecret.txt',
+      ),
+      isNull,
+    );
   });
 
   test('WebDAV media upload decision should skip files already on remote', () {

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -268,6 +268,12 @@ void main() {
     );
     expect(
       WebDAVSyncService.mediaRelativePathFromHrefForTesting(
+        'https://example.com/dav/thoughtecho/media/images/photo.png?token=secret#section',
+      ),
+      'images/photo.png',
+    );
+    expect(
+      WebDAVSyncService.mediaRelativePathFromHrefForTesting(
         '/dav/thoughtecho/media/images/%252e%252e/secret.txt',
       ),
       isNull,


### PR DESCRIPTION
🎯 **What:** Fixed path traversal vulnerability in `WebDAVSyncService.mediaRelativePathFromHref` by using `p.posix.normalize()` and strict prefix/boundary checks.

⚠️ **Risk:** Manually comparing relative path segments (`segment == '.' || segment == '..'`) could allow directory traversal attempts or unexpected paths via path encoding or normalization edge cases when processing WebDAV media file URLs.

🛡️ **Solution:**
- Replaced manual path segment checks in `_mediaRelativePathFromHref` with `p.posix.normalize()`.
- Added null-byte (`\u0000`) and absolute path checks.
- Enforced that normalized paths do not escape relative root (`startsWith('../')`) and strictly maintain the expected subfolder prefix (`images/`, `videos/`, `audios/`).
- Added comprehensive unit tests covering path normalization, path traversal rejection, and null-byte injection.

---
*PR created automatically by Jules for task [13547118670642325633](https://jules.google.com/task/13547118670642325633) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `WebDAVSyncService.mediaRelativePathFromHref` 的路径遍历漏洞，同时让含空格或特殊字符的媒体文件在 WebDAV 上传/下载中正常工作。

- 用 `p.posix.normalize()` 替代手动路径段比较，统一处理 `.` 和 `..`。
- 解码 href 全部内容并拦截 `%2e`、`%2f`、`%5c` 等编码绕过，防止多重编码造成路径逃逸。
- 校验空字节、绝对路径、`../` 越界，并强制保留 `images/`、`videos/`、`audios/` 前缀。
- 手动剥离 query/fragment，避免 `Uri.tryParse` 自动规范化导致绕过。
- 上传和下载 URL 的路径段改用 `Uri.encodeComponent` 逐段编码。
- 新增覆盖规范化、遍历攻击、空字节、多重编码和特殊字符的单元测试。

<sup>Written for commit f350e38ff38c492fa4db5769e74ac2cdce0a9a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media files with spaces or special characters in their filenames now upload and download correctly through WebDAV.
  * Improved protection against encoded path traversal attempts during media synchronization.
  * WebDAV media paths are now normalized more reliably, including paths containing redundant segments or query and fragment suffixes.

* **Tests**
  * Added coverage for path normalization, invalid paths, encoded traversal attempts, and special-character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->