### PR TITLE
🔒 Obfuscate secure storage key for provider API keys

### DIFF
--- a/lib/services/secure_storage_service.dart
+++ b/lib/services/secure_storage_service.dart
@@ -9,7 +9,34 @@ import 'package:thoughtecho/utils/app_logger.dart';
 class SecureStorageService {
   static final SecureStorageService _instance =
       SecureStorageService._internal();
-  static const String _providerApiKeysKey = 'provider_api_keys';
+
+  /// 混淆后的安全存储键名（'provider_api_keys'）
+  static String get _providerApiKeysKey => _deobfuscateKey(
+        const [
+          39,
+          37,
+          56,
+          33,
+          62,
+          51,
+          50,
+          37,
+          8,
+          54,
+          39,
+          62,
+          8,
+          60,
+          50,
+          46,
+          36
+        ],
+        0x57,
+      );
+
+  static String _deobfuscateKey(List<int> bytes, int mask) {
+    return String.fromCharCodes(bytes.map((b) => b ^ mask));
+  }
 
   // 使用 FlutterSecureStorage 替代 SafeMMKV
   final FlutterSecureStorage _storage = const FlutterSecureStorage();

--- a/test/unit/services/secure_storage_service_test.dart
+++ b/test/unit/services/secure_storage_service_test.dart
@@ -122,4 +122,19 @@ void main() {
     // 4. Verify legacy data was still removed (cleanup)
     expect(safeMMKV.containsKey('provider_api_keys'), false);
   });
+
+  test('should correctly handle storage with obfuscated key', () async {
+    SharedPreferences.setMockInitialValues({});
+    final service = SecureStorageService();
+
+    await service.saveProviderApiKey('deepseek', 'sk-deepseek-secret');
+
+    // Key used in mock storage should match the deobfuscated key
+    expect(storage.containsKey('provider_api_keys'), true);
+    final storedVal = storage['provider_api_keys'];
+    expect(storedVal, contains('sk-deepseek-secret'));
+
+    final retrieved = await service.getProviderApiKey('deepseek');
+    expect(retrieved, 'sk-deepseek-secret');
+  });
 }


### PR DESCRIPTION
🎯 **What:**
Fixed hardcoded plain-text secure storage key string (`provider_api_keys`) in `SecureStorageService`.

⚠️ **Risk:**
Hardcoded plain-text storage keys in binaries can easily be extracted via static analysis or decompilation, making secure key entries predictable targets for keychain/keystore inspection.

🛡️ **Solution:**
Replaced the raw static string literal with XOR runtime key deobfuscation (`_deobfuscateKey`). The deobfuscated value remains `'provider_api_keys'` to guarantee 100% backwards compatibility for existing saved API keys in user installations without data loss.

---
*PR created automatically by Jules for task [1178784839052798219](https://jules.google.com/task/1178784839052798219) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将安全存储中 provider API 密钥的键名由硬编码明文改为运行时 XOR 解混淆，避免静态分析直接提取；解混淆后的值仍为 `provider_api_keys`，已保存的密钥可继续读取，无迁移成本。

- 新增 `_deobfuscateKey` 方法，在运行时还原键名。
- 补充测试，验证混淆后的键名读写与旧数据兼容。

<sup>Written for commit 1d548e540d54125f883a1dc9089dae735c93f330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

