### PR TITLE
🔒 Fix hardcoded secure storage key in WebDAVSyncService

### DIFF
--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -109,6 +109,7 @@ class WebDAVSyncService extends ChangeNotifier {
   // 冲突分类固定ID
   static const String conflictCategoryId = 'system_sync_conflicts_category';
   static const Set<String> _mediaSubFolders = {'images', 'videos', 'audios'};
+  static const String _passwordStorageKey = 'webdav_password';
 
   /// 初始化设置，从 MMKV 中读取缓存配置
   void _initSettings() {
@@ -138,7 +139,7 @@ class WebDAVSyncService extends ChangeNotifier {
   /// 获取保存的安全密码/Token
   Future<String?> getPassword() async {
     try {
-      return await _secureStorage.read(key: 'webdav_password');
+      return await _secureStorage.read(key: _passwordStorageKey);
     } catch (e) {
       logError('读取 WebDAV 密码失败', error: e, source: 'WebDAVSyncService');
       return null;
@@ -184,7 +185,7 @@ class WebDAVSyncService extends ChangeNotifier {
 
     if (password != null) {
       await _secureStorage.write(
-        key: 'webdav_password',
+        key: _passwordStorageKey,
         value: password.trim(),
       );
     }


### PR DESCRIPTION
🎯 **What:** Extracted hardcoded `'webdav_password'` string key used with `FlutterSecureStorage` into `static const String _passwordStorageKey = 'webdav_password';` within `WebDAVSyncService`.

⚠️ **Risk:** Hardcoding key strings in storage calls can lead to typos or inconsistent key references across operations.

🛡️ **Solution:** Centralized the secure storage key into a single constant field, improving code hygiene and maintainability.

---
*PR created automatically by Jules for task [9918613303832392105](https://jules.google.com/task/9918613303832392105) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `WebDAVSyncService` 中硬编码的 `'webdav_password'` 存储键提取为私有静态常量 `_passwordStorageKey`，消除读写操作中键名不一致的隐患，降低拼写错误风险，更方便统一维护。

<sup>Written for commit 434a5e8e577652069e37b515fa6fbef4fbd308d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized the WebDAV password storage key for improved code consistency.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->