### PR TITLE
⚡ Bolt: 优化 DeltaBuilder 中的正则表达式编译性能

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -168,3 +168,10 @@ Updated `importDataFromMap` and `_mergeQuotes` in `lib/services/database_backup_
 
 **Learning:** 在初始化或批量生成笔记标签（如添加一言默认标签）时，如果在循环体内逐个通过 `db.getTagById(fixedId)` 查询数据库，会造成 N+1 查询模式。将标签类别列表预先加载或更新至内存缓存（`allCategoriesCache`），并在内存中基于 `fixedId` 或 `name` 进行匹配，可消除循环内的数据库 I/O 交互。
 **Action:** 修改 `lib/controllers/add_note_controller.dart` 中 `ensureTagExists` 和 `addDefaultHitokotoTagsAsync`，在处理标签前统一使用 `db.getTags()` 填充 `allCategoriesCache`，并在内存中进行 ID/名称匹配和副分类 ID 获取，将 `getTagById` 查询次数降为 0。
+
+## 2026-08-18 - 优化 DeltaBuilder 中的正则表达式编译性能
+
+**Learning:**
+在 Markdown 转换 Delta 及解析行内 Formatting 的工具方法（如 `markdownToDelta`、`_appendInlineMarkdown`）中，内联或在循环中频繁实例化 `RegExp` 会导致重复的正则表达式分配与编译开销。
+**Action:**
+将 `DeltaBuilder` 中的标题、列表、引用、行内 markdown 及行尾换行符匹配模式提取为类的 `static final RegExp` 静态成员，使其仅在类加载时编译一次，降低重复解析处理时的内存开销与 CPU 占用。

--- a/lib/utils/quill_delta_builder.dart
+++ b/lib/utils/quill_delta_builder.dart
@@ -5,6 +5,18 @@ import 'string_utils.dart';
 /// Quill Delta操作的构建工具类
 /// 用于AI修改笔记时，正确处理纯文本→Delta转换、并保留嵌入式内容（图片等）
 class DeltaBuilder {
+  static final RegExp _headingRegex = RegExp(r'^(#{1,6})\s+(.+)$');
+  static final RegExp _bulletRegex = RegExp(r'^\s*[-*+]\s+(.+)$');
+  static final RegExp _orderedRegex = RegExp(r'^\s*\d+[.)]\s+(.+)$');
+  static final RegExp _quoteRegex = RegExp(r'^\s*>\s?(.*)$');
+  static final RegExp _inlineMarkdownRegex = RegExp(
+    r'(\*\*|__)(.+?)\1|\*([^*\n]+)\*|`([^`\n]+)`|~~(.+?)~~|\[([^\]]+)\]\(([^)]+)\)',
+  );
+  static final RegExp _trailingNewlineRegex = RegExp(r'\n$');
+  static final RegExp _markdownFormattingRegex = RegExp(
+    r'(^|\n)\s*(#{1,6}\s|[-*+]\s|\d+[.)]\s|>\s|```)|\*\*|__|~~|`[^`]+`|\[[^\]]+\]\([^)]+\)',
+  );
+
   /// 将纯文本内容转换为基础的Delta操作数组
   static List<Map<String, dynamic>> textToDelta(String text) {
     if (text.isEmpty) {
@@ -29,10 +41,10 @@ class DeltaBuilder {
         inCodeBlock = !inCodeBlock;
         return;
       }
-      final heading = RegExp(r'^(#{1,6})\s+(.+)$').firstMatch(line);
-      final bullet = RegExp(r'^\s*[-*+]\s+(.+)$').firstMatch(line);
-      final ordered = RegExp(r'^\s*\d+[.)]\s+(.+)$').firstMatch(line);
-      final quote = RegExp(r'^\s*>\s?(.*)$').firstMatch(line);
+      final heading = _headingRegex.firstMatch(line);
+      final bullet = _bulletRegex.firstMatch(line);
+      final ordered = _orderedRegex.firstMatch(line);
+      final quote = _quoteRegex.firstMatch(line);
       final body = heading?.group(2) ??
           bullet?.group(1) ??
           ordered?.group(1) ??
@@ -58,11 +70,8 @@ class DeltaBuilder {
     List<Map<String, dynamic>> ops,
     String text,
   ) {
-    final pattern = RegExp(
-      r'(\*\*|__)(.+?)\1|\*([^*\n]+)\*|`([^`\n]+)`|~~(.+?)~~|\[([^\]]+)\]\(([^)]+)\)',
-    );
     var cursor = 0;
-    for (final match in pattern.allMatches(text)) {
+    for (final match in _inlineMarkdownRegex.allMatches(text)) {
       if (match.start > cursor) {
         ops.add({'insert': text.substring(cursor, match.start)});
       }
@@ -95,11 +104,10 @@ class DeltaBuilder {
           .map((op) => op['insert'])
           .whereType<String>()
           .join()
-          .replaceFirst(RegExp(r'\n$'), '');
+          .replaceFirst(_trailingNewlineRegex, '');
 
-  static bool hasMarkdownFormatting(String markdown) => RegExp(
-        r'(^|\n)\s*(#{1,6}\s|[-*+]\s|\d+[.)]\s|>\s|```)|\*\*|__|~~|`[^`]+`|\[[^\]]+\]\([^)]+\)',
-      ).hasMatch(markdown);
+  static bool hasMarkdownFormatting(String markdown) =>
+      _markdownFormattingRegex.hasMatch(markdown);
 
   static List<Map<String, dynamic>> appendMarkdownToDelta({
     required String? originalDeltaJson,


### PR DESCRIPTION
⚡ Bolt: 优化 DeltaBuilder 中的正则表达式编译性能

💡 What: 将 `DeltaBuilder` 内用于 Markdown 解析、行内格式提取及换行符匹配的内联 `RegExp` 提取为 `static final` 静态字段。
🎯 Why: 在逐行解析 Markdown 及提取格式时，内联构造 `RegExp` 会导致每次解析和遍历行时重复实例化和编译正则表达式，产生额外的 GC 压力和 CPU 开销。
📊 Impact: 消除高频 Markdown 转 Delta 操作中的重复正则表达式分配与编译开销。
🔬 Measurement: 运行 `flutter test test/unit/utils/quill_delta_builder_test.dart` 确认测试通过且功能一致。

---
*PR created automatically by Jules for task [12056399290810135241](https://jules.google.com/task/12056399290810135241) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `DeltaBuilder` 中用于 Markdown 解析、行内格式提取及换行符匹配的内联 `RegExp` 提取为 `static final` 静态字段，避免每次解析时重复实例化和编译正则表达式，降低 GC 压力与 CPU 开销。行为无变化，测试已通过。

<sup>Written for commit 717131fa69844bf94df8de90853b6c7b51a25a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Optimized Markdown processing by reusing parsing patterns, reducing repeated pattern compilation.
  - Preserved existing behavior for headings, lists, quotes, inline formatting, and trailing newline handling.

- **Documentation**
  - Added a changelog entry documenting the Markdown parsing optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->