### PR TITLE
🩺 Guardian: 修复 DatabaseHealthService 中 COUNT 统计字段 unsafe cast 崩溃隐患

### DIFF
--- a/.jules/guardian.md
+++ b/.jules/guardian.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - [Stability & Availability] Safe numeric reading for SQLite aggregate functions
+**Learning:** SQLite query results for `COUNT(*)` or numeric aggregates can return varying types (`int`, `int64`, `num`) depending on the driver or underlying SQLite library behavior across platforms. Directly using `as int` on `Map<String, dynamic>` rawQuery results introduces dangerous `TypeError` crash risks during startup database health checks.
+**Action:** Always use safe helper methods like `_readCount` or `(row[key] as num?)?.toInt() ?? 0` when parsing aggregate query fields from sqflite.

--- a/lib/services/database_health_service.dart
+++ b/lib/services/database_health_service.dart
@@ -347,12 +347,13 @@ class DatabaseHealthService {
       final categoryCountResult = await db.rawQuery(
         'SELECT COUNT(*) as count FROM categories',
       );
-      final categoryCount = categoryCountResult.first['count'] as int;
+      final categoryCount = _readCount(categoryCountResult.first, 'count');
 
       final tagRelationCountResult = await db.rawQuery(
         'SELECT COUNT(*) as count FROM quote_tags',
       );
-      final tagRelationCount = tagRelationCountResult.first['count'] as int;
+      final tagRelationCount =
+          _readCount(tagRelationCountResult.first, 'count');
 
       // 4. 记录健康状态
       logDebug('''
@@ -706,12 +707,13 @@ class DatabaseHealthService {
       final categoryCountResult = await db.rawQuery(
         'SELECT COUNT(*) as count FROM categories',
       );
-      final categoryCount = categoryCountResult.first['count'] as int;
+      final categoryCount = _readCount(categoryCountResult.first, 'count');
 
       final tagRelationCountResult = await db.rawQuery(
         'SELECT COUNT(*) as count FROM quote_tags',
       );
-      final tagRelationCount = tagRelationCountResult.first['count'] as int;
+      final tagRelationCount =
+          _readCount(tagRelationCountResult.first, 'count');
 
       // 检查外键约束状态
       final foreignKeysResult = await db.rawQuery('PRAGMA foreign_keys');

--- a/test/unit/services/database_health_service_test.dart
+++ b/test/unit/services/database_health_service_test.dart
@@ -214,5 +214,21 @@ void main() {
       expect(diagnostic.databaseVersion, 20);
       expect(diagnostic.isSuspicious, isFalse);
     });
+
+    test('getDatabaseHealthInfo 与 performStartupHealthCheck 能够安全处理数据库统计返回的数据类型',
+        () async {
+      await database.insert('categories', {'id': 'cat-1'});
+      await database
+          .insert('quote_tags', {'quote_id': 'quote-1', 'tag_id': 'cat-1'});
+
+      final info = await service.getDatabaseHealthInfo(database);
+      expect(info['category_count'], 1);
+      expect(info['tag_relation_count'], 1);
+
+      await expectLater(
+        service.performStartupHealthCheck(database, expectedPath: databasePath),
+        completes,
+      );
+    });
   });
 }


### PR DESCRIPTION
🏷️ 问题类别: 🩺 Stability & Availability (稳定性与可用性)

💡 隐患剖析: 
`DatabaseHealthService` 中的 `performStartupHealthCheck` 与 `getDatabaseHealthInfo` 方法在查询 `categories` 与 `quote_tags` 表的 `COUNT(*)` 字段时，直接使用了 `as int` 强转。在跨平台运行或不同的 SQLite 引擎驱动层（如 `int64` / `num` / `null`）下，直接强转会导致运行时抛出 `TypeError` 异常从而导致崩溃。

🎯 解决方案:
将 `categoryCountResult.first['count'] as int` 与 `tagRelationCountResult.first['count'] as int` 统一替换为已有且经过测试保护的类型安全辅助函数 `_readCount(row, key)`。

📊 收益影响:
消除应用启动阶段及获取数据库健康状态时因 SQL 查询结果类型转换带来的崩溃风险，显著提升系统的稳定性与可用性。

🔬 验证方式:
1. 运行 `flutter analyze --no-fatal-infos` 无分析警告。
2. 运行 `flutter test test/unit/services/database_health_service_test.dart` 包含新增的 Count 字段类型安全解析测试，全部通过。

---
*PR created automatically by Jules for task [8262318088600831655](https://jules.google.com/task/8262318088600831655) started by @Shangjin-Xiao*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
修复 `DatabaseHealthService` 中 `COUNT(*)` 结果直接使用 `as int` 导致的 `TypeError` 崩溃风险；现在统一安全转换不同数值类型，避免启动检查和数据库健康诊断失败。

- 覆盖 `performStartupHealthCheck` 与 `getDatabaseHealthInfo` 的分类和标签关联统计。
- 新增回归测试，验证非 `int`、`null` 和缺失字段的安全解析，以及启动检查正常完成。
- 补充 SQLite 聚合查询结果的安全读取规范。

<sup>Written for commit 0c6584e6a588d2897bd9a8b60bfcc7b211bae295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Shangjin-Xiao/ThoughtEcho/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database health checks to safely handle numeric count values from SQLite, preventing startup errors caused by type differences.
  - Database diagnostics now reliably report category and tag-relation counts, including when values are returned as decimals or are unavailable.

- **Tests**
  - Added coverage for accurate count reporting, varied numeric formats, missing values, and successful completion of startup health checks.

- **Documentation**
  - Added guidance on safely reading numeric aggregate results from SQLite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->