### PR TITLE
🧪 补充 MediaFileService 错误处理单元测试

### DIFF
--- a/test/unit/services/media_file_service_test.dart
+++ b/test/unit/services/media_file_service_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:thoughtecho/services/large_file_manager.dart';
+import 'package:thoughtecho/services/media_file_service.dart';
+
+class FakePathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  final Directory tempDir;
+
+  FakePathProviderPlatform(this.tempDir);
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async {
+    return tempDir.path;
+  }
+
+  @override
+  Future<String?> getTemporaryPath() async {
+    return tempDir.path;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MediaFileService.saveVideo error handling tests', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir =
+          await Directory.systemTemp.createTemp('media_file_service_test_');
+      PathProviderPlatform.instance = FakePathProviderPlatform(tempDir);
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('源文件不存在时，捕获异常并回调错误状态信息且返回 null', () async {
+      final nonExistentPath = path.join(tempDir.path, 'non_existent_video.mp4');
+      String? updatedStatus;
+
+      final result = await MediaFileService.saveVideo(
+        nonExistentPath,
+        onStatusUpdate: (status) {
+          updatedStatus = status;
+        },
+      );
+
+      expect(result, isNull);
+      expect(updatedStatus, isNotNull);
+      expect(updatedStatus, contains('源文件不存在'));
+    });
+
+    test('取消操作抛出 CancelledException 时，捕获异常并返回对应取消提示信息', () async {
+      final sourceFile = File(path.join(tempDir.path, 'test_video.mp4'));
+      await sourceFile.writeAsBytes([0, 1, 2, 3]);
+
+      String? updatedStatus;
+
+      final result = await MediaFileService.saveVideo(
+        sourceFile.path,
+        onProgress: (_) {
+          throw const CancelledException();
+        },
+        onStatusUpdate: (status) {
+          updatedStatus = status;
+        },
+      );
+
+      expect(result, isNull);
+      expect(updatedStatus, equals('视频导入已取消'));
+    });
+
+    test('捕获包含"权限"等其他异常信息时更新对应错误提示', () async {
+      final sourceFile = File(path.join(tempDir.path, 'dummy_video.mp4'));
+      await sourceFile.writeAsBytes([1, 2, 3]);
+
+      String? updatedStatus;
+
+      final result = await MediaFileService.saveVideo(
+        sourceFile.path,
+        onProgress: (_) {
+          throw Exception('无法访问文件，权限拒绝');
+        },
+        onStatusUpdate: (status) {
+          updatedStatus = status;
+        },
+      );
+
+      expect(result, isNull);
+      expect(updatedStatus, equals('无法访问文件，请检查文件权限'));
+    });
+  });
+}


### PR DESCRIPTION
添加了针对 MediaFileService.saveVideo 的单元测试，覆盖了源文件不存在、任务取消（CancelledException）以及权限/文件访问异常下的错误处理逻辑。

---
*PR created automatically by Jules for task [10139165442226473243](https://jules.google.com/task/10139165442226473243) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
为 `MediaFileService.saveVideo` 补充错误处理单元测试，验证源文件不存在、任务取消、权限异常时均返回 `null` 并更新对应的错误状态信息。

**测试覆盖**
- 新增 `test/unit/services/media_file_service_test.dart`，含 3 个测试用例。
- 使用 `FakePathProviderPlatform` 模拟路径提供，隔离真实文件系统依赖。

<sup>Written for commit 4fd089143022eeb6a1bc33f956620e2b096d4bb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

