### PR TITLE
feat(webdav): use file hash for media sync comparison

### DIFF
--- a/lib/services/webdav_sync_service.dart
+++ b/lib/services/webdav_sync_service.dart
@@ -1263,10 +1263,16 @@ class WebDAVSyncService extends ChangeNotifier {
         continue;
       }
 
-      if (_shouldUploadMediaFile(stdPath, fileLen, remoteMediaFiles)) {
+      if (await _shouldUploadMediaFile(
+        stdPath,
+        fileLen,
+        remoteMediaFiles,
+        file: file,
+        remoteEtag: remoteMediaEtags[stdPath],
+      )) {
         final remoteSize = remoteMediaFiles[stdPath];
         final reason = remoteMediaFiles.containsKey(stdPath)
-            ? '远端大小不一致，本地=$fileLen, 远端=$remoteSize'
+            ? '远端大小不一致或哈希不匹配，本地=$fileLen, 远端=$remoteSize'
             : '远端不存在';
         logDebug('上传本地附件到云端: $stdPath ($reason)');
         final uploadUrl =
@@ -1567,11 +1573,13 @@ class WebDAVSyncService extends ChangeNotifier {
     return null;
   }
 
-  static bool _shouldUploadMediaFile(
+  static Future<bool> _shouldUploadMediaFile(
     String stdPath,
     int localSize,
-    Map<String, int?> remoteMediaFiles,
-  ) {
+    Map<String, int?> remoteMediaFiles, {
+    File? file,
+    String? remoteEtag,
+  }) async {
     if (!remoteMediaFiles.containsKey(stdPath)) return true;
 
     final remoteSize = remoteMediaFiles[stdPath];
@@ -1579,10 +1587,27 @@ class WebDAVSyncService extends ChangeNotifier {
     // 按「可能不一致」处理并重传，宁可多传一次也不留下漏同步的媒体文件。
     if (remoteSize == null) return true;
 
-    // TODO(media-sync): 当前仅以文件大小作为差异判断依据（历史设计）。
-    // 文件大小相同但内容不同的媒体文件（如相同尺寸的不同图片）会漏同步。
-    // 后续可引入 MD5/SHA1 内容哈希或 ETag 校验作为更精确的对比手段。
-    return remoteSize != localSize;
+    if (remoteSize != localSize) return true;
+
+    // 文件大小相同时，若远端提供了 ETag/Hash，通过内容哈希进一步比对
+    final cleanEtag = _cleanHashString(remoteEtag)?.toLowerCase();
+    if (cleanEtag != null && file != null && await file.exists()) {
+      if (cleanEtag.length == 64 &&
+          RegExp(r'^[0-9a-f]{64}$').hasMatch(cleanEtag)) {
+        final digest = await sha256.bind(file.openRead()).first;
+        if (digest.toString().toLowerCase() != cleanEtag) return true;
+      } else if (cleanEtag.length == 40 &&
+          RegExp(r'^[0-9a-f]{40}$').hasMatch(cleanEtag)) {
+        final digest = await sha1.bind(file.openRead()).first;
+        if (digest.toString().toLowerCase() != cleanEtag) return true;
+      } else if (cleanEtag.length == 32 &&
+          RegExp(r'^[0-9a-f]{32}$').hasMatch(cleanEtag)) {
+        final digest = await md5.bind(file.openRead()).first;
+        if (digest.toString().toLowerCase() != cleanEtag) return true;
+      }
+    }
+
+    return false;
   }
 
   static String? _mediaFolderFromRelativePath(String stdPath) {
@@ -1615,12 +1640,20 @@ class WebDAVSyncService extends ChangeNotifier {
   }
 
   @visibleForTesting
-  static bool shouldUploadMediaFileForTesting(
+  static Future<bool> shouldUploadMediaFileForTesting(
     String stdPath,
     int localSize,
-    Map<String, int?> remoteMediaFiles,
-  ) {
-    return _shouldUploadMediaFile(stdPath, localSize, remoteMediaFiles);
+    Map<String, int?> remoteMediaFiles, {
+    File? file,
+    String? remoteEtag,
+  }) {
+    return _shouldUploadMediaFile(
+      stdPath,
+      localSize,
+      remoteMediaFiles,
+      file: file,
+      remoteEtag: remoteEtag,
+    );
   }
 
   @visibleForTesting

--- a/test/unit/services/webdav_sync_service_test.dart
+++ b/test/unit/services/webdav_sync_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -307,14 +309,15 @@ void main() {
     );
   });
 
-  test('WebDAV media upload decision should skip files already on remote', () {
+  test('WebDAV media upload decision should skip files already on remote',
+      () async {
     final remoteMediaFiles = {
       'images/existing.png': 1024,
       'videos/no_size.mp4': null,
     };
 
     expect(
-      WebDAVSyncService.shouldUploadMediaFileForTesting(
+      await WebDAVSyncService.shouldUploadMediaFileForTesting(
         'images/existing.png',
         1024,
         remoteMediaFiles,
@@ -324,7 +327,7 @@ void main() {
     // 远端存在但没报出大小时无从比较，必须按「可能不一致」重传，
     // 否则服务端不返回 getcontentlength 的场景下媒体文件会永远漏同步。
     expect(
-      WebDAVSyncService.shouldUploadMediaFileForTesting(
+      await WebDAVSyncService.shouldUploadMediaFileForTesting(
         'videos/no_size.mp4',
         2048,
         remoteMediaFiles,
@@ -332,7 +335,7 @@ void main() {
       isTrue,
     );
     expect(
-      WebDAVSyncService.shouldUploadMediaFileForTesting(
+      await WebDAVSyncService.shouldUploadMediaFileForTesting(
         'images/existing.png',
         512,
         remoteMediaFiles,
@@ -340,13 +343,85 @@ void main() {
       isTrue,
     );
     expect(
-      WebDAVSyncService.shouldUploadMediaFileForTesting(
+      await WebDAVSyncService.shouldUploadMediaFileForTesting(
         'audios/new.mp3',
         256,
         remoteMediaFiles,
       ),
       isTrue,
     );
+  });
+
+  test(
+      'WebDAV media upload decision should check content hash when size matches',
+      () async {
+    final tempDir = await Directory.systemTemp.createTemp('webdav_hash_test_');
+    try {
+      final file = File('${tempDir.path}/test_image.png');
+      await file.writeAsString('Hello World!'); // 12 bytes
+      final size = await file.length();
+
+      // MD5 of 'Hello World!' is ed076287532e86365e841e92bfc50d8c
+      const correctMd5 = 'ed076287532e86365e841e92bfc50d8c';
+      const wrongMd5 = '00000000000000000000000000000000';
+
+      final Map<String, int?> remoteMediaFiles = {
+        'images/test_image.png': size
+      };
+
+      // 1. MD5 匹配 -> 跳过上传 (false)
+      expect(
+        await WebDAVSyncService.shouldUploadMediaFileForTesting(
+          'images/test_image.png',
+          size,
+          remoteMediaFiles,
+          file: file,
+          remoteEtag: '"$correctMd5"',
+        ),
+        isFalse,
+      );
+
+      // 2. MD5 不匹配 -> 触发上传 (true)
+      expect(
+        await WebDAVSyncService.shouldUploadMediaFileForTesting(
+          'images/test_image.png',
+          size,
+          remoteMediaFiles,
+          file: file,
+          remoteEtag: wrongMd5,
+        ),
+        isTrue,
+      );
+
+      // 3. SHA-1 of 'Hello World!' is 2ef7bde608ce5404e97d5f042f95f89f1c232871
+      const correctSha1 = '2ef7bde608ce5404e97d5f042f95f89f1c232871';
+      expect(
+        await WebDAVSyncService.shouldUploadMediaFileForTesting(
+          'images/test_image.png',
+          size,
+          remoteMediaFiles,
+          file: file,
+          remoteEtag: correctSha1,
+        ),
+        isFalse,
+      );
+
+      // 4. SHA-256 of 'Hello World!' is 7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069
+      const correctSha256 =
+          '7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069';
+      expect(
+        await WebDAVSyncService.shouldUploadMediaFileForTesting(
+          'images/test_image.png',
+          size,
+          remoteMediaFiles,
+          file: file,
+          remoteEtag: 'W/"$correctSha256"',
+        ),
+        isFalse,
+      );
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
   });
 
   test('WebDAV media folder helper should only classify synced folders', () {


### PR DESCRIPTION
Upgraded media file sync comparison in WebDAVSyncService from file size check alone to MD5/SHA1/SHA256 content hash and ETag comparison, ensuring media files with identical size but different content are properly detected and re-uploaded. Added corresponding unit test coverage.

---
*PR created automatically by Jules for task [8811124338081757261](https://jules.google.com/task/8811124338081757261) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 WebDAV 媒体同步的比较方式从仅比较文件大小升级为同时比对内容哈希（MD5/SHA1/SHA256）和 ETag，避免相同大小但内容不同的文件被漏同步。

**变更**
- 当文件大小一致时，若远端提供 ETag 且与本地内容哈希不匹配，也会重新上传。
- 该判断逻辑改为异步，调用方已同步调整。
- 新增对应单元测试覆盖哈希匹配与不匹配场景。

<sup>Written for commit a46f0d321f570f84b57adceb7bb36dad800d1702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

