### PR TITLE
🧪 test: add missing edge case unit tests for StringUtils

### DIFF
--- a/test/unit/utils/string_utils_test.dart
+++ b/test/unit/utils/string_utils_test.dart
@@ -75,6 +75,23 @@ void main() {
         expect(result[1], '');
         expect(result[0], '');
       });
+
+      test('should handle plain text without special source format', () {
+        final result = StringUtils.parseSource('Plain text string');
+        expect(result, ['', '']);
+      });
+
+      test('should handle empty book brackets 《》', () {
+        final result = StringUtils.parseSource('——Author 《》');
+        expect(result, ['Author', '']);
+      });
+
+      test('should extract the first matching book title when multiple exist',
+          () {
+        final result =
+            StringUtils.parseSource('——Author 《Book 1》 and 《Book 2》');
+        expect(result, ['Author', 'Book 1']);
+      });
     });
 
     group('parseSourceToControllers', () {
@@ -105,6 +122,20 @@ void main() {
         expect(authorController.text, '');
         expect(workController.text, '');
       });
+
+      test('should overwrite existing text in controllers', () {
+        final authorController = TextEditingController(text: 'Previous Author');
+        final workController = TextEditingController(text: 'Previous Work');
+
+        StringUtils.parseSourceToControllers(
+          '——New Author 《New Work》',
+          authorController,
+          workController,
+        );
+
+        expect(authorController.text, 'New Author');
+        expect(workController.text, 'New Work');
+      });
     });
 
     group('needsExpansion', () {
@@ -127,6 +158,14 @@ void main() {
         expect(StringUtils.needsExpansion('a' * 100), isFalse);
         expect(StringUtils.needsExpansion('a' * 101), isTrue);
       });
+
+      test('should return true when threshold is 0 and text is non-empty', () {
+        expect(StringUtils.needsExpansion('a', threshold: 0), isTrue);
+      });
+
+      test('should return false when threshold is 0 and text is empty', () {
+        expect(StringUtils.needsExpansion('', threshold: 0), isFalse);
+      });
     });
 
     group('truncateForPreview', () {
@@ -142,6 +181,30 @@ void main() {
 
       test('should remove rich-text object placeholders from previews', () {
         expect(StringUtils.truncateForPreview('珍藏\u{FFFC}😊', 20), '珍藏😊');
+      });
+
+      test('should throw ArgumentError when maxCharacters is negative', () {
+        expect(
+          () => StringUtils.truncateForPreview('Sample text', -1),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test(
+          'should return ellipsis when maxCharacters is 0 and text is non-empty',
+          () {
+        expect(StringUtils.truncateForPreview('Sample text', 0), '...');
+      });
+
+      test('should support custom ellipsis string', () {
+        expect(
+          StringUtils.truncateForPreview(
+            'Long sample text',
+            4,
+            ellipsis: ' [Read More]',
+          ),
+          'Long [Read More]',
+        );
       });
     });
 
@@ -229,6 +292,28 @@ void main() {
         });
         expect(lines, ['line 1', '', 'line 3']);
         expect(isLastFlags, [false, false, true]);
+      });
+
+      test('handles single newline character', () {
+        final List<String> lines = [];
+        final List<bool> isLastFlags = [];
+        StringUtils.forEachLine('\n', (line, isLast) {
+          lines.add(line);
+          isLastFlags.add(isLast);
+        });
+        expect(lines, ['', '']);
+        expect(isLastFlags, [false, true]);
+      });
+
+      test('handles carriage return and newline (\\r\\n)', () {
+        final List<String> lines = [];
+        final List<bool> isLastFlags = [];
+        StringUtils.forEachLine('line 1\r\nline 2', (line, isLast) {
+          lines.add(line);
+          isLastFlags.add(isLast);
+        });
+        expect(lines, ['line 1\r', 'line 2']);
+        expect(isLastFlags, [false, true]);
       });
     });
   });


### PR DESCRIPTION
🎯 **What:** 
为 `StringUtils` 补全边界用例单元测试，提升 `StringUtils` 的测试覆盖率与鲁棒性。

📊 **Coverage:**
- `truncateForPreview`: 补充了负数 `maxCharacters` 抛出 `ArgumentError`、`maxCharacters == 0` 以及自定义 `ellipsis` 的测试用例。
- `parseSource`: 补充了无特定格式纯文本、空书名号 `《》` 以及多组书名号解析的测试用例。
- `parseSourceToControllers`: 补充了控制器原内容被重置覆写的测试用例。
- `needsExpansion`: 补充了 `threshold: 0` 下非空与空字符串的测试用例。
- `forEachLine`: 补充了仅包含单个换行符 `\n` 以及 `\r\n` 换行符遍历的测试用例。

✨ **Result:**
所有单元测试均顺利通过，没有任何回归风险。

---
*PR created automatically by Jules for task [2275679787754194823](https://jules.google.com/task/2275679787754194823) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `StringUtils` 补齐边界用例单元测试，仅增加测试代码，不改变现有行为。所有测试均通过，无回归风险。

- 覆盖 `truncateForPreview` 的负数长度参数、零长度参数及自定义省略号。
- 覆盖 `parseSource` 的纯文本、空书名号 `《》` 及多个书名号时取首个匹配。
- 覆盖 `parseSourceToControllers` 覆写控制器原有内容。
- 覆盖 `needsExpansion` 在 `threshold: 0` 时对非空、空字符串的判定。
- 覆盖 `forEachLine` 对单独 `\n` 及 `\r\n` 换行符的遍历。

<sup>Written for commit 41d5b1c740920ccf709f4f6ce28bc4b117e825dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

