### PR TITLE
🔒 [Security Fix] Sanitize WebDAV password read error logging

### DIFF
--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -140,8 +140,8 @@ class WebDAVSyncService extends ChangeNotifier {
   Future<String?> getPassword() async {
     try {
       return await _secureStorage.read(key: _passwordStorageKey);
-    } catch (e) {
-      logError('读取 WebDAV 密码失败', error: e, source: 'WebDAVSyncService');
+    } catch (_) {
+      logError('读取 WebDAV 密码失败', source: 'WebDAVSyncService');
       return null;
     }
   }

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -54,6 +54,29 @@ void main() {
     );
   });
 
+  test('getPassword should return null gracefully when secure storage throws',
+      () async {
+    final service = WebDAVSyncService();
+
+    // Mock secureStorage to throw an exception on read
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      secureStorageChannel,
+      (MethodCall methodCall) async {
+        if (methodCall.method == 'read') {
+          throw PlatformException(
+            code: 'READ_FAILED',
+            message: 'Failed to read from secure storage',
+          );
+        }
+        return null;
+      },
+    );
+
+    final password = await service.getPassword();
+    expect(password, isNull);
+  });
+
   test('WebDAVSyncService should initialize and save settings correctly',
       () async {
     final service = WebDAVSyncService();

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:thoughtecho/services/mmkv_service.dart';
+import 'package:thoughtecho/services/unified_log_service.dart';
 import 'package:thoughtecho/services/webdav_sync_service.dart';
+import 'package:thoughtecho/utils/app_logger.dart';
 import 'package:thoughtecho/utils/mmkv_ffi_fix.dart';
 
 void main() {
@@ -54,27 +56,45 @@ void main() {
     );
   });
 
-  test('getPassword should return null gracefully when secure storage throws',
+  test(
+      'getPassword returns null without logging the raw exception on storage failure',
       () async {
-    final service = WebDAVSyncService();
+    final logService = _RecordingLogService();
+    AppLogger.serviceForTesting = logService;
+    try {
+      final service = WebDAVSyncService();
 
-    // Mock secureStorage to throw an exception on read
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-      secureStorageChannel,
-      (MethodCall methodCall) async {
-        if (methodCall.method == 'read') {
-          throw PlatformException(
-            code: 'READ_FAILED',
-            message: 'Failed to read from secure storage',
-          );
-        }
-        return null;
-      },
-    );
+      // Mock secureStorage to throw an exception on read
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        secureStorageChannel,
+        (MethodCall methodCall) async {
+          if (methodCall.method == 'read') {
+            throw PlatformException(
+              code: 'READ_FAILED',
+              message: 'Failed to read from secure storage',
+            );
+          }
+          return null;
+        },
+      );
 
-    final password = await service.getPassword();
-    expect(password, isNull);
+      final password = await service.getPassword();
+      expect(password, isNull);
+
+      // 安全回归：读取失败只记来源，不把原始异常对象写入日志。
+      // 若恢复 `error: e`，下面对 error 的断言会失败。
+      final errorLogs = logService.records
+          .where((r) => r.level == UnifiedLogLevel.error)
+          .toList();
+      expect(errorLogs, isNotEmpty);
+      for (final record in errorLogs) {
+        expect(record.message, contains('读取 WebDAV 密码失败'));
+        expect(record.error, isNull);
+      }
+    } finally {
+      AppLogger.initialize();
+    }
   });
 
   test('WebDAVSyncService should initialize and save settings correctly',
@@ -462,4 +482,111 @@ void main() {
       isFalse,
     );
   });
+}
+
+/// 记录型日志服务：只捕获日志调用，不落库、不上报。
+/// 未实现的 [UnifiedLogService] 成员走 [noSuchMethod]，与
+/// `excerpt_intent_service_test.dart` 中的记录器模式一致。
+class _RecordingLogService implements UnifiedLogService {
+  final List<
+      ({
+        UnifiedLogLevel level,
+        String message,
+        String? source,
+        Object? error,
+      })> records = [];
+
+  @override
+  void verbose(
+    String message, {
+    String? source,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    log(
+      UnifiedLogLevel.verbose,
+      message,
+      source: source,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  @override
+  void debug(
+    String message, {
+    String? source,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    log(
+      UnifiedLogLevel.debug,
+      message,
+      source: source,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  @override
+  void info(
+    String message, {
+    String? source,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    log(
+      UnifiedLogLevel.info,
+      message,
+      source: source,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  @override
+  void warning(
+    String message, {
+    String? source,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    log(
+      UnifiedLogLevel.warning,
+      message,
+      source: source,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  @override
+  void error(
+    String message, {
+    String? source,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    log(
+      UnifiedLogLevel.error,
+      message,
+      source: source,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  @override
+  void log(
+    UnifiedLogLevel level,
+    String message, {
+    String? source,
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    records.add((level: level, message: message, source: source, error: error));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }


### PR DESCRIPTION
🎯 **What:** Fixed potential security vulnerability in `WebDAVSyncService.getPassword()` where raw exception details were passed to `logError`.
⚠️ **Risk:** Printing or logging raw exception objects during secure storage read operations could inadvertently leak sensitive data, stack traces, or credentials into application logs.
🛡️ **Solution:** Removed the `error: e` argument from `logError` and caught exceptions using wildcard `catch (_)` in `getPassword()`. Added unit test coverage to ensure `getPassword()` handles errors gracefully and returns `null`.

---
*PR created automatically by Jules for task [17490405148352254346](https://jules.google.com/task/17490405148352254346) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `WebDAVSyncService.getPassword()` 错误日志泄露原始异常的安全隐患，避免堆栈或凭据信息进入日志。旧逻辑在捕获异常时传入 `error: e`，现已移除并用通配符 `catch (_)` 替代，读取失败时优雅返回 `null`。

**Bug Fixes**
- 删除 `logError` 的 `error` 参数，仅记录错误来源。
- 新增测试通过注入记录日志服务，断言错误日志不携带原始异常对象，防止 `error: e` 被恢复。

<sup>Written for commit c988c22eea6ebed79a4925be58b763b29fd21bcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of WebDAV password retrieval failures, allowing the service to continue gracefully when secure storage cannot be read.
  - Reduced sensitive error details recorded in logs for failed password reads.

- **Tests**
  - Added coverage for secure-storage failures during WebDAV password retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->