### PR TITLE
⚡ perf: convert sync file I/O to async in summarize_firebase_performance_results.dart

### DIFF
--- a/scripts/analyze_note_list_performance.dart
+++ b/scripts/analyze_note_list_performance.dart
@@ -1,3 +1,4 @@
+/// Analyzes note list performance timeline summaries and prints a formatted report asynchronously.
 import 'dart:convert';
 import 'dart:io';
 

--- a/scripts/summarize_firebase_performance_results.dart
+++ b/scripts/summarize_firebase_performance_results.dart
@@ -16,18 +16,18 @@ String _format(dynamic value) {
   return '-';
 }
 
-void main(List<String> arguments) {
+Future<void> main(List<String> arguments) async {
   if (arguments.length != 1) {
     _usage();
   }
 
   final file = File(arguments.single);
-  if (!file.existsSync()) {
+  if (!await file.exists()) {
     stderr.writeln('Summary file not found: ${file.path}');
     exit(66);
   }
 
-  final decoded = jsonDecode(file.readAsStringSync());
+  final decoded = jsonDecode(await file.readAsString());
   if (decoded is! Map<String, dynamic> || decoded['scenarios'] is! List) {
     stderr.writeln('Invalid performance summary: ${file.path}');
     exit(65);


### PR DESCRIPTION
Convert synchronous file I/O operations (`file.existsSync()` and `file.readAsStringSync()`) in `scripts/summarize_firebase_performance_results.dart` to non-blocking asynchronous calls (`await file.exists()` and `await file.readAsString()`).

---
*PR created automatically by Jules for task [3935679209173175552](https://jules.google.com/task/3935679209173175552) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 `scripts/summarize_firebase_performance_results.dart` 中的同步文件 I/O（`existsSync()`、`readAsStringSync()`）改为异步调用（`exists()`、`readAsString()`），避免脚本执行时阻塞。`main` 函数改为 `Future<void>`，脚本行为不变。

- 为 `scripts/analyze_note_list_performance.dart` 补充了文档注释。

<sup>Written for commit c749c5aa41818d96cf2a89cdff050ff38ac9fb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

